### PR TITLE
Add source_collection to indexMetaDatabase object and ignore newly added fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
+### v0.7.4
+- Add support to add new fields to response body for describeIndex's indexMetaDatabase object
+
 ### v0.7.3
 - Add assert with retry mechanism
 - Add deprecation warning for queries parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
 ### v0.7.4
-- Added source_collection and support to ignore newly added fields to the response body for describeIndex's indexMetaDatabase object
+- Add source_collection and support to ignore newly added fields to the response body for describeIndex's indexMetaDatabase object
 
 ### v0.7.3
 - Add assert with retry mechanism

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
 ### v0.7.4
-- Add support to add new fields to response body for describeIndex's indexMetaDatabase object
+- Added source_collection and support to ignore newly added fields to the response body for describeIndex's indexMetaDatabase object
 
 ### v0.7.3
 - Add assert with retry mechanism

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Maven:
 <dependency>
   <groupId>io.pinecone</groupId>
   <artifactId>pinecone-client</artifactId>
-  <version>0.7.3</version>
+  <version>0.7.4</version>
 </dependency>
 ```
 
@@ -23,12 +23,12 @@ Maven:
 
 Gradle:
 ```
-implementation "io.pinecone:pinecone-client:0.7.3"
+implementation "io.pinecone:pinecone-client:0.7.4"
 ```
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 
-Alternatively, you can use our standalone uberjar [pinecone-client-0.7.3-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/0.7.3/pinecone-client-0.7.3-all.jar), which bundles the pinecone client and all dependencies together inside a single jar. You can include this on your classpath like any 3rd party JAR without having to obtain the *pinecone-client* dependencies separately.
+Alternatively, you can use our standalone uberjar [pinecone-client-0.7.4-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/0.7.4/pinecone-client-0.7.4-all.jar), which bundles the pinecone client and all dependencies together inside a single jar. You can include this on your classpath like any 3rd party JAR without having to obtain the *pinecone-client* dependencies separately.
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pineconeClientVersion = 0.7.3
+pineconeClientVersion = 0.7.4

--- a/src/integration/java/io/pinecone/helpers/AssertRetry.java
+++ b/src/integration/java/io/pinecone/helpers/AssertRetry.java
@@ -1,8 +1,9 @@
 package io.pinecone.helpers;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-public class RetryAssert {
+public class AssertRetry {
     private static final int maxRetry = 4;
     private static int delay = 1500;
 
@@ -14,7 +15,7 @@ public class RetryAssert {
             try {
                 assertionRunnable.run();
                 success = true;
-            } catch (AssertionError | ExecutionException e) {
+            } catch (AssertionError | ExecutionException | IOException e) {
                 retryCount++;
                 delay*=2;
                 Thread.sleep(delay);
@@ -24,6 +25,6 @@ public class RetryAssert {
 
     @FunctionalInterface
     public interface AssertionRunnable {
-        void run() throws AssertionError, ExecutionException, InterruptedException;
+        void run() throws AssertionError, ExecutionException, InterruptedException, IOException;
     }
 }

--- a/src/integration/java/io/pinecone/integration/controlPlane/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/ConfigureIndexTest.java
@@ -58,7 +58,6 @@ public class ConfigureIndexTest {
             isIndexReady(indexName, indexOperationClient);
             indexOperationClient.configureIndex(indexName, configureIndexRequest);
         } catch (PineconeBadRequestException badRequestException) {
-            System.out.println(badRequestException);
             assert (badRequestException.getLocalizedMessage().contains("Capacity Reached. Increase your quota or upgrade to create more indexes."));
         } catch (Exception exception) {
             logger.error(exception.toString());
@@ -164,9 +163,8 @@ public class ConfigureIndexTest {
             indexOperationClient.configureIndex(indexName, configureIndexRequest);
             Thread.sleep(3500);
         } catch (Exception exception) {
-            System.out.println(exception);
             assertEquals(exception.getClass(), PineconeBadRequestException.class);
-            assertEquals(exception.getMessage(), "Bad request: Cannot scale down an index, only up. Current size is: 1");
+            assert(exception.getMessage().contains("Bad request: Cannot scale down an index, only up."));
         } finally {
             // Delete this index since it'll be unused for other tests
             indexOperationClient.deleteIndex(indexName);

--- a/src/integration/java/io/pinecone/integration/controlPlane/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/ConfigureIndexTest.java
@@ -43,8 +43,8 @@ public class ConfigureIndexTest {
         try {
             isIndexReady(indexName, indexOperationClient);
             indexOperationClient.configureIndex("non-existent-index", configureIndexRequest);
-        } catch (PineconeNotFoundException exception) {
-            assert (exception.getLocalizedMessage().contains("404: Not Found"));
+        } catch (PineconeNotFoundException notFoundException) {
+            assert (notFoundException.getLocalizedMessage().toLowerCase().contains("not found"));
         } catch (IOException | InterruptedException exception) {
             logger.error(exception.toString());
         }
@@ -57,10 +57,9 @@ public class ConfigureIndexTest {
         try {
             isIndexReady(indexName, indexOperationClient);
             indexOperationClient.configureIndex(indexName, configureIndexRequest);
-        } catch (PineconeBadRequestException exception) {
-            assert (exception.getLocalizedMessage().contains("The index exceeds the project quota"));
-            assert (exception.getLocalizedMessage().contains("Upgrade your account or change" +
-                    " the project settings to increase the quota."));
+        } catch (PineconeBadRequestException badRequestException) {
+            System.out.println(badRequestException);
+            assert (badRequestException.getLocalizedMessage().contains("Capacity Reached. Increase your quota or upgrade to create more indexes."));
         } catch (Exception exception) {
             logger.error(exception.toString());
         }
@@ -110,8 +109,8 @@ public class ConfigureIndexTest {
 
             isIndexReady(indexName, indexOperationClient);
             indexOperationClient.configureIndex(indexName, configureIndexRequest);
-        } catch (PineconeBadRequestException pineconeBadRequestException) {
-            assertEquals(pineconeBadRequestException.getMessage(), "updating base pod type is not supported");
+        } catch (PineconeBadRequestException badRequestException) {
+            assertEquals(badRequestException.getMessage(), "Bad request: Cannot change pod type.");
         } catch (Exception exception) {
             logger.error(exception.getLocalizedMessage());
         }
@@ -165,8 +164,9 @@ public class ConfigureIndexTest {
             indexOperationClient.configureIndex(indexName, configureIndexRequest);
             Thread.sleep(3500);
         } catch (Exception exception) {
+            System.out.println(exception);
             assertEquals(exception.getClass(), PineconeBadRequestException.class);
-            assertEquals(exception.getMessage(), "scaling down pod type is not supported");
+            assertEquals(exception.getMessage(), "Bad request: Cannot scale down an index, only up. Current size is: 1");
         } finally {
             // Delete this index since it'll be unused for other tests
             indexOperationClient.deleteIndex(indexName);

--- a/src/integration/java/io/pinecone/integration/dataplane/PineconeClientLiveIntegTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/PineconeClientLiveIntegTest.java
@@ -19,9 +19,6 @@ import java.util.List;
 
 import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
 import static io.pinecone.helpers.RetryAssert.assertWithRetry;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 
 public class PineconeClientLiveIntegTest {
 
@@ -155,8 +152,7 @@ public class PineconeClientLiveIntegTest {
 
         assertWithRetry(() -> {
             QueryResponse queryResponse = blockingStub.query(queryByIdRequest);
-            assertThat(queryResponse, notNullValue());
-            assertThat(queryResponse.getMatchesCount(), equalTo(1));
+            Assertions.assertEquals(queryResponse.getMatchesCount(),1);
             assert (queryResponse.getMatches(0).getValuesList().containsAll(updateValueList));
         });
 

--- a/src/integration/java/io/pinecone/integration/dataplane/PineconeClientLiveIntegTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/PineconeClientLiveIntegTest.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
-import static io.pinecone.helpers.RetryAssert.assertWithRetry;
+import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 
 public class PineconeClientLiveIntegTest {
 

--- a/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataplane/UpsertAndDescribeIndexStatsTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.*;
 
 import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
-import static io.pinecone.helpers.RetryAssert.assertWithRetry;
+import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;

--- a/src/main/java/io/pinecone/PineconeClientConfig.java
+++ b/src/main/java/io/pinecone/PineconeClientConfig.java
@@ -139,7 +139,7 @@ public class PineconeClientConfig {
     }
 
     public String getUserAgent() {
-        String userAgentLanguage = "lang=java; pineconeClientVersion = v0.7.3";
+        String userAgentLanguage = "lang=java; pineconeClientVersion = v0.7.4";
         return (this.getUsageContext() != null) ?
                 userAgentLanguage + "; usageContext=" + this.getUsageContext() : userAgentLanguage;
     }

--- a/src/main/java/io/pinecone/model/CreateIndexRequest.java
+++ b/src/main/java/io/pinecone/model/CreateIndexRequest.java
@@ -12,7 +12,7 @@ public class CreateIndexRequest {
 
     private String metric = "cosine";
 
-    private Integer pods = 1;
+    private Integer pods;
 
     private Integer replicas = 1;
 

--- a/src/main/java/io/pinecone/model/IndexMetaDatabase.java
+++ b/src/main/java/io/pinecone/model/IndexMetaDatabase.java
@@ -1,7 +1,9 @@
 package io.pinecone.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IndexMetaDatabase {
     private String name;
 
@@ -17,6 +19,9 @@ public class IndexMetaDatabase {
 
     @JsonProperty("pod_type")
     private String podType;
+
+    @JsonProperty("source_collection")
+    private String sourceCollection;
 
     private IndexMetadataConfig metadataConfig;
 
@@ -87,6 +92,15 @@ public class IndexMetaDatabase {
         return this;
     }
 
+    public String getSourceCollection() {
+        return sourceCollection;
+    }
+
+    public IndexMetaDatabase withSourceCollection(String sourceCollection) {
+        this.sourceCollection = sourceCollection;
+        return this;
+    }
+
     public IndexMetadataConfig getMetadataConfig() {
         return metadataConfig;
     }
@@ -107,6 +121,7 @@ public class IndexMetaDatabase {
                 ", shards=" + shards +
                 ", podType='" + podType + '\'' +
                 ", metadataConfig=" + metadataConfig +
+                ", sourceCollection=" + sourceCollection +
                 '}';
     }
 }

--- a/src/test/resources/indexJsonString.json
+++ b/src/test/resources/indexJsonString.json
@@ -1,0 +1,1 @@
+{"database":{"name":"testIndex","metric":"cosine","dimension":3,"replicas":1,"shards":1,"pods":1,"pod_type":"p1.x1", "source_collection":"randomCollection"},"status":{"waiting":[],"crashed":[],"host":"url","port":433,"state":"Ready","ready":true}}

--- a/src/test/resources/indexJsonStringWithExtraFields.json
+++ b/src/test/resources/indexJsonStringWithExtraFields.json
@@ -1,0 +1,1 @@
+{"database":{"name":"testIndex","metric":"cosine","dimension":3,"replicas":1,"shards":1,"pods":1,"pod_type":"p1.x1","extra_field":"random1"},"status":{"waiting":[],"crashed":[],"host":"url","port":433,"state":"Ready","ready":true, "extra_field":"random2"}}


### PR DESCRIPTION
## Problem

`source_collection` is a newly added field in `indexMetaDatabase` object of describeIndex response body. But without adding it to the response body of describe index call, it breaks. 

## Solution

Added the field as well as added support to ignore newly added fields.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Ran integration tests and added unit test for the same
