### PR TITLE
Add support for optional fields to create index

### DIFF
--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -1,7 +1,6 @@
 package io.pinecone;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pinecone.model.CreateIndexRequest;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 
@@ -12,7 +11,6 @@ public class PineconeIndexOperationClient {
     private PineconeClientConfig clientConfig;
     private String url;
 
-    // for testing purpose only
     PineconeIndexOperationClient(PineconeClientConfig clientConfig, AsyncHttpClient client) {
         this.clientConfig = clientConfig;
         this.client = client;
@@ -37,21 +35,12 @@ public class PineconeIndexOperationClient {
         client.close();
     }
 
-    public void createIndex(String indexName, int dimension, String metric) throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.createObjectNode()
-                .put("metric", metric)
-                .put("pods", 1)
-                .put("replicas", 1)
-                .put("pod_type", "p1.x1")
-                .put("name", indexName)
-                .put("dimension", dimension);
-
+    public void createIndex(CreateIndexRequest createIndexRequest) throws IOException {
         client.prepare("POST", url)
                 .setHeader("accept", "text/plain")
                 .setHeader("content-type", "application/json")
                 .setHeader("Api-Key", clientConfig.getApiKey())
-                .setBody(jsonNode.toString())
+                .setBody(createIndexRequest.toJson())
                 .execute()
                 .toCompletableFuture()
                 .join();

--- a/src/main/java/io/pinecone/model/CreateIndexRequest.java
+++ b/src/main/java/io/pinecone/model/CreateIndexRequest.java
@@ -70,7 +70,6 @@ public class CreateIndexRequest {
      * The distance metric to be used for similarity search. You can use 'euclidean', 'cosine', or 'dotproduct'.
      * @return metric
      **/
-    @javax.annotation.Nullable
     public String getMetric() {
         return metric;
     }
@@ -88,7 +87,6 @@ public class CreateIndexRequest {
      * The number of pods for the index to use,including replicas.
      * @return pods
      **/
-    @javax.annotation.Nullable
     public Integer getPods() {
         return pods;
     }
@@ -106,7 +104,6 @@ public class CreateIndexRequest {
      * The number of replicas. Replicas duplicate your index. They provide higher availability and throughput.
      * @return replicas
      **/
-    @javax.annotation.Nullable
     public Integer getReplicas() {
         return replicas;
     }
@@ -124,7 +121,6 @@ public class CreateIndexRequest {
      * The type of pod to use. One of s1, p1, or p2 appended with . and one of x1, x2, x4, or x8.
      * @return podType
      **/
-    @javax.annotation.Nullable
     public String getPodType() {
         return podType;
     }
@@ -160,6 +156,7 @@ public class CreateIndexRequest {
      * The name of the collection to create an index from
      * @return sourceCollection
      **/
+    @javax.annotation.Nullable
     public String getSourceCollection() {
         return sourceCollection;
     }

--- a/src/main/java/io/pinecone/model/CreateIndexRequest.java
+++ b/src/main/java/io/pinecone/model/CreateIndexRequest.java
@@ -25,7 +25,7 @@ public class CreateIndexRequest {
     public CreateIndexRequest() {
     }
 
-    public CreateIndexRequest indexName(String name) {
+    public CreateIndexRequest withIndexName(String name) {
         this.indexName = name;
         return this;
     }
@@ -34,7 +34,7 @@ public class CreateIndexRequest {
      * The name of the index to be created. The maximum length is 45 characters.
      * @return name
      **/
-    @javax.annotation.Nullable
+    @javax.annotation.Nonnull
     public String getIndexName() {
         return indexName;
     }
@@ -43,7 +43,7 @@ public class CreateIndexRequest {
         this.indexName = indexName;
     }
 
-    public CreateIndexRequest dimension(Integer dimension) {
+    public CreateIndexRequest withDimension(Integer dimension) {
         this.dimension = dimension;
         return this;
     }
@@ -61,13 +61,13 @@ public class CreateIndexRequest {
         this.dimension = dimension;
     }
 
-    public CreateIndexRequest metric(String metric) {
+    public CreateIndexRequest withMetric(String metric) {
         this.metric = metric;
         return this;
     }
 
     /**
-     * The distance metric to be used for similarity search. You can use &#39;euclidean&#39;, &#39;cosine&#39;, or &#39;dotproduct&#39;.
+     * The distance metric to be used for similarity search. You can use 'euclidean', 'cosine', or 'dotproduct'.
      * @return metric
      **/
     @javax.annotation.Nullable
@@ -79,7 +79,7 @@ public class CreateIndexRequest {
         this.metric = metric;
     }
 
-    public CreateIndexRequest pods(Integer pods) {
+    public CreateIndexRequest withPods(Integer pods) {
         this.pods = pods;
         return this;
     }
@@ -97,7 +97,7 @@ public class CreateIndexRequest {
         this.pods = pods;
     }
 
-    public CreateIndexRequest replicas(Integer replicas) {
+    public CreateIndexRequest withReplicas(Integer replicas) {
         this.replicas = replicas;
         return this;
     }
@@ -115,7 +115,7 @@ public class CreateIndexRequest {
         this.replicas = replicas;
     }
 
-    public CreateIndexRequest podType(String podType) {
+    public CreateIndexRequest withPodType(String podType) {
         this.podType = podType;
         return this;
     }
@@ -133,7 +133,7 @@ public class CreateIndexRequest {
         this.podType = podType;
     }
 
-    public CreateIndexRequest metadataConfig(IndexMetadataConfig metadataConfig) {
+    public CreateIndexRequest withMetadataConfig(IndexMetadataConfig metadataConfig) {
         this.metadataConfig = metadataConfig;
         return this;
     }
@@ -151,7 +151,7 @@ public class CreateIndexRequest {
         this.metadataConfig = metadataConfig;
     }
 
-    public CreateIndexRequest sourceCollection(String sourceCollection) {
+    public CreateIndexRequest withSourceCollection(String sourceCollection) {
         this.sourceCollection = sourceCollection;
         return this;
     }

--- a/src/main/java/io/pinecone/model/CreateIndexRequest.java
+++ b/src/main/java/io/pinecone/model/CreateIndexRequest.java
@@ -1,0 +1,197 @@
+package io.pinecone.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pinecone.PineconeValidationException;
+
+public class CreateIndexRequest {
+    private String indexName;
+
+    private Integer dimension;
+
+    private String metric = "cosine";
+
+    private Integer pods = 1;
+
+    private Integer replicas = 1;
+
+    private String podType = "p1.x1";
+
+    private IndexMetadataConfig metadataConfig;
+
+    private String sourceCollection;
+
+    public CreateIndexRequest() {
+    }
+
+    public CreateIndexRequest indexName(String name) {
+        this.indexName = name;
+        return this;
+    }
+
+    /**
+     * The name of the index to be created. The maximum length is 45 characters.
+     * @return name
+     **/
+    @javax.annotation.Nullable
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public CreateIndexRequest dimension(Integer dimension) {
+        this.dimension = dimension;
+        return this;
+    }
+
+    /**
+     * The dimensions of the vectors to be inserted in the index
+     * @return dimension
+     **/
+    @javax.annotation.Nonnull
+    public Integer getDimension() {
+        return dimension;
+    }
+
+    public void setDimension(Integer dimension) {
+        this.dimension = dimension;
+    }
+
+    public CreateIndexRequest metric(String metric) {
+        this.metric = metric;
+        return this;
+    }
+
+    /**
+     * The distance metric to be used for similarity search. You can use &#39;euclidean&#39;, &#39;cosine&#39;, or &#39;dotproduct&#39;.
+     * @return metric
+     **/
+    @javax.annotation.Nullable
+    public String getMetric() {
+        return metric;
+    }
+
+    public void setMetric(String metric) {
+        this.metric = metric;
+    }
+
+    public CreateIndexRequest pods(Integer pods) {
+        this.pods = pods;
+        return this;
+    }
+
+    /**
+     * The number of pods for the index to use,including replicas.
+     * @return pods
+     **/
+    @javax.annotation.Nullable
+    public Integer getPods() {
+        return pods;
+    }
+
+    public void setPods(Integer pods) {
+        this.pods = pods;
+    }
+
+    public CreateIndexRequest replicas(Integer replicas) {
+        this.replicas = replicas;
+        return this;
+    }
+
+    /**
+     * The number of replicas. Replicas duplicate your index. They provide higher availability and throughput.
+     * @return replicas
+     **/
+    @javax.annotation.Nullable
+    public Integer getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(Integer replicas) {
+        this.replicas = replicas;
+    }
+
+    public CreateIndexRequest podType(String podType) {
+        this.podType = podType;
+        return this;
+    }
+
+    /**
+     * The type of pod to use. One of s1, p1, or p2 appended with . and one of x1, x2, x4, or x8.
+     * @return podType
+     **/
+    @javax.annotation.Nullable
+    public String getPodType() {
+        return podType;
+    }
+
+    public void setPodType(String podType) {
+        this.podType = podType;
+    }
+
+    public CreateIndexRequest metadataConfig(IndexMetadataConfig metadataConfig) {
+        this.metadataConfig = metadataConfig;
+        return this;
+    }
+
+    /**
+     * Get metadataConfig
+     * @return metadataConfig
+     **/
+    @javax.annotation.Nullable
+    public IndexMetadataConfig getMetadataConfig() {
+        return metadataConfig;
+    }
+
+    public void setMetadataConfig(IndexMetadataConfig metadataConfig) {
+        this.metadataConfig = metadataConfig;
+    }
+
+    public CreateIndexRequest sourceCollection(String sourceCollection) {
+        this.sourceCollection = sourceCollection;
+        return this;
+    }
+
+    /**
+     * The name of the collection to create an index from
+     * @return sourceCollection
+     **/
+    public String getSourceCollection() {
+        return sourceCollection;
+    }
+
+    public void setSourceCollection(String sourceCollection) {
+        this.sourceCollection = sourceCollection;
+    }
+
+    public String toJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode jsonNode = mapper.createObjectNode()
+                .put("metric", metric)
+                .put("pods", pods)
+                .put("replicas", replicas)
+                .put("pod_type", podType)
+                .put("name", indexName)
+                .put("dimension", dimension)
+                .put("source_collection", sourceCollection)
+                .set("metadata_config", mapper.valueToTree(metadataConfig));
+
+        validateJsonObject(jsonNode);
+        return jsonNode.toString();
+    }
+
+    public static void validateJsonObject(JsonNode jsonNode) {
+        if(jsonNode.get("name").isNull()) {
+            throw new PineconeValidationException("Index name cannot be empty");
+        }
+        System.out.println("jsonString: " + jsonNode.get("dimension"));
+        if(jsonNode.get("dimension").isNull()) {
+            throw new PineconeValidationException("Dimension cannot be empty");
+        }
+    }
+}

--- a/src/main/java/io/pinecone/model/IndexMetadataConfig.java
+++ b/src/main/java/io/pinecone/model/IndexMetadataConfig.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class IndexMetadataConfig {
-    public static final String SERIALIZED_NAME_INDEXED = "indexed";
     private List<String> indexed;
 
     public IndexMetadataConfig() {

--- a/src/main/java/io/pinecone/model/IndexMetadataConfig.java
+++ b/src/main/java/io/pinecone/model/IndexMetadataConfig.java
@@ -1,0 +1,38 @@
+package io.pinecone.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IndexMetadataConfig {
+    public static final String SERIALIZED_NAME_INDEXED = "indexed";
+    private List<String> indexed;
+
+    public IndexMetadataConfig() {
+    }
+
+    public IndexMetadataConfig indexed(List<String> indexed) {
+        this.indexed = indexed;
+        return this;
+    }
+
+    public IndexMetadataConfig addIndexedItem(String indexedItem) {
+        if (this.indexed == null) {
+            this.indexed = new ArrayList<>();
+        }
+        this.indexed.add(indexedItem);
+        return this;
+    }
+
+    /**
+     * A list of metadata fields to index.
+     * @return indexed
+     **/
+    @javax.annotation.Nullable
+    public List<String> getIndexed() {
+        return indexed;
+    }
+
+    public void setIndexed(List<String> indexed) {
+        this.indexed = indexed;
+    }
+}

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -1,13 +1,10 @@
 package io.pinecone;
 
 import io.pinecone.model.CreateIndexRequest;
-import io.pinecone.model.IndexMetadataConfig;
 import org.asynchttpclient.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.fail;
@@ -58,7 +55,7 @@ public class PineconeIndexOperationClientTest {
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
         PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
-        CreateIndexRequest createIndexRequest = new CreateIndexRequest().indexName("test_name").dimension(3);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest().withIndexName("test_name").withDimension(3);
         indexDeletionService.createIndex(createIndexRequest);
 
         verify(mockClient, times(1)).prepare(eq("POST"), anyString());
@@ -116,7 +113,7 @@ public class PineconeIndexOperationClientTest {
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
         PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
-        CreateIndexRequest createIndexRequest = new CreateIndexRequest().indexName("test_name");
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest().withIndexName("test_name");
 
         try{
             indexDeletionService.createIndex(createIndexRequest);
@@ -124,44 +121,6 @@ public class PineconeIndexOperationClientTest {
         }
         catch (PineconeValidationException validationException) {
             System.out.println("Expected PineconeValidationException with dimension not null occurred!");
-        }
-        catch (IOException e) {
-
-        }
-    }
-
-    @Test
-    public void testIndexCreationWithAllFields() {
-        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
-        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
-        Response mockResponse = mock(Response.class);
-        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
-        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
-        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
-
-        when(mockResponse.getStatusCode()).thenReturn(201);
-        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
-        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
-        when(mockBoundRequestBuilder.setBody(anyString())).thenReturn(mockBoundRequestBuilder);
-        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
-        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
-
-        IndexMetadataConfig metadataConfig = new IndexMetadataConfig();
-        List<String> indexedItems = Arrays.asList("A", "B", "C", "D");
-        metadataConfig.setIndexed(indexedItems);
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
-        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
-                .indexName("test_name")
-                .dimension(3)
-                .metric("euclidean")
-                .pods(2)
-                .podType("p1.x2")
-                .replicas(2)
-                .metadataConfig(metadataConfig)
-                .sourceCollection("step");
-
-        try{
-            indexDeletionService.createIndex(createIndexRequest);
         }
         catch (IOException e) {
 

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -1,10 +1,13 @@
 package io.pinecone;
 
 import io.pinecone.model.CreateIndexRequest;
+import io.pinecone.model.IndexMetadataConfig;
 import org.asynchttpclient.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.fail;
@@ -121,6 +124,44 @@ public class PineconeIndexOperationClientTest {
         }
         catch (PineconeValidationException validationException) {
             System.out.println("Expected PineconeValidationException with dimension not null occurred!");
+        }
+        catch (IOException e) {
+
+        }
+    }
+
+    @Test
+    public void testIndexCreationWithAllFields() {
+        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
+        Response mockResponse = mock(Response.class);
+        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
+        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
+
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setBody(anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
+        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
+
+        IndexMetadataConfig metadataConfig = new IndexMetadataConfig();
+        List<String> indexedItems = Arrays.asList("A", "B", "C", "D");
+        metadataConfig.setIndexed(indexedItems);
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .indexName("test_name")
+                .dimension(3)
+                .metric("euclidean")
+                .pods(2)
+                .podType("p1.x2")
+                .replicas(2)
+                .metadataConfig(metadataConfig)
+                .sourceCollection("step");
+
+        try{
+            indexDeletionService.createIndex(createIndexRequest);
         }
         catch (IOException e) {
 

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -1,10 +1,13 @@
 package io.pinecone;
 
 import io.pinecone.model.CreateIndexRequest;
+import io.pinecone.model.IndexMetadataConfig;
 import org.asynchttpclient.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.fail;
@@ -28,8 +31,8 @@ public class PineconeIndexOperationClientTest {
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
-        indexDeletionService.deleteIndex("testIndex");
+        PineconeIndexOperationClient indexService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        indexService.deleteIndex("testIndex");
 
         verify(mockClient, times(1)).prepare(eq("DELETE"), anyString());
         verify(mockBoundRequestBuilder).setHeader(eq("Api-Key"), eq("testApiKey"));
@@ -54,9 +57,9 @@ public class PineconeIndexOperationClientTest {
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        PineconeIndexOperationClient indexService = new PineconeIndexOperationClient(clientConfig, mockClient);
         CreateIndexRequest createIndexRequest = new CreateIndexRequest().withIndexName("test_name").withDimension(3);
-        indexDeletionService.createIndex(createIndexRequest);
+        indexService.createIndex(createIndexRequest);
 
         verify(mockClient, times(1)).prepare(eq("POST"), anyString());
         verify(mockBoundRequestBuilder).setHeader(eq("accept"), eq("text/plain"));
@@ -81,18 +84,18 @@ public class PineconeIndexOperationClientTest {
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        PineconeIndexOperationClient indexService = new PineconeIndexOperationClient(clientConfig, mockClient);
         CreateIndexRequest createIndexRequest = new CreateIndexRequest();
 
         try{
-            indexDeletionService.createIndex(createIndexRequest);
+            indexService.createIndex(createIndexRequest);
             fail("Expected validation exception not occurred");
         }
         catch (PineconeValidationException validationException) {
             System.out.println("Expected PineconeValidationException with index not null occurred!");
         }
         catch (IOException e) {
-
+            throw new RuntimeException(e);
         }
     }
 
@@ -112,18 +115,55 @@ public class PineconeIndexOperationClientTest {
         when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
-        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        PineconeIndexOperationClient indexService = new PineconeIndexOperationClient(clientConfig, mockClient);
         CreateIndexRequest createIndexRequest = new CreateIndexRequest().withIndexName("test_name");
 
         try{
-            indexDeletionService.createIndex(createIndexRequest);
+            indexService.createIndex(createIndexRequest);
             fail("Expected validation exception not occurred");
         }
         catch (PineconeValidationException validationException) {
             System.out.println("Expected PineconeValidationException with dimension not null occurred!");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testIndexCreationWithAllFields() {
+        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
+        Response mockResponse = mock(Response.class);
+        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
+        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
+
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setBody(anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
+        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
+
+        IndexMetadataConfig metadataConfig = new IndexMetadataConfig();
+        List<String> indexedItems = Arrays.asList("A", "B", "C", "D");
+        metadataConfig.setIndexed(indexedItems);
+        PineconeIndexOperationClient indexService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .withIndexName("test_name")
+                .withDimension(3)
+                .withMetric("euclidean")
+                .withPods(2)
+                .withPodType("p1.x2")
+                .withReplicas(2)
+                .withMetadataConfig(metadataConfig)
+                .withSourceCollection("step");
+
+        try {
+            indexService.createIndex(createIndexRequest);
         }
         catch (IOException e) {
-
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -1,11 +1,13 @@
 package io.pinecone;
 
+import io.pinecone.model.CreateIndexRequest;
 import org.asynchttpclient.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class PineconeIndexOperationClientTest {
@@ -53,12 +55,75 @@ public class PineconeIndexOperationClientTest {
         when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
 
         PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
-        indexDeletionService.createIndex("testEnvironment", 128, "cosine");
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest().indexName("test_name").dimension(3);
+        indexDeletionService.createIndex(createIndexRequest);
 
         verify(mockClient, times(1)).prepare(eq("POST"), anyString());
         verify(mockBoundRequestBuilder).setHeader(eq("accept"), eq("text/plain"));
         verify(mockBoundRequestBuilder).setHeader(eq("content-type"), eq("application/json"));
         verify(mockBoundRequestBuilder).execute();
         verify(mockClient).close();
+    }
+
+    @Test
+    public void testIndexCreationThrowsExceptionWithNullIndex() {
+        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
+        Response mockResponse = mock(Response.class);
+        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
+        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
+
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setBody(anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
+        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
+
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest();
+
+        try{
+            indexDeletionService.createIndex(createIndexRequest);
+            fail("Expected validation exception not occurred");
+        }
+        catch (PineconeValidationException validationException) {
+            System.out.println("Expected PineconeValidationException with index not null occurred!");
+        }
+        catch (IOException e) {
+
+        }
+    }
+
+    @Test
+    public void testIndexCreationThrowsExceptionWithNullDimension() {
+        AsyncHttpClient mockClient = mock(DefaultAsyncHttpClient.class);
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("testApiKey").withEnvironment("testEnvironment");
+        Response mockResponse = mock(Response.class);
+        BoundRequestBuilder mockBoundRequestBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockResponseFuture = mock(ListenableFuture.class);
+        CompletableFuture<Response> mockCompletableFuture = mock(CompletableFuture.class);
+
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(mockClient.prepare(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setHeader(anyString(), anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.setBody(anyString())).thenReturn(mockBoundRequestBuilder);
+        when(mockBoundRequestBuilder.execute()).thenReturn(mockResponseFuture);
+        when(mockResponseFuture.toCompletableFuture()).thenReturn(mockCompletableFuture);
+
+        PineconeIndexOperationClient indexDeletionService = new PineconeIndexOperationClient(clientConfig, mockClient);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest().indexName("test_name");
+
+        try{
+            indexDeletionService.createIndex(createIndexRequest);
+            fail("Expected validation exception not occurred");
+        }
+        catch (PineconeValidationException validationException) {
+            System.out.println("Expected PineconeValidationException with dimension not null occurred!");
+        }
+        catch (IOException e) {
+
+        }
     }
 }


### PR DESCRIPTION
## Problem
The sdk currently lacks support to allow configuring optional fields while creating a new index. 

## Solution
Add support to add optional fields while creating a new index. Newly supported optional fields are pods, replicas, pod_type, source_collection, and metadata_config.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Added unit tests to test for the required and the optional fields.

Describe specific steps for validating this change.
Along with unit tests, an integration test to create the index was successfully ran locally with required fields and verified that the index was created using console.
