### PR TITLE
Add support for connection url for data plane operations only

### DIFF
--- a/src/main/java/io/pinecone/PineconeClient.java
+++ b/src/main/java/io/pinecone/PineconeClient.java
@@ -37,8 +37,8 @@ public final class PineconeClient {
         return new PineconeConnection(config, connectionConfig);
     }
 
-    public PineconeConnection connect(String apiKey, String connectionUrl) {
-        return new PineconeConnection(new PineconeClientConfig().withApiKey(apiKey),
-                new PineconeConnectionConfig().withConnectionUrl(connectionUrl));
+    public PineconeConnection connectWithUrl(String connectionUrl) {
+        return connect(new PineconeConnectionConfig()
+                .withConnectionUrl(connectionUrl));
     }
 }

--- a/src/main/java/io/pinecone/PineconeClient.java
+++ b/src/main/java/io/pinecone/PineconeClient.java
@@ -36,4 +36,9 @@ public final class PineconeClient {
     public PineconeConnection connect(PineconeConnectionConfig connectionConfig) {
         return new PineconeConnection(config, connectionConfig);
     }
+
+    public PineconeConnection connect(String apiKey, String connectionUrl) {
+        return new PineconeConnection(new PineconeClientConfig().withApiKey(apiKey),
+                new PineconeConnectionConfig().withConnectionUrl(connectionUrl));
+    }
 }

