### PR TITLE
Parse connection URL string to autofill indexName, environment, and projectName

### DIFF
--- a/src/main/java/io/pinecone/PineconeConfigs.java
+++ b/src/main/java/io/pinecone/PineconeConfigs.java
@@ -18,7 +18,7 @@ public class PineconeConfigs {
     }
 
     public PineconeConfigs(String apiKey, String connectionURL) {
-        String pattern = "https://([a-zA-Z0-9-]{1,45})-([a-fA-F0-9]+)\\.svc\\.([a-zA-Z0-9]+)\\.pinecone\\.io";
+        String pattern = "https://([a-zA-Z0-9-]{1,45})-([a-fA-F0-9]+)\\.svc\\.([a-zA-Z0-9-]+)\\.pinecone\\.io";
         Pattern regexPattern = Pattern.compile(pattern);
         Matcher matcher = regexPattern.matcher(connectionURL);
 

--- a/src/main/java/io/pinecone/PineconeConfigs.java
+++ b/src/main/java/io/pinecone/PineconeConfigs.java
@@ -7,9 +7,6 @@ public class PineconeConfigs {
     private PineconeClientConfig clientConfig;
     private PineconeConnectionConfig connectionConfig;
 
-    public PineconeConfigs() {
-    }
-
     protected  PineconeConfigs(PineconeConfigs other) {
         clientConfig = other.clientConfig;
         connectionConfig = other.connectionConfig;
@@ -21,7 +18,6 @@ public class PineconeConfigs {
     }
 
     public PineconeConfigs(String apiKey, String connectionURL) {
-        this();
         String pattern = "https://([a-zA-Z0-9-]{1,45})-([a-fA-F0-9]+)\\.svc\\.([a-zA-Z0-9]+)\\.pinecone\\.io";
         Pattern regexPattern = Pattern.compile(pattern);
         Matcher matcher = regexPattern.matcher(connectionURL);
@@ -30,8 +26,8 @@ public class PineconeConfigs {
             String indexName = matcher.group(1);
             String projectName = matcher.group(2);
             String environment = matcher.group(3);
-            clientConfig = clientConfig.withApiKey(apiKey).withProjectName(projectName).withEnvironment(environment);
-            connectionConfig = connectionConfig.withIndexName(indexName);
+            clientConfig = new PineconeClientConfig().withApiKey(apiKey).withProjectName(projectName).withEnvironment(environment);
+            connectionConfig = new PineconeConnectionConfig().withIndexName(indexName);
         }
         else {
             throw new PineconeValidationException("Unable to parse connection url");

--- a/src/main/java/io/pinecone/PineconeConfigs.java
+++ b/src/main/java/io/pinecone/PineconeConfigs.java
@@ -1,0 +1,53 @@
+package io.pinecone;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PineconeConfigs {
+    private PineconeClientConfig clientConfig;
+    private PineconeConnectionConfig connectionConfig;
+
+    public PineconeConfigs() {
+        clientConfig = new PineconeClientConfig();
+        connectionConfig = new PineconeConnectionConfig();
+    }
+
+    public PineconeConfigs(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
+        this.clientConfig = clientConfig;
+        this.connectionConfig = connectionConfig;
+    }
+
+    public PineconeConfigs(String apiKey, String connectionURL) {
+        this();
+        String pattern = "https://([a-zA-Z0-9-]{1,45})-([a-fA-F0-9]+)\\.svc\\.([a-zA-Z0-9]+)\\.pinecone\\.io";
+        Pattern regexPattern = Pattern.compile(pattern);
+        Matcher matcher = regexPattern.matcher(connectionURL);
+
+        if (matcher.matches()) {
+            String indexName = matcher.group(1);
+            String projectName = matcher.group(2);
+            String environment = matcher.group(3);
+            clientConfig = clientConfig.withApiKey(apiKey).withProjectName(projectName).withEnvironment(environment);
+            connectionConfig = connectionConfig.withIndexName(indexName);
+        }
+        else {
+            throw new PineconeValidationException("Unable to parse connection url");
+        }
+    }
+
+    public PineconeClientConfig getClientConfig() {
+        return clientConfig;
+    }
+
+    public PineconeConnectionConfig getConnectionConfig() {
+        return connectionConfig;
+    }
+
+    public PineconeConfigs withClientConfig(PineconeClientConfig clientConfig) {
+        return new PineconeConfigs(clientConfig, new PineconeConnectionConfig());
+    }
+
+    public PineconeConfigs withConnectionConfig(PineconeConnectionConfig connectionConfig) {
+        return new PineconeConfigs(new PineconeClientConfig(), connectionConfig);
+    }
+}

--- a/src/main/java/io/pinecone/PineconeConfigs.java
+++ b/src/main/java/io/pinecone/PineconeConfigs.java
@@ -17,20 +17,20 @@ public class PineconeConfigs {
         this.connectionConfig = connectionConfig;
     }
 
-    public PineconeConfigs(String apiKey, String connectionURL) {
-        String pattern = "https://([a-zA-Z0-9-]{1,45})-([a-fA-F0-9]+)\\.svc\\.([a-zA-Z0-9-]+)\\.pinecone\\.io";
+    public PineconeConfigs(String apiKey, String connectionUrl) {
+        String pattern = "https://([a-zA-Z0-9-]+)-([a-fA-F0-9]+)\\.svc\\.([a-zA-Z0-9-]+)\\.pinecone\\.io";
         Pattern regexPattern = Pattern.compile(pattern);
-        Matcher matcher = regexPattern.matcher(connectionURL);
+        Matcher matcher = regexPattern.matcher(connectionUrl);
 
         if (matcher.matches()) {
             String indexName = matcher.group(1);
             String projectName = matcher.group(2);
             String environment = matcher.group(3);
             clientConfig = new PineconeClientConfig().withApiKey(apiKey).withProjectName(projectName).withEnvironment(environment);
-            connectionConfig = new PineconeConnectionConfig().withIndexName(indexName);
+            connectionConfig = new PineconeConnectionConfig().withIndexName(indexName).withConnectionUrl(connectionUrl);
         }
         else {
-            throw new PineconeValidationException("Unable to parse connection url");
+            throw new PineconeValidationException("Unable to parse connection url " + connectionUrl);
         }
     }
 

--- a/src/main/java/io/pinecone/PineconeConfigs.java
+++ b/src/main/java/io/pinecone/PineconeConfigs.java
@@ -8,8 +8,11 @@ public class PineconeConfigs {
     private PineconeConnectionConfig connectionConfig;
 
     public PineconeConfigs() {
-        clientConfig = new PineconeClientConfig();
-        connectionConfig = new PineconeConnectionConfig();
+    }
+
+    protected  PineconeConfigs(PineconeConfigs other) {
+        clientConfig = other.clientConfig;
+        connectionConfig = other.connectionConfig;
     }
 
     public PineconeConfigs(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
@@ -44,10 +47,14 @@ public class PineconeConfigs {
     }
 
     public PineconeConfigs withClientConfig(PineconeClientConfig clientConfig) {
-        return new PineconeConfigs(clientConfig, new PineconeConnectionConfig());
+        PineconeConfigs configs = new PineconeConfigs(this);
+        configs.clientConfig = clientConfig;
+        return configs;
     }
 
     public PineconeConfigs withConnectionConfig(PineconeConnectionConfig connectionConfig) {
-        return new PineconeConfigs(new PineconeClientConfig(), connectionConfig);
+        PineconeConfigs configs = new PineconeConfigs(this);
+        configs.connectionConfig = connectionConfig;
+        return configs;
     }
 }

--- a/src/main/java/io/pinecone/PineconeConnection.java
+++ b/src/main/java/io/pinecone/PineconeConnection.java
@@ -113,15 +113,16 @@ public class PineconeConnection implements AutoCloseable {
                 .withMaxOutboundMessageSize(DEFAULT_MAX_MESSAGE_SIZE);
     }
 
-    private static String getEndpoint(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
-        String endpoint = String.format("%s-%s.svc.%s.pinecone.io",
-                connectionConfig.getIndexName(),
-                clientConfig.getProjectName(),
-                clientConfig.getEnvironment());
+    static String getEndpoint(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
+        String endpoint = (connectionConfig.getConnectionUrl() != null) ?
+                connectionConfig.getConnectionUrl() :
+                String.format("%s-%s.svc.%s.pinecone.io",
+                        connectionConfig.getIndexName(),
+                        clientConfig.getProjectName(),
+                        clientConfig.getEnvironment());
 
         logger.debug("Pinecone endpoint is: " + endpoint);
 
         return endpoint;
-
     }
 }

--- a/src/main/java/io/pinecone/PineconeConnectionConfig.java
+++ b/src/main/java/io/pinecone/PineconeConnectionConfig.java
@@ -3,6 +3,8 @@ package io.pinecone;
 import io.grpc.ManagedChannel;
 
 import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This class contains the connection-level configuration options for the Pinecone client.
@@ -16,6 +18,8 @@ public class PineconeConnectionConfig {
      */
     private String indexName;
 
+    private String connectionUrl;
+
     /**
      * Creates a new default config.
      */
@@ -23,6 +27,7 @@ public class PineconeConnectionConfig {
 
     protected PineconeConnectionConfig(PineconeConnectionConfig other) {
         indexName = other.indexName;
+        connectionUrl = other.connectionUrl;
         customChannelBuilder = other.customChannelBuilder;
     }
 
@@ -39,6 +44,16 @@ public class PineconeConnectionConfig {
     public PineconeConnectionConfig withIndexName(String indexName) {
         PineconeConnectionConfig config = new PineconeConnectionConfig(this);
         config.indexName = indexName;
+        return config;
+    }
+
+    public String getConnectionUrl() {
+        return connectionUrl;
+    }
+
+    public PineconeConnectionConfig withConnectionUrl(String connectionUrl) {
+        PineconeConnectionConfig config = new PineconeConnectionConfig(this);
+        config.connectionUrl = connectionUrl;
         return config;
     }
 

--- a/src/test/java/io/pinecone/PineconeConfigTest.java
+++ b/src/test/java/io/pinecone/PineconeConfigTest.java
@@ -1,0 +1,139 @@
+package io.pinecone;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+public class PineconeConfigTest {
+    @Test
+    public void testValidConnectionURL() {
+        String apiKey = "secret-api-key";
+        String connectionURL = "https://step-918-f1eea9.svc.production.pinecone.io";
+        PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
+
+        assertNotNull(config.getClientConfig());
+        assertNotNull(config.getConnectionConfig());
+        assertEquals(apiKey, config.getClientConfig().getApiKey());
+        assertEquals("f1eea9", config.getClientConfig().getProjectName());
+        assertEquals("production", config.getClientConfig().getEnvironment());
+        assertEquals("step-918", config.getConnectionConfig().getIndexName());
+    }
+
+    @Test
+    public void testValidLengthIndexName() {
+        // Index name can be 45 chars long
+        String apiKey = "secret-api-key";
+        String connectionURL = "https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io";
+        PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
+
+        assertNotNull(config.getClientConfig());
+        assertNotNull(config.getConnectionConfig());
+        assertEquals(apiKey, config.getClientConfig().getApiKey());
+        assertEquals("f1eea9", config.getClientConfig().getProjectName());
+        assertEquals("production", config.getClientConfig().getEnvironment());
+        assertEquals("steps-784-123-eqasas0aaaa1213aasasc-1223", config.getConnectionConfig().getIndexName());
+    }
+
+    @Test
+    public void testSingleCharacterIndexName() {
+        String apiKey = "api-key";
+        String connectionURL = "https://a-abcdef123.svc.development.pinecone.io";
+
+        PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
+
+        assertNotNull(config.getClientConfig());
+        assertNotNull(config.getConnectionConfig());
+        assertEquals(apiKey, config.getClientConfig().getApiKey());
+        assertEquals("abcdef123", config.getClientConfig().getProjectName());
+        assertEquals("development", config.getClientConfig().getEnvironment());
+        assertEquals("a", config.getConnectionConfig().getIndexName());
+    }
+
+    @Test
+    public void testInvalidLengthIndexName() {
+        String apiKey = "api-key";
+        String connectionURL = "https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea91-projectName.svc.production.pinecone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testUpperCaseIndexAndProjectName() {
+        String apiKey = "secret-api-key";
+        String connectionURL = "https://INDEX-UPPER-3901-A120EF.svc.development.pinecone.io";
+
+        PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
+
+        assertNotNull(config.getClientConfig());
+        assertNotNull(config.getConnectionConfig());
+        assertEquals(apiKey, config.getClientConfig().getApiKey());
+        assertEquals("A120EF", config.getClientConfig().getProjectName());
+        assertEquals("development", config.getClientConfig().getEnvironment());
+        assertEquals("INDEX-UPPER-3901", config.getConnectionConfig().getIndexName());
+    }
+
+    @Test
+    public void testInvalidConnectionURL() {
+        String apiKey = "secret-api-key";
+        String connectionURL = "https://invalid-url";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testMissingIndexName() {
+        String apiKey = "your-api-key";
+        String connectionURL = "https://-projectName.svc.production.pinecone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testMissingProjectName() {
+        String apiKey = "secret-api-key";
+        String connectionURL = "https://indexName.svc.production.pinecone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testInvalidProjectName() {
+        String apiKey = "your-api-key";
+        // Project name must be hexadecimal
+        String connectionURL = "https://indexName-url.svc.production.pinecone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+
+    @Test
+    public void testInvalidSubDomain() {
+        String apiKey = "your-api-key";
+        String connectionURL = "https://my-index-abcdef123.wrongsubdomain.pinecone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testMissingSubDomain() {
+        String apiKey = "your-api-key";
+        String connectionURL = "https://my-index-abcdef123.pinecone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testInvalidDomain() {
+        String apiKey = "your-api-key";
+        String connectionURL = "https://my-index-abcdef123.svc.pinenotcone.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+
+    @Test
+    public void testMissingDomain() {
+        String apiKey = "your-api-key";
+        String connectionURL = "https://my-index-abcdef123.svc.io";
+
+        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+    }
+}

--- a/src/test/java/io/pinecone/PineconeConfigTest.java
+++ b/src/test/java/io/pinecone/PineconeConfigTest.java
@@ -36,7 +36,7 @@ public class PineconeConfigTest {
     @Test
     public void testSingleCharacterIndexName() {
         String apiKey = "api-key";
-        String connectionURL = "https://a-abcdef123.svc.development.pinecone.io";
+        String connectionURL = "https://a-abcdef123.svc.us-east4-gcp.pinecone.io";
 
         PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
 
@@ -44,7 +44,7 @@ public class PineconeConfigTest {
         assertNotNull(config.getConnectionConfig());
         assertEquals(apiKey, config.getClientConfig().getApiKey());
         assertEquals("abcdef123", config.getClientConfig().getProjectName());
-        assertEquals("development", config.getClientConfig().getEnvironment());
+        assertEquals("us-east4-gcp", config.getClientConfig().getEnvironment());
         assertEquals("a", config.getConnectionConfig().getIndexName());
     }
 
@@ -59,7 +59,7 @@ public class PineconeConfigTest {
     @Test
     public void testUpperCaseIndexAndProjectName() {
         String apiKey = "secret-api-key";
-        String connectionURL = "https://INDEX-UPPER-3901-A120EF.svc.development.pinecone.io";
+        String connectionURL = "https://INDEX-UPPER-3901-A120EF.svc.us-west1-aws.pinecone.io";
 
         PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
 
@@ -67,7 +67,7 @@ public class PineconeConfigTest {
         assertNotNull(config.getConnectionConfig());
         assertEquals(apiKey, config.getClientConfig().getApiKey());
         assertEquals("A120EF", config.getClientConfig().getProjectName());
-        assertEquals("development", config.getClientConfig().getEnvironment());
+        assertEquals("us-west1-aws", config.getClientConfig().getEnvironment());
         assertEquals("INDEX-UPPER-3901", config.getConnectionConfig().getIndexName());
     }
 

--- a/src/test/java/io/pinecone/PineconeConfigsTest.java
+++ b/src/test/java/io/pinecone/PineconeConfigsTest.java
@@ -3,7 +3,7 @@ package io.pinecone;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
-public class PineconeConfigTest {
+public class PineconeConfigsTest {
     @Test
     public void testValidConnectionURL() {
         String apiKey = "secret-api-key";
@@ -20,7 +20,7 @@ public class PineconeConfigTest {
 
     @Test
     public void testValidLengthIndexName() {
-        // Index name can be 45 chars long
+        // Index name is 1-45 chars long, so testing for indexName with length = 41 (i.e. 1<length<45)
         String apiKey = "secret-api-key";
         String connectionURL = "https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io";
         PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
@@ -50,10 +50,17 @@ public class PineconeConfigTest {
 
     @Test
     public void testInvalidLengthIndexName() {
+        // Index name is 1-45 chars long, but currently not enforcing the upper bound of 45 chars long.
+        // This test should pass for index name with length > 45 chars long.
         String apiKey = "api-key";
-        String connectionURL = "https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea91-projectName.svc.production.pinecone.io";
-
-        assertThrows(PineconeValidationException.class, () -> new PineconeConfigs(apiKey, connectionURL));
+        String connectionURL = "https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea911-abcdef123.svc.us-east4-gcp.pinecone.io";
+        PineconeConfigs config = new PineconeConfigs(apiKey, connectionURL);
+        assertNotNull(config.getClientConfig());
+        assertNotNull(config.getConnectionConfig());
+        assertEquals(apiKey, config.getClientConfig().getApiKey());
+        assertEquals("abcdef123", config.getClientConfig().getProjectName());
+        assertEquals("us-east4-gcp", config.getClientConfig().getEnvironment());
+        assertEquals("steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea911", config.getConnectionConfig().getIndexName());
     }
 
     @Test

--- a/src/test/java/io/pinecone/PineconeConnectionTest.java
+++ b/src/test/java/io/pinecone/PineconeConnectionTest.java
@@ -1,0 +1,36 @@
+package io.pinecone;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PineconeConnectionTest {
+
+    @Test
+    void testGetEndpointWithConnectionUrl() {
+        // Setting connection-url via PineconeConfigs()
+        PineconeConfigs configs = new PineconeConfigs("api-key",
+                "https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io");
+        PineconeClientConfig clientConfig = configs.getClientConfig();
+        PineconeConnectionConfig connectionConfig = configs.getConnectionConfig();
+
+        String endpoint = PineconeConnection.getEndpoint(clientConfig, connectionConfig);
+
+        assertEquals("https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io", endpoint);
+    }
+
+    @Test
+    void testGetEndpointWithoutConnectionUrl() {
+        // Connection-url is never set
+        PineconeClientConfig clientConfig = new PineconeClientConfig()
+                .withApiKey("secret-api-key")
+                .withEnvironment("aws-us-east4")
+                .withProjectName("fee911a");
+        PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
+                .withIndexName("step-2");
+
+        String endpoint = PineconeConnection.getEndpoint(clientConfig, connectionConfig);
+
+        assertEquals("step-2-fee911a.svc.aws-us-east4.pinecone.io", endpoint);
+    }
+}


### PR DESCRIPTION
## Problem
Connection url contains indexName, environment, and projectName but currently these values are manually set by the users.

## Solution
To reduce user errors, parse the connection url string to get indexName, environment, and projectName and add them to the configurations. 

There are two config classes, PineconeClientConfig (will refer as clientConfig) and PineconeConnectionConfig (will refer as connectionConfig). The clientConfig contains environment and projectName, and connectionConfig contains indexName, so there were two approaches possible to set these values:
1. Delete connectionConfig class completely and add the members (indexName and customChannelBuilder for custom GRPC calls) in the clientConfig. This approach would have made things cleaner since the end user will only have to define one config object and use it to instantiate the PineconeClient class but the downside was in order for it to be backwards compatible, we'll have to maintain the connectionConfig for a while and secondly, the clientConfig would be bigger and harder to maintain over time.
2. Create PineconeConfigs class which has clientConfig and connectionConfig. Parse the connection url string as a part of the PineconeConfigs constructor that accepts apiKey and url, and set the values of clientConfig (apiKey, environment, and projectName) as well as of the connectionConfig (indexName). If the user is now interested in setting serverSideTimeouts to clientConfig or use customChannelBuilder of connectionConfig, they can do so by extracting the config objects and use there respective .with(). 

Below is the sample of how this config will be consumed:
PineconeConfigs configs = new PineconeConfigs("apiKey", "url");
        PineconeClient pineconeClient = new PineconeClient(configs.getClientConfig());
        PineconeConnection connection = pineconeClient.connect(configs.getConnectionConfig());
        connection.doVectorOperations()

Also, note that this can be improved even further as shown below by adding an overloaded constructor in Pineconeclient class as shown below but in order for the user to set serverSideTimeout or use the custom GRPC channel, they'll have to extract the configs from PineconeConfigs. So the code below can be only helpful if the user is fine with the default serverSideTimeout and GRPC channel:
PineconeClient client = new PineconeClient();
PineconeConnection connection = client.connect("apiKey", "url");
        
        
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
A series of unit tests have been added. The follow up subtask to this ticket is integration test.
