### PR TITLE
Add integration test for deleting vectors

### DIFF
--- a/src/integration/java/io/pinecone/helpers/BuildUpsertRequest.java
+++ b/src/integration/java/io/pinecone/helpers/BuildUpsertRequest.java
@@ -15,17 +15,22 @@ public class BuildUpsertRequest {
     private static final float[][] upsertData = {{1.0F, 2.0F, 3.0F}, {4.0F, 5.0F, 6.0F}, {7.0F, 8.0F, 9.0F}};
 
     public static UpsertRequest buildRequiredUpsertRequest() {
-        String namespace = RandomStringBuilder.build("ns", 8);
-        List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
-        List<Vector> upsertVectors = new ArrayList<>();
+        return buildRequiredUpsertRequest(new ArrayList<>(), "");
+    }
 
+    public static UpsertRequest buildRequiredUpsertRequest(String namespace) {
+        return buildRequiredUpsertRequest(new ArrayList<>(), namespace);
+    }
+
+    public static UpsertRequest buildRequiredUpsertRequest(List<String> upsertIds, String namespace) {
+        if (upsertIds.isEmpty()) upsertIds = Arrays.asList("v1", "v2", "v3");
+        if (namespace.isEmpty()) namespace = RandomStringBuilder.build("ns", 8);
+
+        List<Vector> upsertVectors = new ArrayList<>();
         for (int i = 0; i < upsertData.length; i++) {
             upsertVectors.add(Vector.newBuilder()
                     .addAllValues(Floats.asList(upsertData[i]))
-                    .setMetadata(Struct.newBuilder()
-                            .putFields("some_field", Value.newBuilder().setNumberValue(i).build())
-                            .build())
-                    .setId(upsertIds.get(i))
+                    .setId(upsertIds.get(i % upsertData.length))
                     .build());
         }
 
@@ -36,19 +41,38 @@ public class BuildUpsertRequest {
     }
 
     public static UpsertRequest buildOptionalUpsertRequest() {
-        String namespace = RandomStringBuilder.build("ns", 8);
-        List<String> hybridsIds = Arrays.asList("v4", "v5", "v6");
+        return buildOptionalUpsertRequest(new ArrayList<>(), "");
+    }
+
+    public static UpsertRequest buildOptionalUpsertRequest(String namespace) {
+        return buildOptionalUpsertRequest(new ArrayList<>(), namespace);
+    }
+
+    public static UpsertRequest buildOptionalUpsertRequest(List<String> upsertIds, String namespace) {
+        if (upsertIds.isEmpty()) upsertIds = Arrays.asList("v4", "v5", "v6");
+        if (namespace.isEmpty()) namespace = RandomStringBuilder.build("ns", 8);
+
         List<Vector> hybridVectors = new ArrayList<>();
         List<Integer> sparseIndices = Arrays.asList(0, 1, 2);
         List<Float> sparseValues = Arrays.asList(0.11f, 0.22f, 0.33f);
-        for (int i = 0; i < hybridsIds.size(); i++) {
+        String[] genreArrays = {"thriller", "drama", "fiction"};
+        String[] yearArrays = {"2018", "2019", "2020"};
+        for (int i = 0; i < upsertIds.size(); i++) {
             hybridVectors.add(
                     Vector.newBuilder()
                             .addAllValues(Floats.asList(upsertData[i]))
+                            .setMetadata(Struct.newBuilder()
+                                    .putFields("genre", Value.newBuilder().setStringValue(genreArrays[i % genreArrays.length]).build())
+                                    .putFields("year", Value.newBuilder().setStringValue(yearArrays[i % yearArrays.length]).build())
+                                    .build())
                             .setSparseValues(
-                                    SparseValues.newBuilder().addAllIndices(sparseIndices).addAllValues(sparseValues).build()
+                                    SparseValues
+                                            .newBuilder()
+                                            .addAllIndices(sparseIndices)
+                                            .addAllValues(sparseValues)
+                                            .build()
                             )
-                            .setId(hybridsIds.get(i))
+                            .setId(upsertIds.get(i))
                             .build());
         }
 

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDeleteTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDeleteTest.java
@@ -1,0 +1,240 @@
+package io.pinecone.integration.dataplane;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import io.pinecone.PineconeConnection;
+import io.pinecone.helpers.IndexManager;
+import io.pinecone.helpers.RandomStringBuilder;
+import io.pinecone.proto.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static io.pinecone.helpers.BuildUpsertRequest.buildOptionalUpsertRequest;
+import static io.pinecone.helpers.BuildUpsertRequest.buildRequiredUpsertRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UpsertAndDeleteTest {
+    private static VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
+    private static VectorServiceGrpc.VectorServiceFutureStub futureStub;
+    private static final int dimension = 3;
+
+    @BeforeAll
+    public static void setUp() throws IOException, InterruptedException {
+        PineconeConnection connection = new IndexManager().createIndexIfNotExists(dimension);
+        blockingStub = connection.getBlockingStub();
+        futureStub = connection.getFutureStub();
+    }
+
+    @Test
+    public void UpsertVectorsAndDeleteByIdSyncTest() throws InterruptedException {
+        // upsert vectors with required parameters
+        String namespace = RandomStringBuilder.build("ns", 8);
+        List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
+        UpsertResponse upsertResponse = blockingStub.upsert(buildRequiredUpsertRequest(upsertIds, namespace));
+
+        // Get vector count before deleting vectors
+        DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
+        DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        int startVectorCount = describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount();
+        assertEquals(startVectorCount, upsertResponse.getUpsertedCount());
+
+        // Delete 1 vector
+        String[] idsToDelete = new String[]{upsertIds.get(0)};
+        DeleteRequest deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .addAllIds(Arrays.asList(idsToDelete))
+                .setDeleteAll(false)
+                .build();
+        blockingStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        // verify updated vector count
+        assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), startVectorCount - idsToDelete.length);
+
+        // Delete multiple vectors
+        idsToDelete = new String[]{upsertIds.get(0), upsertIds.get(2)};
+        deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .addAllIds(Arrays.asList(idsToDelete))
+                .setDeleteAll(false)
+                .build();
+        blockingStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        // verify updated vector and namespace counts
+        assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), startVectorCount - idsToDelete.length);
+    }
+
+    @Test
+    public void UpsertVectorsAndDeleteByNamespaceSyncTest() throws InterruptedException {
+        // upsert vectors with optional parameters
+        String namespace = RandomStringBuilder.build("ns", 8);
+        UpsertResponse upsertResponse = blockingStub.upsert(buildOptionalUpsertRequest(namespace));
+
+        // Get vector count before deleting vectors
+        DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
+        DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        int startVectorCount = describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount();
+        assertEquals(startVectorCount, upsertResponse.getUpsertedCount());
+
+        // Delete all vectors in the namespace
+        DeleteRequest deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .setDeleteAll(true)
+                .build();
+        blockingStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        NamespaceSummary namespaceSummary = blockingStub.describeIndexStats(describeIndexRequest).getNamespacesMap().get(namespace);
+        // verify the namespace is deleted
+        assertThrows(NullPointerException.class, () -> namespaceSummary.getVectorCount());
+    }
+
+    @Test
+    public void UpsertVectorsAndDeleteByFilterSyncTest() throws InterruptedException {
+        // upsert vectors with optional and custom metadata parameters
+        String namespace = RandomStringBuilder.build("ns", 8);
+        UpsertResponse upsertResponse = blockingStub.upsert(buildOptionalUpsertRequest(namespace));
+
+        // Get vector count before deleting vectors
+        DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
+        DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        int startVectorCount = describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount();
+        assertEquals(upsertResponse.getUpsertedCount(), startVectorCount);
+
+        // Delete by filtering
+        DeleteRequest deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .setDeleteAll(false)
+                .setFilter(Struct.newBuilder()
+                        .putFields("genre", Value.newBuilder()
+                                .setStructValue(Struct.newBuilder()
+                                        .putFields("$eq", Value.newBuilder()
+                                                .setStringValue("drama")
+                                                .build()))
+                                .build())
+                        .build())
+                .build();
+        blockingStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        NamespaceSummary namespaceSummary = blockingStub.describeIndexStats(describeIndexRequest).getNamespacesMap().get(namespace);
+        // verify the namespace is deleted
+        assertEquals(namespaceSummary.getVectorCount(), upsertResponse.getUpsertedCount() - 1);
+    }
+
+    @Test
+    public void UpsertVectorsAndDeleteByIdFutureTest() throws ExecutionException, InterruptedException {
+        // upsert vectors with required parameters
+        String namespace = RandomStringBuilder.build("ns", 8);
+        List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
+        UpsertResponse upsertResponse = futureStub.upsert(buildRequiredUpsertRequest(upsertIds, namespace)).get();
+
+        // Get vector count before deleting vectors
+        DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
+        DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        int startVectorCount = describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount();
+        assertEquals(startVectorCount, upsertResponse.getUpsertedCount());
+
+        // Delete 1 vector
+        String[] idsToDelete = new String[]{upsertIds.get(0)};
+        DeleteRequest deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .addAllIds(Arrays.asList(idsToDelete))
+                .setDeleteAll(false)
+                .build();
+        blockingStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
+        assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), startVectorCount - idsToDelete.length);
+
+        // Delete multiple vectors
+        idsToDelete = new String[]{upsertIds.get(0), upsertIds.get(2)};
+        deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .addAllIds(Arrays.asList(idsToDelete))
+                .setDeleteAll(false)
+                .build();
+        blockingStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
+        // verify updated vector and namespace counts
+        assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), startVectorCount - idsToDelete.length);
+    }
+
+    @Test
+    public void UpsertVectorsAndDeleteByNamespaceFutureTest() throws ExecutionException, InterruptedException {
+        // upsert vectors with optional parameters
+        String namespace = RandomStringBuilder.build("ns", 8);
+        UpsertResponse upsertResponse = futureStub.upsert(buildOptionalUpsertRequest(namespace)).get();
+
+        // Get vector count before deleting vectors
+        DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
+        DescribeIndexStatsResponse describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
+        int startVectorCount = describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount();
+        assertEquals(startVectorCount, upsertResponse.getUpsertedCount());
+
+        // Delete all vectors in the namespace
+        DeleteRequest deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .setDeleteAll(true)
+                .build();
+        futureStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        NamespaceSummary namespaceSummary = futureStub.describeIndexStats(describeIndexRequest).get().getNamespacesMap().get(namespace);
+        // verify the namespace is deleted
+        assertThrows(NullPointerException.class, () -> namespaceSummary.getVectorCount());
+    }
+
+    @Test
+    public void UpsertVectorsAndDeleteByFilterFutureTest() throws InterruptedException, ExecutionException {
+        // upsert vectors with optional and custom metadata parameters
+        String namespace = RandomStringBuilder.build("ns", 8);
+        UpsertResponse upsertResponse = futureStub.upsert(buildOptionalUpsertRequest(namespace)).get();
+
+        // Get vector count before deleting vectors
+        DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
+        DescribeIndexStatsResponse describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
+        int startVectorCount = describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount();
+        assertEquals(upsertResponse.getUpsertedCount(), startVectorCount);
+
+        // Delete by filtering
+        DeleteRequest deleteRequest = DeleteRequest.newBuilder()
+                .setNamespace(namespace)
+                .setDeleteAll(false)
+                .setFilter(Struct.newBuilder()
+                        .putFields("genre", Value.newBuilder()
+                                .setStructValue(Struct.newBuilder()
+                                        .putFields("$eq", Value.newBuilder()
+                                                .setStringValue("drama")
+                                                .build()))
+                                .build())
+                        .build())
+                .build();
+        futureStub.delete(deleteRequest);
+        Thread.sleep(3500);
+
+        // call describeIndexStats to get updated counts
+        NamespaceSummary namespaceSummary = futureStub.describeIndexStats(describeIndexRequest).get().getNamespacesMap().get(namespace);
+        // verify the namespace is deleted
+        assertEquals(namespaceSummary.getVectorCount(), upsertResponse.getUpsertedCount() - 1);
+    }
+}

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
@@ -24,7 +24,7 @@ public class UpsertAndDescribeIndexStatsTest {
     }
 
     @Test
