### PR TITLE
Update build.gradle file to fix dependency issues and improve testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
 
+### v0.5.1
+- Update build.gradle
+
 ### v0.5.0
 - Update asyncHttpClient with okHttpClient for control plane operations
 - Add ability to describe index

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,11 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+
 
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation 'org.mockito:mockito-inline:4.8.0'
@@ -90,7 +90,6 @@ protobuf {
     }
 }
 
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
 sourceSets {
     main {
         java {
@@ -130,6 +129,20 @@ publishing {
                 }
             }
         }
+    }
+
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            pom {
+                artifactId = 'pinecone-client'
+                name = 'pinecone-client'
+                description = 'The Pinecone.io Java Client'
+            }
+        }
+    }
+    repositories {
+        mavenLocal()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'io.pinecone'
-version = '0.5.0' // [pc:VERSION_NEXT]
+version = '0.5.1' // [pc:VERSION_NEXT]
 description = 'The Pinecone.io Java Client'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -25,12 +25,11 @@ dependencies {
     api "io.grpc:grpc-protobuf:${grpcVersion}"
     api "io.grpc:grpc-stub:${grpcVersion}"
     api "io.grpc:grpc-netty:${grpcVersion}"
-    runtime 'io.netty:netty-tcnative-boringssl-static:2.0.59.Final'
+    runtimeOnly 'io.netty:netty-tcnative-boringssl-static:2.0.61.Final'
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
-    implementation 'org.asynchttpclient:async-http-client:2.12.1'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+


### PR DESCRIPTION
## Problem

Transitive dependencies are causing issues in the java sdk. Also there's no support to publish jars locally to test updated changes in a separate test-example repository.

## Solution

Remove unnecessary libraries, update deprecated methods, and `netty-tcnative-boringssl-static` version that is compatible with `grpc v1.58.0` per [grpc java compatibility matrix](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty) in `build.gradle` file. Also add `PublishToMavenLocal` function in `build.gradle` file which will copy jars to the local maven cache, including their metadata (POM files, etc.).

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran all unit tests along with integration tests and the updated `java-mvn-example` locally.
