### PR TITLE
Update changelogs, sdk version, and user-agent for v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
+### v0.8.0
+- Add support for control plane operations for serverless indexes
+- Add support for collections for pod indexes
+
 ### v0.7.4
 - Add source_collection and support to ignore newly added fields to the response body for describeIndex's indexMetaDatabase object
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Maven:
 <dependency>
   <groupId>io.pinecone</groupId>
   <artifactId>pinecone-client</artifactId>
-  <version>0.7.4</version>
+  <version>0.8.0</version>
 </dependency>
 ```
 
@@ -23,12 +23,12 @@ Maven:
 
 Gradle:
 ```
-implementation "io.pinecone:pinecone-client:0.7.4"
+implementation "io.pinecone:pinecone-client:0.8.0"
 ```
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 
-Alternatively, you can use our standalone uberjar [pinecone-client-0.7.4-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/0.7.4/pinecone-client-0.7.4-all.jar), which bundles the pinecone client and all dependencies together inside a single jar. You can include this on your classpath like any 3rd party JAR without having to obtain the *pinecone-client* dependencies separately.
+Alternatively, you can use our standalone uberjar [pinecone-client-0.8.0-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/0.8.0/pinecone-client-0.8.0-all.jar), which bundles the pinecone client and all dependencies together inside a single jar. You can include this on your classpath like any 3rd party JAR without having to obtain the *pinecone-client* dependencies separately.
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pineconeClientVersion = 0.7.4
+pineconeClientVersion = 0.8.0

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -3,7 +3,6 @@ package io.pinecone.integration.controlPlane.pod;
 import io.pinecone.PineconeControlPlaneClient;
 import io.pinecone.exceptions.PineconeException;
 import io.pinecone.exceptions.PineconeForbiddenException;
-import io.pinecone.integration.dataplane.PineconeClientLiveIntegTest;
 import io.pinecone.exceptions.PineconeBadRequestException;
 import io.pinecone.exceptions.PineconeNotFoundException;
 import org.junit.jupiter.api.*;
@@ -111,7 +110,7 @@ public class ConfigureIndexTest {
         } catch (PineconeBadRequestException badRequestException) {
             assert(badRequestException.getMessage().contains("Bad request: Cannot change pod type."));
         } catch (Exception exception) {
-            logger.error(exception.getLocalizedMessage());
+            throw new PineconeException("Test failed: " + exception.getLocalizedMessage());
         }
     }
 
@@ -135,22 +134,8 @@ public class ConfigureIndexTest {
                 assert (podSpec != null);
                 assertEquals(podSpec.getPodType(), "p1.x2");
             });
-
-            // Attempt to scale down
-            pod = new ConfigureIndexRequestSpecPod().podType("p1.x1");
-            spec = new ConfigureIndexRequestSpec().pod(pod);
-            configureIndexRequest = new ConfigureIndexRequest().spec(spec);
-            controlPlaneClient.configureIndex(indexName, configureIndexRequest);
-
-            // Get the index description to verify the new pod type
-            assertWithRetry(() -> {
-                PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
-                assert (podSpec != null);
-                assertEquals(podSpec.getPodType(), "p1.x1");
-            });
-
         } catch (Exception exception) {
-            logger.error(exception.getLocalizedMessage());
+            throw new PineconeException("Test failed: " + exception.getLocalizedMessage());
         } finally {
             // Delete this index since it'll be unused for future tests
             controlPlaneClient.deleteIndex(indexName);

--- a/src/main/java/io/pinecone/PineconeClientConfig.java
+++ b/src/main/java/io/pinecone/PineconeClientConfig.java
@@ -135,7 +135,7 @@ public class PineconeClientConfig {
     }
 
     public String getUserAgent() {
-        String userAgentLanguage = "lang=java; pineconeClientVersion = v0.7.4";
+        String userAgentLanguage = "lang=java; pineconeClientVersion = v0.8.0";
         return (this.getUsageContext() != null) ?
                 userAgentLanguage + "; usageContext=" + this.getUsageContext() : userAgentLanguage;
     }


### PR DESCRIPTION
## Problem

Release control plane operations for java sdk and cleanup configure index test

## Solution

Update changelogs, sdk version, and user-agent for v0.8.0 release
Configure index test had an incorrect condition and the catch() wasn't throwing the exception.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: (explain here)

## Test Plan

Ran integration tests and published the jar locally to test all operations in a maven project