--- a/src/main/java/io/pinecone/PineconeClientConfig.java
+++ b/src/main/java/io/pinecone/PineconeClientConfig.java
@@ -100,10 +100,6 @@ public class PineconeClientConfig {
     void validate() {
         if (apiKey == null)
             throw new PineconeValidationException("Invalid Pinecone config: missing apiKey");
-        if (environment == null)
-            throw new PineconeValidationException("Invalid Pinecone config: missing environment");
-        if (projectName == null)
-            throw new PineconeValidationException("Invalid Pinecone config: missing projectName ");
     }
 
     @Override

--- a/src/main/java/io/pinecone/PineconeConnection.java
+++ b/src/main/java/io/pinecone/PineconeConnection.java
@@ -113,15 +113,16 @@ public class PineconeConnection implements AutoCloseable {
                 .withMaxOutboundMessageSize(DEFAULT_MAX_MESSAGE_SIZE);
     }
 
-    private static String getEndpoint(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
-        String endpoint = String.format("%s-%s.svc.%s.pinecone.io",
-                connectionConfig.getIndexName(),
-                clientConfig.getProjectName(),
-                clientConfig.getEnvironment());
+    static String getEndpoint(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
+        String endpoint = (connectionConfig.getConnectionUrl() != null) ?
+                connectionConfig.getConnectionUrl() :
+                String.format("%s-%s.svc.%s.pinecone.io",
+                        connectionConfig.getIndexName(),
+                        clientConfig.getProjectName(),
+                        clientConfig.getEnvironment());
 
         logger.debug("Pinecone endpoint is: " + endpoint);
 
         return endpoint;
-
     }
 }

--- a/src/main/java/io/pinecone/PineconeConnection.java
+++ b/src/main/java/io/pinecone/PineconeConnection.java
@@ -114,7 +114,7 @@ public class PineconeConnection implements AutoCloseable {
 
     static String getEndpoint(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
         String endpoint = (connectionConfig.getConnectionUrl() != null) ?
-                connectionConfig.getConnectionUrl().split("//")[1] :
+                connectionConfig.getConnectionUrl().replaceFirst("https?://", "") :
                 String.format("%s-%s.svc.%s.pinecone.io",
                         connectionConfig.getIndexName(),
                         clientConfig.getProjectName(),

--- a/src/main/java/io/pinecone/PineconeConnection.java
+++ b/src/main/java/io/pinecone/PineconeConnection.java
@@ -2,7 +2,6 @@ package io.pinecone;
 
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
-import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -115,7 +114,7 @@ public class PineconeConnection implements AutoCloseable {
 
     static String getEndpoint(PineconeClientConfig clientConfig, PineconeConnectionConfig connectionConfig) {
         String endpoint = (connectionConfig.getConnectionUrl() != null) ?
-                connectionConfig.getConnectionUrl() :
+                connectionConfig.getConnectionUrl().split("//")[1] :
                 String.format("%s-%s.svc.%s.pinecone.io",
                         connectionConfig.getIndexName(),
                         clientConfig.getProjectName(),

--- a/src/main/java/io/pinecone/PineconeConnectionConfig.java
+++ b/src/main/java/io/pinecone/PineconeConnectionConfig.java
@@ -67,8 +67,8 @@ public class PineconeConnectionConfig {
 
     void validate() {
         String messagePrefix = "Invalid Pinecone config: ";
-        if (indexName == null)
-            throw new PineconeValidationException(messagePrefix + "indexName must be specified");
+        if (indexName == null && connectionUrl == null)
+            throw new PineconeValidationException(messagePrefix + "indexName or connection url must be specified");
     }
 
     @Override

--- a/src/main/java/io/pinecone/PineconeConnectionConfig.java
+++ b/src/main/java/io/pinecone/PineconeConnectionConfig.java
@@ -16,6 +16,8 @@ public class PineconeConnectionConfig {
      */
     private String indexName;
 
+    private String connectionUrl;
+
     /**
      * Creates a new default config.
      */
@@ -23,6 +25,7 @@ public class PineconeConnectionConfig {
 
     protected PineconeConnectionConfig(PineconeConnectionConfig other) {
         indexName = other.indexName;
+        connectionUrl = other.connectionUrl;
         customChannelBuilder = other.customChannelBuilder;
     }
 
@@ -39,6 +42,16 @@ public class PineconeConnectionConfig {
     public PineconeConnectionConfig withIndexName(String indexName) {
         PineconeConnectionConfig config = new PineconeConnectionConfig(this);
         config.indexName = indexName;
+        return config;
+    }
+
+    public String getConnectionUrl() {
+        return connectionUrl;
+    }
+
+    public PineconeConnectionConfig withConnectionUrl(String connectionUrl) {
+        PineconeConnectionConfig config = new PineconeConnectionConfig(this);
+        config.connectionUrl = connectionUrl;
         return config;
     }
 
@@ -63,6 +76,7 @@ public class PineconeConnectionConfig {
         return "PineconeConnectionConfig("
                 + "customChannelBuilder=" + getCustomChannelBuilder()
                 + ", indexName=" + getIndexName()
+                + ", connectionUrl=" + getConnectionUrl()
                 + ")";
     }
 }

--- a/src/main/java/io/pinecone/PineconeConnectionConfig.java
+++ b/src/main/java/io/pinecone/PineconeConnectionConfig.java
@@ -66,9 +66,8 @@ public class PineconeConnectionConfig {
     }
 
     void validate() {
-        String messagePrefix = "Invalid Pinecone config: ";
         if (indexName == null && connectionUrl == null)
-            throw new PineconeValidationException(messagePrefix + "indexName or connection url must be specified");
+            throw new PineconeValidationException("Invalid PineconeConnectionConfig, indexName or connection url must be specified.");
     }
 
     @Override

--- a/src/test/java/io/pinecone/PineconeConnectionTest.java
+++ b/src/test/java/io/pinecone/PineconeConnectionTest.java
@@ -1,0 +1,33 @@
+package io.pinecone;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PineconeConnectionTest {
+    
+    @Test
+    void testGetEndpointWithConnectionUrl() {
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("api-key");
+        PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
+                .withConnectionUrl("https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io");
+
+        String endpoint = PineconeConnection.getEndpoint(clientConfig, connectionConfig);
+
+        assertEquals("https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io", endpoint);
+    }
+
+    @Test
+    void testGetEndpointWithoutConnectionUrl() {
+        PineconeClientConfig clientConfig = new PineconeClientConfig()
+                .withApiKey("secret-api-key")
+                .withEnvironment("aws-us-east4")
+                .withProjectName("fee911a");
+        PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
+                .withIndexName("step-2");
+
+        String endpoint = PineconeConnection.getEndpoint(clientConfig, connectionConfig);
+
+        assertEquals("step-2-fee911a.svc.aws-us-east4.pinecone.io", endpoint);
+    }
+}

--- a/src/test/java/io/pinecone/PineconeConnectionTest.java
+++ b/src/test/java/io/pinecone/PineconeConnectionTest.java
@@ -5,16 +5,27 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PineconeConnectionTest {
-    
+
     @Test
-    void testGetEndpointWithConnectionUrl() {
+    void testGetEndpointWithConnectionUrlWithHttps() {
         PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("api-key");
         PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
                 .withConnectionUrl("https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io");
 
         String endpoint = PineconeConnection.getEndpoint(clientConfig, connectionConfig);
 
-        assertEquals("https://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io", endpoint);
+        assertEquals("steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io", endpoint);
+    }
+
+    @Test
+    void testGetEndpointWithConnectionUrlWithHttp() {
+        PineconeClientConfig clientConfig = new PineconeClientConfig().withApiKey("api-key");
+        PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
+                .withConnectionUrl("http://steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io");
+
+        String endpoint = PineconeConnection.getEndpoint(clientConfig, connectionConfig);
+
+        assertEquals("steps-784-123-eqasas0aaaa1213aasasc-1223-f1eea9.svc.production.pinecone.io", endpoint);
     }
 
     @Test


### PR DESCRIPTION
## Problem
Connection url contains indexName, environment, and projectName but currently these values are manually set by the users in configuration, so the use the connection url string instead of asking for 3 different variables for data plane operations only.

## Solution
To reduce user errors, parse the connection url string to get indexName, environment, and projectName and add them to the configurations. The grpc calls for data plane were using these variables for reconstructing the endpoint again so added an if-else loop where if a valid connection url is found, it'll be used instead of reconstructing the endpoint. Although, if no connection url is passed, it'll be constructing the endpoint using the three variables mentioned before which is done as of today.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Created unit tests and performed manual integration tests locally.
