### PR TITLE
Refactor configure index test

### DIFF
--- a/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
+++ b/src/integration/java/io/pinecone/PineconeIndexOperationsClientIntegrationTest.java
@@ -25,7 +25,7 @@ public class PineconeIndexOperationsClientIntegrationTest {
     }
 
     @Test
-    public void createAndDelete() throws IOException {
+    public void createAndDelete() throws IOException, InterruptedException {
         String indexName = RandomStringBuilder.build("index-name", 8);
 
         // Create an index
@@ -48,5 +48,6 @@ public class PineconeIndexOperationsClientIntegrationTest {
 
         // Cleanup
         pinecone.deleteIndex(indexName);
+        Thread.sleep(3500);
     }
 }

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -8,31 +8,15 @@ import java.io.IOException;
 import java.util.List;
 
 public class IndexManager {
-    public PineconeConnection createIndexIfNotExists(int dimension) throws IOException, InterruptedException {
-        boolean createNewIndex = false;
-        String indexName = "";
+    public PineconeConnection createIndexIfNotExistsDataPlane(int dimension) throws IOException, InterruptedException {
         PineconeClientConfig config = new PineconeClientConfig()
                 .withApiKey(System.getenv("PINECONE_API_KEY"))
                 .withEnvironment(System.getenv("PINECONE_ENVIRONMENT"));
         PineconeIndexOperationClient controlPlaneClient = new PineconeIndexOperationClient(config);
         List<String> indexList = controlPlaneClient.listIndexes();
 
-        if (!indexList.isEmpty()) {
-            indexName = indexList.get(0);
-            IndexMeta indexMeta = isIndexReady(indexName, controlPlaneClient);
-            if (indexMeta.getDatabase().getDimension() != dimension) {
-                createNewIndex = true;
-            }
-        }
-
-        if (createNewIndex) {
-            indexName = RandomStringBuilder.build("index-name", 8);
-            CreateIndexRequest createIndexRequest = new CreateIndexRequest()
-                    .withIndexName(indexName)
-                    .withDimension(dimension)
-                    .withMetric("euclidean");
-            controlPlaneClient.createIndex(createIndexRequest);
-        }
+        String indexName = checkIfIndexExists(indexList, dimension, controlPlaneClient);
+        if(indexName.isEmpty()) indexName = createNewIndex(dimension, controlPlaneClient);
 
         PineconeClient dataPlaneClient = new PineconeClient(config);
         IndexMeta indexMeta = controlPlaneClient.describeIndex(indexName);
@@ -43,6 +27,40 @@ public class IndexManager {
                         .withConnectionUrl("https://" + host));
     }
 
+    public String createIndexIfNotExistsControlPlane(PineconeClientConfig config, int dimension) throws IOException, InterruptedException {
+        PineconeIndexOperationClient controlPlaneClient = new PineconeIndexOperationClient(config);
+        List<String> indexList = controlPlaneClient.listIndexes();
+        String indexName = checkIfIndexExists(indexList, dimension, controlPlaneClient);
+
+        return (indexName.isEmpty()) ? createNewIndex(dimension, controlPlaneClient) : indexName;
+    }
+
+    private static String checkIfIndexExists(List<String> indexList, int dimension, PineconeIndexOperationClient controlPlaneClient)
+            throws IOException, InterruptedException {
+        int i = 0;
+        while (i < indexList.size()) {
+            IndexMeta indexMeta = isIndexReady(indexList.get(i), controlPlaneClient);
+            if (indexMeta.getDatabase().getDimension() == dimension
+                    && indexMeta.getDatabase().getPodType().equals("p1.x1")) {
+                return indexList.get(i);
+            }
+            i++;
+        }
+        return "";
+    }
+
+    private static String createNewIndex(int dimension, PineconeIndexOperationClient controlPlaneClient) throws IOException {
+        String indexName = RandomStringBuilder.build("index-name", 8);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .withIndexName(indexName)
+                .withDimension(dimension)
+                .withMetric("euclidean")
+                .withPodType("p1.x1");
+        controlPlaneClient.createIndex(createIndexRequest);
+
+        return indexName;
+    }
+
     public static IndexMeta isIndexReady(String indexName, PineconeIndexOperationClient indexOperationClient)
             throws IOException, InterruptedException {
         IndexMeta indexMeta;
@@ -51,9 +69,9 @@ public class IndexManager {
             if (indexMeta.getStatus().getState().equalsIgnoreCase("ready")) {
                 break;
             }
-
             Thread.sleep(1000);
         }
+
         return indexMeta;
     }
 }

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -8,14 +8,14 @@ import java.io.IOException;
 import java.util.List;
 
 public class IndexManager {
-    public PineconeConnection createIndexIfNotExistsDataPlane(int dimension) throws IOException, InterruptedException {
+    public static PineconeConnection createIndexIfNotExistsDataPlane(int dimension) throws IOException, InterruptedException {
         PineconeClientConfig config = new PineconeClientConfig()
                 .withApiKey(System.getenv("PINECONE_API_KEY"))
                 .withEnvironment(System.getenv("PINECONE_ENVIRONMENT"));
         PineconeIndexOperationClient controlPlaneClient = new PineconeIndexOperationClient(config);
         List<String> indexList = controlPlaneClient.listIndexes();
 
-        String indexName = checkIfIndexExists(indexList, dimension, controlPlaneClient);
+        String indexName = findIndexWithDimensionAndPodType(indexList, dimension, controlPlaneClient);
         if(indexName.isEmpty()) indexName = createNewIndex(dimension, controlPlaneClient);
 
         PineconeClient dataPlaneClient = new PineconeClient(config);
@@ -27,15 +27,15 @@ public class IndexManager {
                         .withConnectionUrl("https://" + host));
     }
 
-    public String createIndexIfNotExistsControlPlane(PineconeClientConfig config, int dimension) throws IOException, InterruptedException {
+    public static String createIndexIfNotExistsControlPlane(PineconeClientConfig config, int dimension) throws IOException, InterruptedException {
         PineconeIndexOperationClient controlPlaneClient = new PineconeIndexOperationClient(config);
         List<String> indexList = controlPlaneClient.listIndexes();
-        String indexName = checkIfIndexExists(indexList, dimension, controlPlaneClient);
+        String indexName = findIndexWithDimensionAndPodType(indexList, dimension, controlPlaneClient);
 
         return (indexName.isEmpty()) ? createNewIndex(dimension, controlPlaneClient) : indexName;
     }
 
-    private static String checkIfIndexExists(List<String> indexList, int dimension, PineconeIndexOperationClient controlPlaneClient)
+    private static String findIndexWithDimensionAndPodType(List<String> indexList, int dimension, PineconeIndexOperationClient controlPlaneClient)
             throws IOException, InterruptedException {
         int i = 0;
         while (i < indexList.size()) {

--- a/src/integration/java/io/pinecone/integration/controlPlane/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/ConfigureIndexTest.java
@@ -5,7 +5,6 @@ import io.pinecone.PineconeClientLiveIntegTest;
 import io.pinecone.PineconeIndexOperationClient;
 import io.pinecone.exceptions.PineconeBadRequestException;
 import io.pinecone.exceptions.PineconeNotFoundException;
-import io.pinecone.helpers.IndexManager;
 import io.pinecone.model.ConfigureIndexRequest;
 import io.pinecone.model.IndexMeta;
 import org.junit.jupiter.api.*;
@@ -14,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsControlPlane;
 import static io.pinecone.helpers.IndexManager.isIndexReady;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -32,7 +32,7 @@ public class ConfigureIndexTest {
 
     @BeforeEach
     public void setUp() throws IOException, InterruptedException {
-        indexName = new IndexManager().createIndexIfNotExistsControlPlane(config, 5);
+        indexName = createIndexIfNotExistsControlPlane(config, 5);
         indexOperationClient = new PineconeIndexOperationClient(config);
     }
 

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDeleteTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDeleteTest.java
@@ -3,7 +3,6 @@ package io.pinecone.integration.dataplane;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import io.pinecone.PineconeConnection;
-import io.pinecone.helpers.IndexManager;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.proto.*;
 import org.junit.jupiter.api.BeforeAll;
@@ -15,6 +14,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static io.pinecone.helpers.BuildUpsertRequest.*;
+import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,7 +25,7 @@ public class UpsertAndDeleteTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        PineconeConnection connection = new IndexManager().createIndexIfNotExistsDataPlane(dimension);
+        PineconeConnection connection = createIndexIfNotExistsDataPlane(dimension);
         blockingStub = connection.getBlockingStub();
         futureStub = connection.getFutureStub();
     }

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDeleteTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDeleteTest.java
@@ -25,7 +25,7 @@ public class UpsertAndDeleteTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        PineconeConnection connection = new IndexManager().createIndexIfNotExists(dimension);
+        PineconeConnection connection = new IndexManager().createIndexIfNotExistsDataPlane(dimension);
         blockingStub = connection.getBlockingStub();
         futureStub = connection.getFutureStub();
     }

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
@@ -18,7 +18,7 @@ public class UpsertAndDescribeIndexStatsTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        PineconeConnection connection = new IndexManager().createIndexIfNotExists(dimension);
+        PineconeConnection connection = new IndexManager().createIndexIfNotExistsDataPlane(dimension);
         blockingStub = connection.getBlockingStub();
         futureStub = connection.getFutureStub();
     }

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
@@ -1,11 +1,11 @@
 package io.pinecone.integration.dataplane;
 
 import io.pinecone.*;
-import io.pinecone.helpers.IndexManager;
 import io.pinecone.proto.*;
 import org.junit.jupiter.api.*;
 
 import static io.pinecone.helpers.BuildUpsertRequest.*;
+import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -18,7 +18,7 @@ public class UpsertAndDescribeIndexStatsTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        PineconeConnection connection = new IndexManager().createIndexIfNotExistsDataPlane(dimension);
+        PineconeConnection connection = createIndexIfNotExistsDataPlane(dimension);
         blockingStub = connection.getBlockingStub();
         futureStub = connection.getFutureStub();
     }


### PR DESCRIPTION
## Problem

After recent changes in integration test to use the existing index if it exists, the configure index test was required to be updated to consume less resources.

## Solution

1. Refactored checkIfIndexExists code: 
    a. To support both data and control plane integration tests
    b. Check if any index matches the criteria compared to old approach of checking the first index of the list and otherwise create a new index.
2. For configure test: 
    a. Updated the beforeAll logic to check if an index exist 
    b. Deleted the afterEach block to delete each index and save them for future test



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: (explain here)
Added Integration tests

## Test Plan

Ran integration tests locally.
