### PR TITLE
Fix path for gcp-starter env, add assert with retry mechanism, and add deprecation warning in vector_service.proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
+### v0.7.3
+- Add assert with retry mechanism
+- Add deprecation warning for queries parameter
+- Fix path for create and list indexes calls for gcp-stater
+
 ### v0.7.2
 - Fix extraction of SDK version
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Alternatively, you can use our standalone uberjar [pinecone-client-0.7.2-all.jar
 ## Examples
 
 - The data and control plane operation examples can be found in `io/pinecone/integration` folder.
+
+## Deprecation Warning
+`queries` parameter of `VectorRequest` has been deprecated. Please use `vector` parameter of `VectorRequest` and the associated methods.
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Maven:
 <dependency>
   <groupId>io.pinecone</groupId>
   <artifactId>pinecone-client</artifactId>
-  <version>0.7.2</version>
+  <version>0.7.3</version>
 </dependency>
 ```
 
@@ -23,12 +23,12 @@ Maven:
 
 Gradle:
 ```
-implementation "io.pinecone:pinecone-client:0.7.2"
+implementation "io.pinecone:pinecone-client:0.7.3"
 ```
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 
-Alternatively, you can use our standalone uberjar [pinecone-client-0.7.2-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/0.7.2/pinecone-client-0.7.2-all.jar), which bundles the pinecone client and all dependencies together inside a single jar. You can include this on your classpath like any 3rd party JAR without having to obtain the *pinecone-client* dependencies separately.
+Alternatively, you can use our standalone uberjar [pinecone-client-0.7.3-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/0.7.3/pinecone-client-0.7.3-all.jar), which bundles the pinecone client and all dependencies together inside a single jar. You can include this on your classpath like any 3rd party JAR without having to obtain the *pinecone-client* dependencies separately.
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 

--- a/examples/java-basic-mvn/src/main/java/pineconeexamples/MinimalUpsertAndQueryExample.java
+++ b/examples/java-basic-mvn/src/main/java/pineconeexamples/MinimalUpsertAndQueryExample.java
@@ -38,7 +38,6 @@ public class MinimalUpsertAndQueryExample {
 
         PineconeClient pineconeClient = new PineconeClient(configuration);
 
-
         PineconeConnectionConfig connectionConfig = new PineconeConnectionConfig()
                 .withIndexName(args.indexName);
 
@@ -53,7 +52,6 @@ public class MinimalUpsertAndQueryExample {
                     .addAllValues(Floats.asList(5F, 3F, 1F))
                     .build();
 
-            // Deprecated: use addValue() or addAllValues() instead of addVector() and addAllVectors() respectively
             UpsertRequest upsertRequest = UpsertRequest.newBuilder()
                     .addVectors(v1)
                     .addVectors(v2)
@@ -68,7 +66,6 @@ public class MinimalUpsertAndQueryExample {
             System.out.println("Got upsert response:");
             System.out.println(upsertResponse);
 
-
             QueryVector queryVector = QueryVector
                     .newBuilder()
                     .addAllValues(Floats.asList(1F, 2F, 2F))
@@ -78,7 +75,7 @@ public class MinimalUpsertAndQueryExample {
 
             QueryRequest queryRequest = QueryRequest
                     .newBuilder()
-                    .addQueries(queryVector)
+                    .addQueries(queryVector) // Deprecated: addQueries(), use addVector() or addAllVector() instead
                     .setTopK(args.topK)
                     .build();
 

--- a/examples/java-basic-mvn/src/main/java/pineconeexamples/MinimalUpsertAndQueryExample.java
+++ b/examples/java-basic-mvn/src/main/java/pineconeexamples/MinimalUpsertAndQueryExample.java
@@ -73,9 +73,10 @@ public class MinimalUpsertAndQueryExample {
                     .setNamespace(args.namespace)
                     .build();
 
+            // Deprecated: queries param on QueryRequest is deprecated, use vector parameter and the associated methods
             QueryRequest queryRequest = QueryRequest
                     .newBuilder()
-                    .addQueries(queryVector) // Deprecated: addQueries(), use addVector() or addAllVector() instead
+                    .addQueries(queryVector) // use addVector() or addAllVector() as shown in PineconeLiveIntegrationTest.java
                     .setTopK(args.topK)
                     .build();
 

--- a/examples/java-basic-mvn/src/main/java/pineconeexamples/UpsertsAndQueriesConcurrentExample.java
+++ b/examples/java-basic-mvn/src/main/java/pineconeexamples/UpsertsAndQueriesConcurrentExample.java
@@ -106,8 +106,6 @@ public class UpsertsAndQueriesConcurrentExample {
                         }
 
                         try {
-                            // Deprecated: use addValue() or addAllValues() instead of addVector()
-                            // and addAllVectors() respectively
                             UpsertRequest upsertRequest = UpsertRequest.newBuilder()
                                     .addAllVectors(vectors)
                                     .build();
@@ -197,6 +195,8 @@ public class UpsertsAndQueriesConcurrentExample {
                                         .setTopK(args.topK)
                                         .build());
                             }
+
+                            // addAllQueries() is deprecated. Use addAllVector() instead
                             QueryRequest queryRequest = QueryRequest.newBuilder().addAllQueries(queryVectors)
                                     .setTopK(args.topK)
                                     .build();

--- a/examples/java-basic-mvn/src/main/java/pineconeexamples/UpsertsAndQueriesConcurrentExample.java
+++ b/examples/java-basic-mvn/src/main/java/pineconeexamples/UpsertsAndQueriesConcurrentExample.java
@@ -196,8 +196,10 @@ public class UpsertsAndQueriesConcurrentExample {
                                         .build());
                             }
 
-                            // addAllQueries() is deprecated. Use addAllVector() instead
-                            QueryRequest queryRequest = QueryRequest.newBuilder().addAllQueries(queryVectors)
+                            // Deprecated: queries param on QueryRequest is deprecated, use vector parameter and the associated methods
+                            QueryRequest queryRequest = QueryRequest
+                                    .newBuilder()
+                                    .addAllQueries(queryVectors) // use addVector() or addAllVector() as shown in PineconeLiveIntegrationTest.java
                                     .setTopK(args.topK)
                                     .build();
                             QueryResponse response = conn.getBlockingStub().query(queryRequest);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pineconeClientVersion = 0.7.2
+pineconeClientVersion = 0.7.3

--- a/src/integration/java/io/pinecone/helpers/RetryAssert.java
+++ b/src/integration/java/io/pinecone/helpers/RetryAssert.java
@@ -1,0 +1,27 @@
+package io.pinecone.helpers;
+
+public class RetryAssert {
+    private static final int maxRetry = 4;
+    private static int delay = 1500;
+
+    public static void assertWithRetry(AssertionRunnable assertionRunnable) throws InterruptedException {
+        int retryCount = 0;
+        boolean success = false;
+
+        while (retryCount < maxRetry && !success) {
+            try {
+                assertionRunnable.run();
+                success = true;
+            } catch (AssertionError e) {
+                retryCount++;
+                delay*=2;
+                Thread.sleep(delay);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface AssertionRunnable {
+        void run() throws AssertionError;
+    }
+}

--- a/src/integration/java/io/pinecone/helpers/RetryAssert.java
+++ b/src/integration/java/io/pinecone/helpers/RetryAssert.java
@@ -1,5 +1,7 @@
 package io.pinecone.helpers;
 
+import java.util.concurrent.ExecutionException;
+
 public class RetryAssert {
     private static final int maxRetry = 4;
     private static int delay = 1500;
@@ -12,7 +14,7 @@ public class RetryAssert {
             try {
                 assertionRunnable.run();
                 success = true;
-            } catch (AssertionError e) {
+            } catch (AssertionError | ExecutionException e) {
                 retryCount++;
                 delay*=2;
                 Thread.sleep(delay);
@@ -22,6 +24,6 @@ public class RetryAssert {
 
     @FunctionalInterface
     public interface AssertionRunnable {
-        void run() throws AssertionError;
+        void run() throws AssertionError, ExecutionException, InterruptedException;
     }
 }

--- a/src/integration/java/io/pinecone/integration/controlPlane/CreateListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/CreateListAndDeleteIndexTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 
+import static io.pinecone.helpers.IndexManager.isIndexReady;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -36,6 +37,8 @@ public class CreateListAndDeleteIndexTest {
                 .withDimension(10)
                 .withMetric("euclidean");
         pinecone.createIndex(request);
+
+        isIndexReady(indexName, pinecone);
 
         // Get the index description
         IndexMeta indexMeta = pinecone.describeIndex(indexName);

--- a/src/integration/java/io/pinecone/integration/dataplane/PineconeClientLiveIntegTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/PineconeClientLiveIntegTest.java
@@ -103,9 +103,9 @@ public class PineconeClientLiveIntegTest {
                 .build();
         blockingStub.update(updateRequest);
 
-        // DEPRECATED: all methods related to queries parameter in QueryRequest.
-        // Use vector parameter and all of the methods of vector parameter instead.
-        // Below commented example shows usage of addQueries() which is deprecated.
+        // DEPRECATED: queries parameter of QueryRequest has been deprecated
+        // Use vector parameter and the associated methods.
+        // Below commented example shows addQueries() which is deprecated
 /*
         float[] rawVector = {1.0F, 2.0F, 3.0F};
         QueryVector queryVector = QueryVector.newBuilder()
@@ -122,15 +122,14 @@ public class PineconeClientLiveIntegTest {
                 .build();
 
         QueryRequest batchQueryRequest = QueryRequest.newBuilder()
-                .addQueries(queryVector)
+                .addQueries(queryVector)            // Deprecated
                 .setNamespace(namespace)
                 .setTopK(2)
                 .setIncludeMetadata(true)
                 .build();
 */
 
-        // Below example shows how to query() using addAllVector() which is associated with vector parameter
-        // of QueryRequest in the vector_service.proto file.
+        // Below example shows usage of addAllVector() which is associated with vector parameter of QueryRequest.
         Iterable<Float> iterableVector = Arrays.asList(1.0F, 2.0F, 3.0F);
         QueryRequest queryRequest = QueryRequest.newBuilder()
                 .addAllVector(iterableVector)

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.*;
 
 import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
+import static io.pinecone.helpers.RetryAssert.assertWithRetry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -24,43 +25,48 @@ public class UpsertAndDescribeIndexStatsTest {
     }
 
     @Test
-    public void UpsertRequiredVectorsAndDescribeIndexStatsSyncTest() {
+    public void UpsertRequiredVectorsAndDescribeIndexStatsSyncTest() throws InterruptedException {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
-        DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
-        assertEquals(describeIndexStatsResponse.getDimension(), dimension);
-        int startVectorCount = describeIndexStatsResponse.getTotalVectorCount();
-        int startNamespaceCount = describeIndexStatsResponse.getNamespacesCount();
+        DescribeIndexStatsResponse describeIndexStatsResponse1 = blockingStub.describeIndexStats(describeIndexRequest);
+        assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
+        int startVectorCount = describeIndexStatsResponse1.getTotalVectorCount();
+        int startNamespaceCount = describeIndexStatsResponse1.getNamespacesCount();
 
         // upsert vectors with required parameters
         UpsertResponse upsertResponse = blockingStub.upsert(buildRequiredUpsertRequest());
 
-        // call describeIndexStats to get updated counts
-        describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        assertWithRetry(() -> {
+            // call describeIndexStats to get updated counts
+            DescribeIndexStatsResponse describeIndexStatsResponse2 = blockingStub.describeIndexStats(describeIndexRequest);
 
-        // verify updated vector and namespace counts
-        assertEquals(describeIndexStatsResponse.getNamespacesCount(), startNamespaceCount + 1);
-        assertEquals(describeIndexStatsResponse.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
+            // verify updated vector and namespace counts
+            assertEquals(describeIndexStatsResponse2.getNamespacesCount(), startNamespaceCount + 1);
+            assertEquals(describeIndexStatsResponse2.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
+        });
+
     }
 
     @Test
-    public void UpsertOptionalVectorsAndDescribeIndexStatsSyncTest() {
+    public void UpsertOptionalVectorsAndDescribeIndexStatsSyncTest() throws InterruptedException {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
-        DescribeIndexStatsResponse describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
-        assertEquals(describeIndexStatsResponse.getDimension(), dimension);
-        int startVectorCount = describeIndexStatsResponse.getTotalVectorCount();
-        int startNamespaceCount = describeIndexStatsResponse.getNamespacesCount();
+        DescribeIndexStatsResponse describeIndexStatsResponse1 = blockingStub.describeIndexStats(describeIndexRequest);
+        assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
+        int startVectorCount = describeIndexStatsResponse1.getTotalVectorCount();
+        int startNamespaceCount = describeIndexStatsResponse1.getNamespacesCount();
 
         // upsert vectors with required parameters
         UpsertResponse upsertResponse = blockingStub.upsert(buildOptionalUpsertRequest());
 
-        // call describeIndexStats to get updated counts
-        describeIndexStatsResponse = blockingStub.describeIndexStats(describeIndexRequest);
+        assertWithRetry(() -> {
+            // call describeIndexStats to get updated counts
+            DescribeIndexStatsResponse describeIndexStatsResponse2 = blockingStub.describeIndexStats(describeIndexRequest);
 
-        // verify updated vector and namespace counts
-        assertEquals(describeIndexStatsResponse.getNamespacesCount(), startNamespaceCount + 1);
-        assertEquals(describeIndexStatsResponse.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
+            // verify updated vector and namespace counts
+            assertEquals(describeIndexStatsResponse2.getNamespacesCount(), startNamespaceCount + 1);
+            assertEquals(describeIndexStatsResponse2.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
+        });
     }
 
 
@@ -68,39 +74,43 @@ public class UpsertAndDescribeIndexStatsTest {
     public void UpsertRequiredVectorsAndDescribeIndexStatsFutureTest() throws ExecutionException, InterruptedException {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
-        DescribeIndexStatsResponse describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
-        assertEquals(describeIndexStatsResponse.getDimension(), dimension);
-        int startVectorCount = describeIndexStatsResponse.getTotalVectorCount();
-        int startNamespaceCount = describeIndexStatsResponse.getNamespacesCount();
+        DescribeIndexStatsResponse describeIndexStatsResponse1 = futureStub.describeIndexStats(describeIndexRequest).get();
+        assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
+        int startVectorCount = describeIndexStatsResponse1.getTotalVectorCount();
+        int startNamespaceCount = describeIndexStatsResponse1.getNamespacesCount();
 
         // upsert optional vectors
         UpsertResponse upsertResponse = futureStub.upsert(buildRequiredUpsertRequest()).get();
 
-        // call describeIndexStats to get updated counts
-        describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
+        assertWithRetry(() -> {
+            // call describeIndexStats to get updated counts
+            DescribeIndexStatsResponse describeIndexStatsResponse2 = futureStub.describeIndexStats(describeIndexRequest).get();
 
-        // verify updated vector and namespace counts
-        assertEquals(describeIndexStatsResponse.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
-        assertEquals(describeIndexStatsResponse.getNamespacesCount(), startNamespaceCount + 1);
+            // verify updated vector and namespace counts
+            assertEquals(describeIndexStatsResponse2.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
+            assertEquals(describeIndexStatsResponse2.getNamespacesCount(), startNamespaceCount + 1);
+        });
     }
 
     @Test
     public void UpsertOptionalVectorsAndDescribeIndexStatsFutureTest() throws ExecutionException, InterruptedException {
         // Get vector and namespace counts before upserting vectors with required parameters
         DescribeIndexStatsRequest describeIndexRequest = DescribeIndexStatsRequest.newBuilder().build();
-        DescribeIndexStatsResponse describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
-        assertEquals(describeIndexStatsResponse.getDimension(), dimension);
-        int startVectorCount = describeIndexStatsResponse.getTotalVectorCount();
-        int startNamespaceCount = describeIndexStatsResponse.getNamespacesCount();
+        DescribeIndexStatsResponse describeIndexStatsResponse1 = futureStub.describeIndexStats(describeIndexRequest).get();
+        assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
+        int startVectorCount = describeIndexStatsResponse1.getTotalVectorCount();
+        int startNamespaceCount = describeIndexStatsResponse1.getNamespacesCount();
 
         // upsert optional vectors
         UpsertResponse upsertResponse = futureStub.upsert(buildOptionalUpsertRequest()).get();
 
-        // call describeIndexStats to get updated counts
-        describeIndexStatsResponse = futureStub.describeIndexStats(describeIndexRequest).get();
+        assertWithRetry(() -> {
+            // call describeIndexStats to get updated counts
+            DescribeIndexStatsResponse describeIndexStatsResponse2 = futureStub.describeIndexStats(describeIndexRequest).get();
 
-        // verify updated vector and namespace counts
-        assertEquals(describeIndexStatsResponse.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
-        assertEquals(describeIndexStatsResponse.getNamespacesCount(), startNamespaceCount + 1);
+            // verify updated vector and namespace counts
+            assertEquals(describeIndexStatsResponse2.getTotalVectorCount(), startVectorCount + upsertResponse.getUpsertedCount());
+            assertEquals(describeIndexStatsResponse2.getNamespacesCount(), startNamespaceCount + 1);
+        });
     }
 }

--- a/src/main/java/io/pinecone/PineconeClientConfig.java
+++ b/src/main/java/io/pinecone/PineconeClientConfig.java
@@ -139,7 +139,7 @@ public class PineconeClientConfig {
     }
 
     public String getUserAgent() {
-        String userAgentLanguage = "lang=java; pineconeClientVersion = v0.7.2";
+        String userAgentLanguage = "lang=java; pineconeClientVersion = v0.7.3";
         return (this.getUsageContext() != null) ?
                 userAgentLanguage + "; usageContext=" + this.getUsageContext() : userAgentLanguage;
     }

--- a/src/main/java/io/pinecone/PineconeIndexOperationClient.java
+++ b/src/main/java/io/pinecone/PineconeIndexOperationClient.java
@@ -20,7 +20,7 @@ public class PineconeIndexOperationClient {
     public static final String ACCEPT_HEADER = "accept";
     public static final String API_KEY_HEADER_NAME = "Api-Key";
     public static final String BASE_URL_PREFIX = "https://controller.";
-    public static final String BASE_URL_SUFFIX = ".pinecone.io/databases/";
+    public static final String BASE_URL_SUFFIX = ".pinecone.io/databases";
     public static final String CONTENT_TYPE = "content-type";
     public static final String CONTENT_TYPE_JSON = "application/json";
     public static final String CONTENT_TYPE_CHARSET_UTF8 = "charset=utf-8";
@@ -102,8 +102,9 @@ public class PineconeIndexOperationClient {
     }
 
     private Request buildRequest(String method, String path, String acceptHeader, RequestBody requestBody) {
+        String completeUrl = (path.equals(EMPTY_RESOURCE_PATH)) ? url : url + "/" + path;
         Request.Builder builder = new Request.Builder()
-                .url(url + path)
+                .url(completeUrl)
                 .addHeader(ACCEPT_HEADER, acceptHeader)
                 .addHeader(API_KEY_HEADER_NAME, clientConfig.getApiKey())
                 .addHeader(USER_AGENT_HEADER, clientConfig.getUserAgent());

--- a/src/main/proto/vector_service.proto
+++ b/src/main/proto/vector_service.proto
@@ -137,7 +137,9 @@ message QueryRequest {
   bool                   include_metadata = 5;
 
   // The query vectors.
-  repeated QueryVector   queries = 6;
+  repeated QueryVector   queries = 6 [
+  deprecated = true
+  ];
 
   // The query vector. This should be the same length as the dimension of the index being queried.
   repeated float         vector = 7;


### PR DESCRIPTION
## Problem

When running tests with gcp-starter env. in java sdk, there were a couple of issues that needed to be addressed. In particular:
1. Create and listIndexes wasn't working.
2. Queries parameter was deprecated but the proto file wasn't updated with a warning.
3. After upserting vectors into an index of gcp-starter env., there was some latency in querying the vectors which caused tests to fail.

## Solution
This PR addresses the following:
1. Fixed path for gcp-starter env to address the createIndex and listIndexes issue in gcp-starter env. 
2. Add deprecation tag for queries parameter of VectorRequest in vector_service.proto file.
3. Added assert with retry mechanism function to make sure the tests are passing even though they fail for first couple of times. Given gcp-starter is a free-tier and not as performant as pod indexes, the retry mechanism will help ensure passing of the tests. 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran integration tests suite.
