### PR TITLE
Update readme for outdated java-basic-mvn example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ The Java client doesn't support managing Pinecone services, only reading and wri
 ## Examples
 
 - The most basic example usage is in `src/test/java/io/pinecone/PineconeClientLiveIntegTest.java`, covering most basic operations.
+> [!NOTE]
+> The java-basic-mvn example is outdated.


### PR DESCRIPTION
## Problem

Java-basic-mvn is a subfolder with examples for data plane operations which has been outdated.

## Solution

Update the README.md file with a note saying the java-basic-mvn is outdated.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

NA
