### PR TITLE
Setup starter CI job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,8 @@ jobs:
         
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: 6.8
     
     - name: Execute Gradle build
       run: ./gradlew build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,26 @@
+name: Pull Request
+
+on: 
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        javaVersion: [8, 11, 16, 17]
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: ${{ matrix.javaVersion}}
+        
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+    
+    - name: Execute Gradle build
+      run: ./gradlew build


### PR DESCRIPTION
## Problem

We need to setup [Github Actions](https://docs.github.com/en/actions) for this repository. 

## Solution

Setup a starter job, mostly copied from docs for [gradle build action](https://github.com/gradle/gradle-build-action) that builds the code and nothing else.

We'll want to add stuff and customize this more, but you can't run CI workflows in branches until you have something in main. This is just an unfortunate limitation of github actions.

For now this job only runs when manually triggered (e.g. `workflow_dispatch`), but later after we're happy with how it works we will triigger automatically on every PR.

## Type of Change

- [x] Infrastructure change (CI configs, etc)
