### PR TITLE
Update gRPC version to 1.58.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     jcenter()
 }
 
-def grpcVersion = '1.53.0'
+def grpcVersion = '1.58.0'
 
 dependencies {
     api "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/src/main/java/io/pinecone/PineconeConnection.java
+++ b/src/main/java/io/pinecone/PineconeConnection.java
@@ -46,9 +46,14 @@ public class PineconeConnection implements AutoCloseable {
                 : buildChannel(clientConfig, connectionConfig);
         channel.notifyWhenStateChanged(channel.getState(false), this::onConnectivityStateChanged);
         Metadata metadata = assembleMetadata(clientConfig, connectionConfig);
-        blockingStub = applyDefaultBlockingStubConfig(
-                MetadataUtils.attachHeaders(VectorServiceGrpc.newBlockingStub(channel), metadata));
-        asyncStub = MetadataUtils.attachHeaders(VectorServiceGrpc.newStub(channel), metadata);
+//        blockingStub = applyDefaultBlockingStubConfig(
+//                MetadataUtils.attachHeaders(VectorServiceGrpc.newBlockingStub(channel), metadata));
+        blockingStub = VectorServiceGrpc
+                .newBlockingStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+        asyncStub = VectorServiceGrpc
+                .newStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
         logger.debug("created new PineconeConnection for channel: {}", channel);
     }
 

--- a/src/main/java/io/pinecone/PineconeConnection.java
+++ b/src/main/java/io/pinecone/PineconeConnection.java
@@ -46,8 +46,6 @@ public class PineconeConnection implements AutoCloseable {
                 : buildChannel(clientConfig, connectionConfig);
         channel.notifyWhenStateChanged(channel.getState(false), this::onConnectivityStateChanged);
         Metadata metadata = assembleMetadata(clientConfig, connectionConfig);
-//        blockingStub = applyDefaultBlockingStubConfig(
-//                MetadataUtils.attachHeaders(VectorServiceGrpc.newBlockingStub(channel), metadata));
         blockingStub = VectorServiceGrpc
                 .newBlockingStub(channel)
                 .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));


### PR DESCRIPTION
## Problem

The Java SDK currently uses gRPC version `1.53.0`, which has a deprecated method called `attachHeaders`. Since the latest release of gRPC version `1.58.0`, the `attachHeaders` method has been removed. Therefore, users running gRPC version `1.58.0` and attempting to use this SDK will encounter an error stating that the method is not found. 

## Solution

Update gRPC version `1.53.0` to the latest version `1.58.0`.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran integration tests locally for all data plane operations.
