### PR TITLE
Add create index to java sdk client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 
-
+### v0.2.4
+- Added support for index operations
+  - Ability to create index
+  - Ability to delete index
 
 ### v0.2.3
 - Update to use latest protos

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.pinecone'
-version = '0.2.5' // [pc:VERSION_NEXT]
+version = '0.2.3' // [pc:VERSION_NEXT]
 description = 'The Pinecone.io Java Client'
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
     implementation 'org.asynchttpclient:async-http-client:2.12.1'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.pinecone'
-version = '0.2.4' // [pc:VERSION_NEXT]
+version = '0.2.5' // [pc:VERSION_NEXT]
 description = 'The Pinecone.io Java Client'
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -1,6 +1,9 @@
 package io.pinecone;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClient;
 
 import java.io.IOException;
 
@@ -18,6 +21,7 @@ public class PineconeIndexOperationClient {
 
     public PineconeIndexOperationClient(PineconeClientConfig clientConfig) {
         this.clientConfig = clientConfig;
+        client = new DefaultAsyncHttpClient();
         this.url = "https://controller." + clientConfig.getEnvironment() + ".pinecone.io/databases/";
     }
 
@@ -26,6 +30,28 @@ public class PineconeIndexOperationClient {
         client.prepare("DELETE", url + indexName)
                 .setHeader("accept", "text/plain")
                 .setHeader("Api-Key", clientConfig.getApiKey())
+                .execute()
+                .toCompletableFuture()
+                .join();
+
+        client.close();
+    }
+
+    public void createIndex(String indexName, int dimension, String metric) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.createObjectNode()
+                .put("metric", metric)
+                .put("pods", 1)
+                .put("replicas", 1)
+                .put("pod_type", "p1.x1")
+                .put("name", indexName)
+                .put("dimension", dimension);
+
+        client.prepare("POST", url)
+                .setHeader("accept", "text/plain")
+                .setHeader("content-type", "application/json")
+                .setHeader("Api-Key", clientConfig.getApiKey())
+                .setBody(jsonNode.toString())
                 .execute()
                 .toCompletableFuture()
                 .join();

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -12,7 +12,7 @@ public class PineconeIndexOperationClientTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testSuccessfulIndexDeletion() throws IOException {
+    public void testIndexDeletion() throws IOException {
         AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
         PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
         Response mockResponse = mock(Response.class);
@@ -23,7 +23,6 @@ public class PineconeIndexOperationClientTest {
         when(mockResponse.getStatusCode()).thenReturn(202);
         when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
         when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
-        when(mockBoundRequestBuilder.setHeader(eq("Api-Key"), eq("testApiKey"))).thenReturn(mockBoundRequestBuilder);
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
@@ -32,6 +31,33 @@ public class PineconeIndexOperationClientTest {
 
         verify(mockClient, times(1)).prepare(eq("DELETE"), anyString());
         verify(mockBoundRequestBuilder).setHeader(eq("Api-Key"), eq("testApiKey"));
+        verify(mockBoundRequestBuilder).execute();
+        verify(mockClient).close();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testIndexCreation() throws IOException {
+        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
+        Response mockResponse = mock(Response.class);
+        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
+        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
+
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setBody(anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
+        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
+
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        indexDeletionService.createIndex("testEnvironment", 128, "cosine");
+
+        verify(mockClient, times(1)).prepare(eq("POST"), anyString());
+        verify(mockBoundRequestBuilder).setHeader(eq("accept"), eq("text/plain"));
+        verify(mockBoundRequestBuilder).setHeader(eq("content-type"), eq("application/json"));
         verify(mockBoundRequestBuilder).execute();
         verify(mockClient).close();
     }


### PR DESCRIPTION
## Problem
The java sdk client is currently missing index creation code.

## Solution
This PR adds index creation code and the PR contains client wrapper to make a http call to create Index endpoint along with a unit test.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Unit test is added as a part of this PR and as a part of integration test, ran it manually by creating an index using the createIndex() against my account and checked that the index was created using console.