-    public void UpsertRequiredVectorsAndDescribeIndexStatsTestSync() {
+    public void UpsertRequiredVectorsAndDescribeIndexStatsSyncTest() {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
         DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
@@ -44,7 +44,7 @@ public class UpsertAndDescribeIndexStatsTest {
     }
 
     @Test
-    public void UpsertOptionalVectorsAndDescribeIndexStatsTestSync() {
+    public void UpsertOptionalVectorsAndDescribeIndexStatsSyncTest() {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
         DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
@@ -65,7 +65,7 @@ public class UpsertAndDescribeIndexStatsTest {
 
 
     @Test
-    public void UpsertRequiredVectorsAndDescribeIndexStatsTestFuture() throws ExecutionException, InterruptedException {
+    public void UpsertRequiredVectorsAndDescribeIndexStatsFutureTest() throws ExecutionException, InterruptedException {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
         DescribeIndexStatsResponse describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
@@ -85,7 +85,7 @@ public class UpsertAndDescribeIndexStatsTest {
     }
 
     @Test
-    public void UpsertOptionalVectorsAndDescribeIndexStatsTestFuture() throws ExecutionException, InterruptedException {
+    public void UpsertOptionalVectorsAndDescribeIndexStatsFutureTest() throws ExecutionException, InterruptedException {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
         DescribeIndexStatsResponse describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();


### PR DESCRIPTION
## Problem

The sdk currently lacks integration tests for deleting vectors.

## Solution

Vectors can be deleted in multiple ways, so added an integration tests that covers all of the different possibilities.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: Integration tests

## Test Plan

Ran integration tests
