### PR TITLE
Add delete index support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.pinecone'
-version = '0.2.3' // [pc:VERSION_NEXT]
+version = '0.2.4' // [pc:VERSION_NEXT]
 description = 'The Pinecone.io Java Client'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -28,14 +28,17 @@ dependencies {
     runtime 'io.netty:netty-tcnative-boringssl-static:2.0.59.Final'
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
+    implementation 'org.asynchttpclient:async-http-client:2.12.1'
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation 'org.mockito:mockito-core:4.8.0'
     testImplementation 'org.slf4j:slf4j-simple:2.0.5'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0'
 }
 
 java {
@@ -52,6 +55,10 @@ tasks.named('jar') {
 
 tasks.named('build') {
     dependsOn('shadowJar')
+}
+
+test {
+    useJUnitPlatform()
 }
 
 // Configure Auto Relocation

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -1,25 +1,34 @@
 package io.pinecone;
 
 import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClient;
 
 import java.io.IOException;
 
 public class PineconeIndexOperationClient {
-
     private AsyncHttpClient client;
+    private PineconeClientConfig clientConfig;
+    private PineconeConnectionConfig connectionConfig;
+    private String url;
 
-    PineconeIndexOperationClient(AsyncHttpClient client) {
+    PineconeIndexOperationClient(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig, AsyncHttpClient client) {
+        this.clientConfig = clientConfig;
+        this.connectionConfig = connectionConfig;
         this.client = client;
+        this.url = "https://controller." + clientConfig.getEnvironment() + ".pinecone.io/databases/";
     }
 
-    public void deleteIndex(String environment, String apiKey, String indexName) throws IOException {
-        String url = "https://controller." + environment + ".pinecone.io/databases/" + indexName;
+    public PineconeIndexOperationClient(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
+        this.clientConfig = clientConfig;
+        this.connectionConfig = connectionConfig;
+        this.url = "https://controller." + clientConfig.getEnvironment() + ".pinecone.io/databases/";
+    }
+
+    public void deleteIndex() throws IOException {
         System.out.println("Sending delete index request:");
         // ToDo: Capture Response response and customized error messages
-        client.prepare("DELETE", url)
+        client.prepare("DELETE", url + connectionConfig.getIndexName())
                 .setHeader("accept", "text/plain")
-                .setHeader("Api-Key", apiKey)
+                .setHeader("Api-Key", clientConfig.getApiKey())
                 .execute()
                 .toCompletableFuture()
                 .join();

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -7,26 +7,23 @@ import java.io.IOException;
 public class PineconeIndexOperationClient {
     private AsyncHttpClient client;
     private PineconeClientConfig clientConfig;
-    private PineconeConnectionConfig connectionConfig;
     private String url;
 
-    PineconeIndexOperationClient(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig, AsyncHttpClient client) {
+    // for testing purpose only
+    PineconeIndexOperationClient(PineconeClientConfig clientConfig, AsyncHttpClient client) {
         this.clientConfig = clientConfig;
-        this.connectionConfig = connectionConfig;
         this.client = client;
         this.url = "https://controller." + clientConfig.getEnvironment() + ".pinecone.io/databases/";
     }
 
-    public PineconeIndexOperationClient(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
+    public PineconeIndexOperationClient(PineconeClientConfig clientConfig) {
         this.clientConfig = clientConfig;
-        this.connectionConfig = connectionConfig;
         this.url = "https://controller." + clientConfig.getEnvironment() + ".pinecone.io/databases/";
     }
 
-    public void deleteIndex() throws IOException {
+    public void deleteIndex(String indexName) throws IOException {
         System.out.println("Sending delete index request:");
-        // ToDo: Capture Response response and customized error messages
-        client.prepare("DELETE", url + connectionConfig.getIndexName())
+        client.prepare("DELETE", url + indexName)
                 .setHeader("accept", "text/plain")
                 .setHeader("Api-Key", clientConfig.getApiKey())
                 .execute()

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -1,0 +1,31 @@
+package io.pinecone;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+
+import java.io.IOException;
+
+public class PineconeIndexOperationClient {
+
+    private AsyncHttpClient client;
+
+    PineconeIndexOperationClient(AsyncHttpClient client) {
+        this.client = client;
+    }
+
+    public void deleteIndex(String environment, String apiKey, String indexName) throws IOException {
+        String url = "https://controller." + environment + ".pinecone.io/databases/" + indexName;
+        System.out.println("Sending delete index request:");
+        // ToDo: Capture Response response and customized error messages
+        client.prepare("DELETE", url)
+                .setHeader("accept", "text/plain")
+                .setHeader("Api-Key", apiKey)
+                .execute()
+                .toCompletableFuture()
+                .join();
+
+        client.close();
+    }
+}
+
+

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -14,6 +14,8 @@ public class PineconeIndexOperationClientTest {
     @Test
     public void testSuccessfulIndexDeletion() throws IOException {
         AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
+        PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig().withIndexName("testIndex");
         Response mockResponse = mock(Response.class);
         BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
         ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
@@ -26,8 +28,8 @@ public class PineconeIndexOperationClientTest {
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(mockClient);
-        indexDeletionService.deleteIndex("testEnvironment", "testApiKey", "testIndex");
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, connectionConfig, mockClient);
+        indexDeletionService.deleteIndex();
 
         verify(mockClient, times(1)).prepare(eq("DELETE"), anyString());
         verify(mockBoundRequestBuilder).setHeader(eq("Api-Key"), eq("testApiKey"));

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -1,0 +1,37 @@
+package io.pinecone;
+
+import org.asynchttpclient.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Mockito.*;
+
+public class PineconeIndexOperationClientTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSuccessfulIndexDeletion() throws IOException {
+        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        Response mockResponse = mock(Response.class);
+        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
+        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
+
+        when(mockResponse.getStatusCode()).thenReturn(202);
+        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(eq("Api-Key"), eq("testApiKey"))).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
+        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
+
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(mockClient);
+        indexDeletionService.deleteIndex("testEnvironment", "testApiKey", "testIndex");
+
+        verify(mockClient, times(1)).prepare(eq("DELETE"), anyString());
+        verify(mockBoundRequestBuilder).setHeader(eq("Api-Key"), eq("testApiKey"));
+        verify(mockBoundRequestBuilder).execute();
+        verify(mockClient).close();
+    }
+}

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -15,7 +15,6 @@ public class PineconeIndexOperationClientTest {
     public void testSuccessfulIndexDeletion() throws IOException {
         AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
         PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
-        PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig().withIndexName("testIndex");
         Response mockResponse = mock(Response.class);
         BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
         ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
@@ -28,8 +27,8 @@ public class PineconeIndexOperationClientTest {
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, connectionConfig, mockClient);
-        indexDeletionService.deleteIndex();
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        indexDeletionService.deleteIndex("testIndex");
 
         verify(mockClient, times(1)).prepare(eq("DELETE"), anyString());
         verify(mockBoundRequestBuilder).setHeader(eq("Api-Key"), eq("testApiKey"));


### PR DESCRIPTION
## Problem

The java client is missing delete index support, so this PR aims at adding the function to make http call to the delete index endpoint.

## Solution

I've added the delete index client along with a unit test. As a follow up to this PR, I'll be adding an example to demonstrate how to consume the delete index client to the examples subfolder.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
A unit test is added to test the functionality.