### PR TITLE
Add support to configure index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
+- Add support to list indexes
 
 ### v0.6.0
 - Add async stub for data plane operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
 - Add support to list indexes
+- Add support to configure index
 
 ### v0.6.0
 - Add async stub for data plane operations

--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.pinecone;
 
 import io.pinecone.helpers.RandomStringBuilder;
+import io.pinecone.model.ConfigureIndexRequest;
 import io.pinecone.model.CreateIndexRequest;
 import io.pinecone.model.IndexMeta;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,18 @@ public class PineconeIndexOperationsClientIntegrationTest {
         // List the index
         List<String> indexList = pinecone.listIndexes();
         assert !indexList.isEmpty();
+
+        // Configure the index
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("p1.x2")
+                .withReplicas(3);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Get the index description
+        indexMeta = pinecone.describeIndex(indexName);
+        assertNotNull(indexMeta);
+        assertEquals(3, indexMeta.getDatabase().getReplicas());
+        assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
 
         // Cleanup
         pinecone.deleteIndex(indexName);

--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -44,8 +44,7 @@ public class PineconeIndexOperationsClientIntegrationTest {
 
         // List the index
         List<String> indexList = pinecone.listIndexes();
-        assertEquals(1, indexList.size());
-        assertEquals(indexList.get(0), indexName);
+        assert !indexList.isEmpty();
 
         // Cleanup
         pinecone.deleteIndex(indexName);

--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,6 +41,11 @@ public class PineconeIndexOperationsClientIntegrationTest {
         assertEquals(10, indexMeta.getDatabase().getDimension());
         assertEquals(indexName, indexMeta.getDatabase().getName());
         assertEquals("euclidean", indexMeta.getDatabase().getMetric());
+
+        // List the index
+        List<String> indexList = pinecone.listIndexes();
+        assertEquals(1, indexList.size());
+        assertEquals(indexList.get(0), indexName);
 
         // Cleanup
         pinecone.deleteIndex(indexName);

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.pinecone.exceptions.FailedRequestInfo;
 import io.pinecone.exceptions.HttpErrorMapper;
 import io.pinecone.exceptions.PineconeConfigurationException;
+import io.pinecone.model.ConfigureIndexRequest;
 import io.pinecone.model.CreateIndexRequest;
 import io.pinecone.model.IndexMeta;
 import okhttp3.*;
@@ -26,6 +27,7 @@ public class PineconeIndexOperationClient {
     public static final String EMPTY_RESOURCE_PATH = "";
     public static final String HTTP_METHOD_DELETE = "DELETE";
     public static final String HTTP_METHOD_GET = "GET";
+    public static final String HTTP_METHOD_PATCH = "HTTP_METHOD_PATCH";
     public static final String HTTP_METHOD_POST = "POST";
     public static final String TEXT_PLAIN = "text/plain";
 
@@ -59,7 +61,7 @@ public class PineconeIndexOperationClient {
     }
 
     public void createIndex(CreateIndexRequest createIndexRequest) throws IOException {
-        MediaType mediaType = MediaType.parse("application/json; charset=utf-8");
+        MediaType mediaType = MediaType.parse(CONTENT_TYPE_JSON + ";" + CONTENT_TYPE_CHARSET_UTF8);
         RequestBody requestBody = RequestBody.create(createIndexRequest.toJson(), mediaType);
         Request request = buildRequest(HTTP_METHOD_POST, EMPTY_RESOURCE_PATH, TEXT_PLAIN, requestBody);
         try (Response response = client.newCall(request).execute()) {
@@ -88,6 +90,15 @@ public class PineconeIndexOperationClient {
         return indexList;
     }
 
+    public void configureIndex(String indexName, ConfigureIndexRequest configureIndexRequest) throws IOException {
+        MediaType mediaType = MediaType.parse(CONTENT_TYPE_JSON + ";" + CONTENT_TYPE_CHARSET_UTF8);
+        RequestBody requestBody = RequestBody.create(configureIndexRequest.toJson(), mediaType);
+        Request request = buildRequest(HTTP_METHOD_PATCH, indexName, TEXT_PLAIN, requestBody);
+        try (Response response = client.newCall(request).execute()) {
+            handleResponse(response);
+        }
+    }
+
     private Request buildRequest(String method, String path, String acceptHeader, RequestBody requestBody) {
         Request.Builder builder = new Request.Builder()
                 .url(url + path)
@@ -96,9 +107,12 @@ public class PineconeIndexOperationClient {
         if (HTTP_METHOD_POST.equals(method)) {
             builder.post(requestBody);
             builder.addHeader(CONTENT_TYPE, CONTENT_TYPE_JSON);
-        } else if (HTTP_METHOD_DELETE.equals(method)) {
-            builder.delete();
-        }
+        } else if(HTTP_METHOD_PATCH.equals(method)) {
+            builder.patch(requestBody);
+            builder.addHeader(CONTENT_TYPE, CONTENT_TYPE_JSON);
+        } else if (HTTP_METHOD_DELETE.equals(method))
+        builder.delete();
+
         return builder.build();
     }
 

--- a/src/main/java/io/pinecone/model/ConfigureIndexRequest.java
+++ b/src/main/java/io/pinecone/model/ConfigureIndexRequest.java
@@ -1,0 +1,50 @@
+package io.pinecone.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ConfigureIndexRequest {
+    private Integer replicas = 1;
+
+    private String podType = "p1.x1";
+
+    public ConfigureIndexRequest() {
+    }
+
+    public ConfigureIndexRequest withReplicas(Integer replicas) {
+        this.replicas = replicas;
+        return this;
+    }
+
+    /**
+     * The number of replicas. Replicas duplicate your index. They provide higher availability and throughput.
+     * @return replicas
+     **/
+    public Integer getReplicas() {
+        return replicas;
+    }
+
+    public ConfigureIndexRequest withPodType(String podType) {
+        this.podType = podType;
+        return this;
+    }
+
+    /**
+     * The type of pod to use. One of s1, p1, or p2 appended with . and one of x1, x2, x4, or x8.
+     * @return podType
+     **/
+    public String getPodType() {
+        return podType;
+    }
+
+    public String toJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode jsonNode = mapper.createObjectNode()
+                .put("replicas", replicas)
+                .put("pod_type", podType);
+
+        return jsonNode.toString();
+    }
+}

--- a/src/test/java/io/pinecone/PineconeConnectionTest.java
+++ b/src/test/java/io/pinecone/PineconeConnectionTest.java
@@ -1,8 +1,5 @@
 package io.pinecone;
 
-import io.pinecone.PineconeClientConfig;
-import io.pinecone.PineconeConnection;
-import io.pinecone.PineconeConnectionConfig;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -34,7 +34,7 @@ public class PineconeIndexOperationClientTest {
     }
 
     @Test
-    public void IndexOpsWithoutApiKey() throws IOException {
+    public void IndexOpsWithoutApiKey() {
         PineconeClientConfig clientConfig = new PineconeClientConfig()
                 .withEnvironment("testEnvironment");
         OkHttpClient mockClient = mock(OkHttpClient.class);
@@ -43,7 +43,7 @@ public class PineconeIndexOperationClientTest {
     }
 
     @Test
-    public void IndexOpsWithoutEnvironment() throws IOException {
+    public void IndexOpsWithoutEnvironment() {
         PineconeClientConfig clientConfig = new PineconeClientConfig()
                 .withApiKey("testApiKey");
         OkHttpClient mockClient = mock(OkHttpClient.class);
@@ -52,7 +52,7 @@ public class PineconeIndexOperationClientTest {
     }
 
     @Test
-    public void IndexOpsWithoutApiKeyAndEnvironment() throws IOException {
+    public void IndexOpsWithoutApiKeyAndEnvironment() {
         PineconeClientConfig clientConfig = new PineconeClientConfig();
         OkHttpClient mockClient = mock(OkHttpClient.class);
 
@@ -264,5 +264,32 @@ public class PineconeIndexOperationClientTest {
         List<String> emptyIndexList = indexOperationClient.listIndexes();
         assertNotNull(emptyIndexList);
         assertTrue(emptyIndexList.isEmpty());
+    }
+
+    @Test
+    public void testConfigureIndex() throws IOException {
+        String indexName = "test-index";
+        PineconeClientConfig clientConfig = new PineconeClientConfig()
+                .withApiKey("testApiKey")
+                .withEnvironment("testEnvironment");
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("s1.x2").withReplicas(3);
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(202)
+                .message("The index has been successfully updated.")
+                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
+                .build());
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        PineconeIndexOperationClient indexOperationClient = new PineconeIndexOperationClient(clientConfig, mockClient);
+        indexOperationClient.configureIndex(indexName, configureIndexRequest);
+
+        verify(mockClient, times(1)).newCall(any(Request.class));
+        verify(mockCall, times(1)).execute();
     }
 }


### PR DESCRIPTION
## Problem

The sdk lacks the ability to configure the index.

## Solution

Added support to configure `podtype` and the `number of replicas` for an index.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Added unit and integrations tests.
