### PR TITLE
Add support to configure index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
 - Add support to list indexes
+- Add support to configure index
 
 ### v0.6.0
 - Add async stub for data plane operations

--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.pinecone;
 
 import io.pinecone.helpers.RandomStringBuilder;
+import io.pinecone.model.ConfigureIndexRequest;
 import io.pinecone.model.CreateIndexRequest;
 import io.pinecone.model.IndexMeta;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,18 @@ public class PineconeIndexOperationsClientIntegrationTest {
         // List the index
         List<String> indexList = pinecone.listIndexes();
         assert !indexList.isEmpty();
+
+        // Configure the index
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("p1.x2")
+                .withReplicas(3);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Get the index description
+        indexMeta = pinecone.describeIndex(indexName);
+        assertNotNull(indexMeta);
+        assertEquals(3, indexMeta.getDatabase().getReplicas());
+        assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
 
         // Cleanup
         pinecone.deleteIndex(indexName);

--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -1,7 +1,6 @@
 package io.pinecone;
 
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.model.ConfigureIndexRequest;
 import io.pinecone.model.CreateIndexRequest;
 import io.pinecone.model.IndexMeta;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -47,18 +47,6 @@ public class PineconeIndexOperationsClientIntegrationTest {
         List<String> indexList = pinecone.listIndexes();
         assert !indexList.isEmpty();
 
-        // Configure the index
-        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
-                .withPodType("p1.x2")
-                .withReplicas(3);
-        pinecone.configureIndex(indexName, configureIndexRequest);
-
-        // Get the index description
-        indexMeta = pinecone.describeIndex(indexName);
-        assertNotNull(indexMeta);
-        assertEquals(3, indexMeta.getDatabase().getReplicas());
-        assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
-
         // Cleanup
         pinecone.deleteIndex(indexName);
     }

--- a/src/integration/java/io/pinecone/integration/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/ConfigureIndexTest.java
@@ -1,0 +1,150 @@
+package io.pinecone.integration;
+
+import io.pinecone.PineconeClientConfig;
+import io.pinecone.PineconeIndexOperationClient;
+import io.pinecone.exceptions.PineconeBadRequestException;
+import io.pinecone.helpers.RandomStringBuilder;
+import io.pinecone.model.ConfigureIndexRequest;
+import io.pinecone.model.CreateIndexRequest;
+import io.pinecone.model.IndexMeta;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConfigureIndexTest {
+    private PineconeIndexOperationClient pinecone;
+    private String indexName = RandomStringBuilder.build("index-name", 8);
+
+    @BeforeEach
+    public void setUp() throws IOException{
+        PineconeClientConfig config = new PineconeClientConfig()
+                .withApiKey(System.getenv("PINECONE_API_KEY"))
+                .withEnvironment(System.getenv("PINECONE_ENVIRONMENT"))
+                .withServerSideTimeoutSec(10);
+        pinecone = new PineconeIndexOperationClient(config);
+
+        // Create an index
+        CreateIndexRequest request = new CreateIndexRequest()
+                .withIndexName(indexName)
+                .withDimension(5)
+                .withMetric("euclidean");
+        pinecone.createIndex(request);
+    }
+
+    @AfterEach
+    public void cleanUp() throws IOException {
+        pinecone.deleteIndex(indexName);
+    }
+
+    @Nested
+    class scalingReplicas {
+        @Test
+        public void scaleUp() throws IOException {
+            // Verify the starting state
+            IndexMeta indexMeta = pinecone.describeIndex(indexName);
+            assertEquals(1, indexMeta.getDatabase().getReplicas());
+
+            // Configure the index
+            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                    .withReplicas(2);
+            pinecone.configureIndex(indexName, configureIndexRequest);
+
+            // Verify replicas were scaled up
+            indexMeta = pinecone.describeIndex(indexName);
+            assertEquals(2, indexMeta.getDatabase().getReplicas());
+        }
+
+        @Test
+        public void scaleDown() throws IOException {
+            // Verify the starting state
+            IndexMeta indexMeta = pinecone.describeIndex(indexName);
+            assertEquals(1, indexMeta.getDatabase().getReplicas());
+
+            // Scale up for the test
+            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                    .withReplicas(3);
+            pinecone.configureIndex(indexName, configureIndexRequest);
+
+            // Verify the scaled up replicas
+            indexMeta = pinecone.describeIndex(indexName);
+            assertEquals(3, indexMeta.getDatabase().getReplicas());
+
+            // Scaling down
+            configureIndexRequest = new ConfigureIndexRequest()
+                    .withReplicas(2);
+            pinecone.configureIndex(indexName, configureIndexRequest);
+
+            // Verify replicas were scaled down
+            indexMeta = pinecone.describeIndex(indexName);
+            assertEquals(2, indexMeta.getDatabase().getReplicas());
+        }
+    }
+
+    @Nested
+    class ScalingPodTypeTests {
+        @Test
+        public void changingBasePodType() throws IOException {
+            // Verify the starting state
+            IndexMeta indexMeta = pinecone.describeIndex(indexName);
+            assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
+
+            // Try to change the base pod type
+            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                    .withPodType("p2.x1");
+            try {
+                pinecone.configureIndex(indexName, configureIndexRequest);
+            } catch (Exception exception) {
+                assertEquals(exception.getClass(), PineconeBadRequestException.class);
+                assertEquals(exception.getMessage(), "updating base pod type is not supported");
+            }
+        }
+
+        @Test
+        public void sizeIncrease() throws IOException {
+            // Verify the starting state
+            IndexMeta indexMeta = pinecone.describeIndex(indexName);
+            assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
+
+            // Change the pod type to a larger one
+            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                    .withPodType("p1.x2");
+            pinecone.configureIndex(indexName, configureIndexRequest);
+
+            // Get the index description to verify the new pod type
+            indexMeta = pinecone.describeIndex(indexName);
+            assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+        }
+
+        @Test
+        public void sizeDown() throws IOException {
+            // Verify the starting state
+            IndexMeta indexMeta = pinecone.describeIndex(indexName);
+            assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
+
+            // Increase the pod type
+            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                    .withPodType("p1.x2");
+            pinecone.configureIndex(indexName, configureIndexRequest);
+
+            // Get the index description to verify the new pod type
+            indexMeta = pinecone.describeIndex(indexName);
+            assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+
+            // Attempt to scale down
+            configureIndexRequest = new ConfigureIndexRequest()
+                    .withPodType("p1.x1");
+            try {
+                pinecone.configureIndex(indexName, configureIndexRequest);
+            } catch (Exception exception) {
+                assertEquals(exception.getClass(), PineconeBadRequestException.class);
+                assertEquals(exception.getMessage(), "scaling down pod type is not supported");
+            }
+
+            // Get the index description to verify the pod type remains unchanged
+            indexMeta = pinecone.describeIndex(indexName);
+            assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+        }
+    }
+}

--- a/src/integration/java/io/pinecone/integration/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/ConfigureIndexTest.java
@@ -3,6 +3,7 @@ package io.pinecone.integration;
 import io.pinecone.PineconeClientConfig;
 import io.pinecone.PineconeIndexOperationClient;
 import io.pinecone.exceptions.PineconeBadRequestException;
+import io.pinecone.exceptions.PineconeNotFoundException;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.model.ConfigureIndexRequest;
 import io.pinecone.model.CreateIndexRequest;
@@ -11,18 +12,19 @@ import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConfigureIndexTest {
     private PineconeIndexOperationClient pinecone;
-    private String indexName = RandomStringBuilder.build("index-name", 8);
+    private String indexName;
 
     @BeforeEach
-    public void setUp() throws IOException{
+    public void setUp() throws IOException {
+        indexName = RandomStringBuilder.build("index-name", 8);
         PineconeClientConfig config = new PineconeClientConfig()
                 .withApiKey(System.getenv("PINECONE_API_KEY"))
-                .withEnvironment(System.getenv("PINECONE_ENVIRONMENT"))
-                .withServerSideTimeoutSec(10);
+                .withEnvironment(System.getenv("PINECONE_ENVIRONMENT"));
         pinecone = new PineconeIndexOperationClient(config);
 
         // Create an index
@@ -38,113 +40,144 @@ public class ConfigureIndexTest {
         pinecone.deleteIndex(indexName);
     }
 
-    @Nested
-    class scalingReplicas {
-        @Test
-        public void scaleUp() throws IOException {
-            // Verify the starting state
-            IndexMeta indexMeta = pinecone.describeIndex(indexName);
-            assertEquals(1, indexMeta.getDatabase().getReplicas());
+    @Test
+    public void configureIndexWithInvalidIndexName() throws IOException, InterruptedException {
+        // Verify that configuring an invalid index name throws an exception
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withReplicas(2);
+        checkIndexStatusReady(indexName);
+        assertThrows(PineconeNotFoundException.class, () -> {
+            pinecone.configureIndex("non-existent-index", configureIndexRequest);
+        });
+    }
 
-            // Configure the index
-            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
-                    .withReplicas(2);
+    @Test
+    public void configureIndexExceedingQuota() throws IOException, InterruptedException {
+        // Verify that configuring an index with replicas exceeding the quota throws an exception
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withReplicas(20);
+        checkIndexStatusReady(indexName);
+        assertThrows(PineconeBadRequestException.class, () ->
+            pinecone.configureIndex(indexName, configureIndexRequest));
+    }
+
+    @Test
+    public void scaleUp() throws IOException, InterruptedException {
+        // Verify the starting state
+        IndexMeta indexMeta = pinecone.describeIndex(indexName);
+        assertEquals(1, indexMeta.getDatabase().getReplicas());
+
+        // Configure the index
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withReplicas(2);
+        checkIndexStatusReady(indexName);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Verify replicas were scaled up
+        indexMeta = pinecone.describeIndex(indexName);
+        assertEquals(2, indexMeta.getDatabase().getReplicas());
+    }
+
+    @Test
+    public void scaleDown() throws IOException, InterruptedException {
+        // Verify the starting state
+        IndexMeta indexMeta = pinecone.describeIndex(indexName);
+        assertEquals(1, indexMeta.getDatabase().getReplicas());
+
+        // Scale up for the test
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withReplicas(3);
+        checkIndexStatusReady(indexName);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Verify the scaled up replicas
+        indexMeta = pinecone.describeIndex(indexName);
+        assertEquals(3, indexMeta.getDatabase().getReplicas());
+
+        // Scaling down
+        configureIndexRequest = new ConfigureIndexRequest()
+                .withReplicas(1);
+        checkIndexStatusReady(indexName);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Verify replicas were scaled down
+        indexMeta = pinecone.describeIndex(indexName);
+        assertEquals(1, indexMeta.getDatabase().getReplicas());
+    }
+
+    @Test
+    public void changingBasePodType() throws IOException, InterruptedException {
+        // Verify the starting state
+        IndexMeta indexMeta = pinecone.describeIndex(indexName);
+        assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
+
+        // Try to change the base pod type
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("p2.x1");
+        try {
+            checkIndexStatusReady(indexName);
             pinecone.configureIndex(indexName, configureIndexRequest);
-
-            // Verify replicas were scaled up
-            indexMeta = pinecone.describeIndex(indexName);
-            assertEquals(2, indexMeta.getDatabase().getReplicas());
-        }
-
-        @Test
-        public void scaleDown() throws IOException {
-            // Verify the starting state
-            IndexMeta indexMeta = pinecone.describeIndex(indexName);
-            assertEquals(1, indexMeta.getDatabase().getReplicas());
-
-            // Scale up for the test
-            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
-                    .withReplicas(3);
-            pinecone.configureIndex(indexName, configureIndexRequest);
-
-            // Verify the scaled up replicas
-            indexMeta = pinecone.describeIndex(indexName);
-            assertEquals(3, indexMeta.getDatabase().getReplicas());
-
-            // Scaling down
-            configureIndexRequest = new ConfigureIndexRequest()
-                    .withReplicas(2);
-            pinecone.configureIndex(indexName, configureIndexRequest);
-
-            // Verify replicas were scaled down
-            indexMeta = pinecone.describeIndex(indexName);
-            assertEquals(2, indexMeta.getDatabase().getReplicas());
+        } catch (PineconeBadRequestException pineconeBadRequestException) {
+            assertEquals(pineconeBadRequestException.getMessage(), "updating base pod type is not supported");
         }
     }
 
-    @Nested
-    class ScalingPodTypeTests {
-        @Test
-        public void changingBasePodType() throws IOException {
-            // Verify the starting state
-            IndexMeta indexMeta = pinecone.describeIndex(indexName);
-            assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
+    @Test
+    public void sizeIncrease() throws IOException, InterruptedException {
+        // Verify the starting state
+        IndexMeta indexMeta = pinecone.describeIndex(indexName);
+        assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
 
-            // Try to change the base pod type
-            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
-                    .withPodType("p2.x1");
-            try {
-                pinecone.configureIndex(indexName, configureIndexRequest);
-            } catch (Exception exception) {
-                assertEquals(exception.getClass(), PineconeBadRequestException.class);
-                assertEquals(exception.getMessage(), "updating base pod type is not supported");
-            }
+        // Change the pod type to a larger one
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("p1.x2");
+        checkIndexStatusReady(indexName);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Get the index description to verify the new pod type
+        indexMeta = pinecone.describeIndex(indexName);
+        assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+    }
+
+    @Test
+    public void sizeDown() throws IOException, InterruptedException {
+        // Verify the starting state
+        IndexMeta indexMeta = pinecone.describeIndex(indexName);
+        assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
+
+        // Increase the pod type
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("p1.x2");
+        checkIndexStatusReady(indexName);
+        pinecone.configureIndex(indexName, configureIndexRequest);
+
+        // Get the index description to verify the new pod type
+        indexMeta = pinecone.describeIndex(indexName);
+        assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+
+        // Attempt to scale down
+        configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("p1.x1");
+        try {
+            pinecone.configureIndex(indexName, configureIndexRequest);
+        } catch (Exception exception) {
+            assertEquals(exception.getClass(), PineconeBadRequestException.class);
+            assertEquals(exception.getMessage(), "scaling down pod type is not supported");
         }
 
-        @Test
-        public void sizeIncrease() throws IOException {
-            // Verify the starting state
+        // Get the index description to verify the pod type remains unchanged
+        indexMeta = pinecone.describeIndex(indexName);
+        assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+    }
+
+    private void checkIndexStatusReady(String indexName) throws IOException, InterruptedException {
+        while (true) {
             IndexMeta indexMeta = pinecone.describeIndex(indexName);
-            assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
-
-            // Change the pod type to a larger one
-            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
-                    .withPodType("p1.x2");
-            pinecone.configureIndex(indexName, configureIndexRequest);
-
-            // Get the index description to verify the new pod type
-            indexMeta = pinecone.describeIndex(indexName);
-            assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
-        }
-
-        @Test
-        public void sizeDown() throws IOException {
-            // Verify the starting state
-            IndexMeta indexMeta = pinecone.describeIndex(indexName);
-            assertEquals("p1.x1", indexMeta.getDatabase().getPodType());
-
-            // Increase the pod type
-            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
-                    .withPodType("p1.x2");
-            pinecone.configureIndex(indexName, configureIndexRequest);
-
-            // Get the index description to verify the new pod type
-            indexMeta = pinecone.describeIndex(indexName);
-            assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
-
-            // Attempt to scale down
-            configureIndexRequest = new ConfigureIndexRequest()
-                    .withPodType("p1.x1");
-            try {
-                pinecone.configureIndex(indexName, configureIndexRequest);
-            } catch (Exception exception) {
-                assertEquals(exception.getClass(), PineconeBadRequestException.class);
-                assertEquals(exception.getMessage(), "scaling down pod type is not supported");
+            if (indexMeta.getStatus().getState().equalsIgnoreCase("ready")) {
+                break;
             }
 
-            // Get the index description to verify the pod type remains unchanged
-            indexMeta = pinecone.describeIndex(indexName);
-            assertEquals("p1.x2", indexMeta.getDatabase().getPodType());
+            Thread.sleep(1000);
         }
     }
 }

--- a/src/integration/java/io/pinecone/integration/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/ConfigureIndexTest.java
@@ -65,8 +65,7 @@ public class ConfigureIndexTest {
             checkIndexStatusReady(indexName);
             pinecone.configureIndex(indexName, configureIndexRequest);
         } catch (PineconeBadRequestException exception) {
-            assert (exception.getLocalizedMessage().contains("The index exceeds the project " +
-                    "quota of 5 pods by 16 pods."));
+            assert (exception.getLocalizedMessage().contains("The index exceeds the project quota"));
             assert (exception.getLocalizedMessage().contains("Upgrade your account or change" +
                     " the project settings to increase the quota."));
         } catch (Exception exception) {
@@ -201,7 +200,7 @@ public class ConfigureIndexTest {
                 break;
             }
 
-            Thread.sleep(500);
+            Thread.sleep(1000);
         }
     }
 }

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -110,8 +110,9 @@ public class PineconeIndexOperationClient {
         } else if(HTTP_METHOD_PATCH.equals(method)) {
             builder.patch(requestBody);
             builder.addHeader(CONTENT_TYPE, CONTENT_TYPE_JSON);
-        } else if (HTTP_METHOD_DELETE.equals(method))
+        } else if (HTTP_METHOD_DELETE.equals(method)) {
             builder.delete();
+        }
         return builder.build();
     }
 

--- a/src/main/java/io/pinecone/model/ConfigureIndexRequest.java
+++ b/src/main/java/io/pinecone/model/ConfigureIndexRequest.java
@@ -1,0 +1,50 @@
+package io.pinecone.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ConfigureIndexRequest {
+    private Integer replicas = 1;
+
+    private String podType = "p1.x1";
+
+    public ConfigureIndexRequest() {
+    }
+
+    public ConfigureIndexRequest withReplicas(Integer replicas) {
+        this.replicas = replicas;
+        return this;
+    }
+
+    /**
+     * The number of replicas. Replicas duplicate your index. They provide higher availability and throughput.
+     * @return replicas
+     **/
+    public Integer getReplicas() {
+        return replicas;
+    }
+
+    public ConfigureIndexRequest withPodType(String podType) {
+        this.podType = podType;
+        return this;
+    }
+
+    /**
+     * The type of pod to use. One of s1, p1, or p2 appended with . and one of x1, x2, x4, or x8.
+     * @return podType
+     **/
+    public String getPodType() {
+        return podType;
+    }
+
+    public String toJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode jsonNode = mapper.createObjectNode()
+                .put("replicas", replicas)
+                .put("pod_type", podType);
+
+        return jsonNode.toString();
+    }
+}

--- a/src/test/java/io/pinecone/PineconeConnectionTest.java
+++ b/src/test/java/io/pinecone/PineconeConnectionTest.java
@@ -1,8 +1,5 @@
 package io.pinecone;
 
-import io.pinecone.PineconeClientConfig;
-import io.pinecone.PineconeConnection;
-import io.pinecone.PineconeConnectionConfig;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationClientTest.java
@@ -265,4 +265,31 @@ public class PineconeIndexOperationClientTest {
         assertNotNull(emptyIndexList);
         assertTrue(emptyIndexList.isEmpty());
     }
+
+    @Test
+    public void testConfigureIndex() throws IOException {
+        String indexName = "test-index";
+        PineconeClientConfig clientConfig = new PineconeClientConfig()
+                .withApiKey("testApiKey")
+                .withEnvironment("testEnvironment");
+        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest()
+                .withPodType("s1.x2").withReplicas(3);
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(202)
+                .message("The index has been successfully updated.")
+                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
+                .build());
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        PineconeIndexOperationClient indexOperationClient = new PineconeIndexOperationClient(clientConfig, mockClient);
+        indexOperationClient.configureIndex(indexName, configureIndexRequest);
+
+        verify(mockClient, times(1)).newCall(any(Request.class));
+        verify(mockCall, times(1)).execute();
+    }
 }


### PR DESCRIPTION
## Problem

The sdk lacks the ability to configure an index.

## Solution

Added support to configure `podtype` and the `number of replicas` for an index.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Added unit and integrations tests.