### PR TITLE
Add PineconeDataPlaneClient Interface

### DIFF
--- a/src/main/java/io/pinecone/clients/PineconeBlockingDataPlaneClient.java
+++ b/src/main/java/io/pinecone/clients/PineconeBlockingDataPlaneClient.java
@@ -1,15 +1,15 @@
 package io.pinecone.clients;
 
 import com.google.protobuf.Struct;
+import io.pinecone.commons.PineconeDataPlaneInterface;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 
 import java.util.List;
 
-import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
-
-public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<UpsertResponse, QueryResponseWithUnsignedIndices, FetchResponse, UpdateResponse, DeleteResponse, DescribeIndexStatsResponse> {
+public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneInterface<UpsertResponse,
+        QueryResponseWithUnsignedIndices, FetchResponse, UpdateResponse, DeleteResponse, DescribeIndexStatsResponse> {
 
     private final VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
 
@@ -26,12 +26,14 @@ public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<
                                  List<Float> values) {
         return upsert(id, values, null, null, null, null);
     }
+
     @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values,
                                  String namespace) {
         return upsert(id, values, null, null, null, namespace);
     }
+
     @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values,
@@ -39,55 +41,64 @@ public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<
                                  List<Float> sparseValues,
                                  com.google.protobuf.Struct metadata,
                                  String namespace) {
-        UpsertRequest upsertRequest = validateUpsertRequest(id, values, sparseIndices, sparseValues, metadata, namespace);
+        UpsertRequest upsertRequest = validateUpsertRequest(id, values, sparseIndices, sparseValues, metadata,
+                namespace);
 
         return blockingStub.upsert(upsertRequest);
     }
+
     @Override
     public QueryResponseWithUnsignedIndices query(int topK,
-                               List<Float> vector,
-                               List<Long> sparseIndices,
-                               List<Float> sparseValues,
-                               String id,
-                               String namespace,
-                               Struct filter,
-                               boolean includeValues,
-                               boolean includeMetadata) {
-        QueryRequest queryRequest = validateQueryRequest(topK, vector, sparseIndices, sparseValues, id, namespace, filter, includeValues, includeMetadata);
+                                                  List<Float> vector,
+                                                  List<Long> sparseIndices,
+                                                  List<Float> sparseValues,
+                                                  String id,
+                                                  String namespace,
+                                                  Struct filter,
+                                                  boolean includeValues,
+                                                  boolean includeMetadata) {
+        QueryRequest queryRequest = validateQueryRequest(topK, vector, sparseIndices, sparseValues, id, namespace,
+                filter, includeValues, includeMetadata);
 
         return new QueryResponseWithUnsignedIndices(blockingStub.query(queryRequest));
     }
+
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
-                                         String id,
-                                         String namespace,
-                                         Struct filter,
-                                         boolean includeValues,
-                                         boolean includeMetadata) {
+                                                            String id,
+                                                            String namespace,
+                                                            Struct filter,
+                                                            boolean includeValues,
+                                                            boolean includeMetadata) {
         return query(topK, null, null, null, id, namespace, filter, includeValues, includeMetadata);
     }
+
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
-                                         String id,
-                                         String namespace,
-                                         Struct filter) {
+                                                            String id,
+                                                            String namespace,
+                                                            Struct filter) {
         return query(topK, null, null, null, id, namespace, filter, false, false);
     }
+
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
-                                         String id,
-                                         String namespace) {
+                                                            String id,
+                                                            String namespace) {
         return query(topK, null, null, null, id, namespace, null, false, false);
     }
+
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
-                                         String id) {
+                                                            String id) {
         return query(topK, null, null, null, id, null, null, false, false);
     }
+
     @Override
     public FetchResponse fetch(List<String> ids) {
         return fetch(ids, null);
     }
+
     @Override
     public FetchResponse fetch(List<String> ids,
                                String namespace) {
@@ -95,17 +106,20 @@ public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<
 
         return blockingStub.fetch(fetchRequest);
     }
+
     @Override
     public UpdateResponse update(String id,
                                  List<Float> values) {
         return update(id, values, null, null, null, null);
     }
+
     @Override
     public UpdateResponse update(String id,
                                  List<Float> values,
                                  String namespace) {
         return update(id, values, null, namespace, null, null);
     }
+
     @Override
     public UpdateResponse update(String id,
                                  List<Float> values,
@@ -113,14 +127,17 @@ public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<
                                  String namespace,
                                  List<Long> sparseIndices,
                                  List<Float> sparseValues) {
-        UpdateRequest updateRequest = validateUpdateRequest(id, values, metadata, namespace, sparseIndices, sparseValues);
+        UpdateRequest updateRequest = validateUpdateRequest(id, values, metadata, namespace, sparseIndices,
+                sparseValues);
 
         return blockingStub.update(updateRequest);
     }
+
     @Override
     public DeleteResponse deleteByIds(List<String> ids, String namespace) {
         return delete(ids, false, namespace, null);
     }
+
     @Override
     public DeleteResponse deleteByIds(List<String> ids) {
         return delete(ids, false, null, null);
@@ -129,14 +146,17 @@ public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<
     public DeleteResponse deleteByFilter(Struct filter, String namespace) {
         return delete(null, false, namespace, filter);
     }
+
     @Override
     public DeleteResponse deleteByFilter(Struct filter) {
         return delete(null, false, null, filter);
     }
+
     @Override
     public DeleteResponse deleteAll(String namespace) {
         return delete(null, true, namespace, null);
     }
+
     @Override
     public DeleteResponse delete(List<String> ids,
                                  boolean deleteAll,
@@ -146,6 +166,7 @@ public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<
 
         return blockingStub.delete(deleteRequest);
     }
+
     @Override
     public DescribeIndexStatsResponse describeIndexStats(Struct filter) {
         DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(filter);

--- a/src/main/java/io/pinecone/clients/PineconeBlockingDataPlaneClient.java
+++ b/src/main/java/io/pinecone/clients/PineconeBlockingDataPlaneClient.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
 
-public class PineconeBlockingDataPlaneClient {
+public class PineconeBlockingDataPlaneClient implements PineconeDataPlaneClient<UpsertResponse, QueryResponseWithUnsignedIndices, FetchResponse, UpdateResponse, DeleteResponse, DescribeIndexStatsResponse> {
 
     private final VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
 
@@ -21,59 +21,29 @@ public class PineconeBlockingDataPlaneClient {
         this.blockingStub = blockingStub;
     }
 
+    @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values) {
         return upsert(id, values, null, null, null, null);
     }
-
+    @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values,
                                  String namespace) {
         return upsert(id, values, null, null, null, namespace);
     }
-
+    @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values,
                                  List<Long> sparseIndices,
                                  List<Float> sparseValues,
                                  com.google.protobuf.Struct metadata,
                                  String namespace) {
-        UpsertRequest.Builder upsertRequest = UpsertRequest.newBuilder();
+        UpsertRequest upsertRequest = validateUpsertRequest(id, values, sparseIndices, sparseValues, metadata, namespace);
 
-        if (id == null || id.isEmpty() || values == null || values.isEmpty()) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both id and values are provided.");
-        }
-
-        Vector.Builder vectorBuilder = Vector.newBuilder()
-                .setId(id)
-                .addAllValues(values);
-
-        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are present.");
-        }
-        if (sparseIndices != null) {
-            if (sparseIndices.size() != sparseValues.size()) {
-                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are of the same length.");
-            }
-            vectorBuilder.setSparseValues(SparseValues.newBuilder()
-                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
-                    .addAllValues(sparseValues)
-                    .build());
-        }
-
-        if (metadata != null) {
-            vectorBuilder.setMetadata(metadata);
-        }
-
-        upsertRequest.addVectors(vectorBuilder.build());
-
-        if (namespace != null) {
-            upsertRequest.setNamespace(namespace);
-        }
-
-        return blockingStub.upsert(upsertRequest.build());
+        return blockingStub.upsert(upsertRequest);
     }
-
+    @Override
     public QueryResponseWithUnsignedIndices query(int topK,
                                List<Float> vector,
                                List<Long> sparseIndices,
@@ -83,49 +53,11 @@ public class PineconeBlockingDataPlaneClient {
                                Struct filter,
                                boolean includeValues,
                                boolean includeMetadata) {
-        QueryRequest.Builder queryRequest = QueryRequest.newBuilder();
+        QueryRequest queryRequest = validateQueryRequest(topK, vector, sparseIndices, sparseValues, id, namespace, filter, includeValues, includeMetadata);
 
-        if (id != null && !id.isEmpty() && vector != null && !vector.isEmpty()) {
-            throw new PineconeValidationException("Invalid query request. Cannot query with both vector id and vector values.");
-        }
-
-        if (id != null && !id.isEmpty()) {
-            queryRequest.setId(id);
-        }
-
-        if (namespace != null) {
-            queryRequest.setNamespace(namespace);
-        }
-
-        queryRequest.setTopK(topK)
-                .setIncludeValues(includeValues)
-                .setIncludeMetadata(includeMetadata);
-
-        if (filter != null) {
-            queryRequest.setFilter(filter);
-        }
-
-        if (vector != null && !vector.isEmpty()) {
-            queryRequest.addAllVector(vector);
-        }
-
-        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are present.");
-        }
-
-        if (sparseIndices != null) {
-            if (sparseIndices.size() != sparseValues.size()) {
-                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are of the same length.");
-            }
-            queryRequest.setSparseVector(SparseValues.newBuilder()
-                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
-                    .addAllValues(sparseValues)
-                    .build());
-        }
-
-        return new QueryResponseWithUnsignedIndices(blockingStub.query(queryRequest.build()));
+        return new QueryResponseWithUnsignedIndices(blockingStub.query(queryRequest));
     }
-
+    @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                          String id,
                                          String namespace,
@@ -134,103 +66,62 @@ public class PineconeBlockingDataPlaneClient {
                                          boolean includeMetadata) {
         return query(topK, null, null, null, id, namespace, filter, includeValues, includeMetadata);
     }
-
+    @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                          String id,
                                          String namespace,
                                          Struct filter) {
         return query(topK, null, null, null, id, namespace, filter, false, false);
     }
-
+    @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                          String id,
                                          String namespace) {
         return query(topK, null, null, null, id, namespace, null, false, false);
     }
-
+    @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                          String id) {
         return query(topK, null, null, null, id, null, null, false, false);
     }
-
+    @Override
     public FetchResponse fetch(List<String> ids) {
         return fetch(ids, null);
     }
-
+    @Override
     public FetchResponse fetch(List<String> ids,
                                String namespace) {
-        FetchRequest.Builder fetchRequest = FetchRequest.newBuilder();
+        FetchRequest fetchRequest = validateFetchRequest(ids, namespace);
 
-        if (ids == null || ids.isEmpty()) {
-            throw new PineconeValidationException("Invalid fetch request. Vector ids must be present");
-        }
-
-        fetchRequest.addAllIds(ids);
-
-        if (namespace != null) {
-            fetchRequest.setNamespace(namespace);
-        }
-
-        return blockingStub.fetch(fetchRequest.build());
+        return blockingStub.fetch(fetchRequest);
     }
-
+    @Override
     public UpdateResponse update(String id,
                                  List<Float> values) {
         return update(id, values, null, null, null, null);
     }
-
+    @Override
     public UpdateResponse update(String id,
                                  List<Float> values,
                                  String namespace) {
         return update(id, values, null, namespace, null, null);
     }
-
+    @Override
     public UpdateResponse update(String id,
                                  List<Float> values,
                                  Struct metadata,
                                  String namespace,
                                  List<Long> sparseIndices,
                                  List<Float> sparseValues) {
-        UpdateRequest.Builder updateRequest = UpdateRequest.newBuilder();
+        UpdateRequest updateRequest = validateUpdateRequest(id, values, metadata, namespace, sparseIndices, sparseValues);
 
-        if (id == null) {
-            throw new PineconeValidationException("Invalid update request. Vector id must be present");
-        }
-        updateRequest.setId(id);
-
-        if (values != null) {
-            updateRequest.addAllValues(values);
-        }
-
-        if (metadata != null) {
-            updateRequest.setSetMetadata(metadata);
-        }
-
-        if (namespace != null) {
-            updateRequest.setNamespace(namespace);
-        }
-
-        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are present.");
-        }
-
-        if (sparseIndices != null) {
-            if (sparseIndices.size() != sparseValues.size()) {
-                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are of the same length.");
-            }
-            updateRequest.setSparseValues(SparseValues.newBuilder()
-                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
-                    .addAllValues(sparseValues)
-                    .build());
-        }
-
-        return blockingStub.update(updateRequest.build());
+        return blockingStub.update(updateRequest);
     }
-
+    @Override
     public DeleteResponse deleteByIds(List<String> ids, String namespace) {
         return delete(ids, false, namespace, null);
     }
-
+    @Override
     public DeleteResponse deleteByIds(List<String> ids) {
         return delete(ids, false, null, null);
     }
@@ -238,43 +129,27 @@ public class PineconeBlockingDataPlaneClient {
     public DeleteResponse deleteByFilter(Struct filter, String namespace) {
         return delete(null, false, namespace, filter);
     }
-
+    @Override
     public DeleteResponse deleteByFilter(Struct filter) {
         return delete(null, false, null, filter);
     }
-
+    @Override
     public DeleteResponse deleteAll(String namespace) {
         return delete(null, true, namespace, null);
     }
-
+    @Override
     public DeleteResponse delete(List<String> ids,
                                  boolean deleteAll,
                                  String namespace,
                                  Struct filter) {
-        DeleteRequest.Builder deleteRequest = DeleteRequest.newBuilder().setDeleteAll(deleteAll);
+        DeleteRequest deleteRequest = validateDeleteRequest(ids, deleteAll, namespace, filter);
 
-        if (ids != null && !ids.isEmpty()) {
-            deleteRequest.addAllIds(ids);
-        }
-
-        if (namespace != null) {
-            deleteRequest.setNamespace(namespace);
-        }
-
-        if (filter != null) {
-            deleteRequest.setFilter(filter);
-        }
-
-        return blockingStub.delete(deleteRequest.build());
+        return blockingStub.delete(deleteRequest);
     }
-
+    @Override
     public DescribeIndexStatsResponse describeIndexStats(Struct filter) {
-        DescribeIndexStatsRequest.Builder describeIndexStatsRequest = DescribeIndexStatsRequest.newBuilder();
+        DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(filter);
 
-        if (filter != null) {
-            describeIndexStatsRequest.setFilter(filter);
-        }
-
-        return blockingStub.describeIndexStats(describeIndexStatsRequest.build());
+        return blockingStub.describeIndexStats(describeIndexStatsRequest);
     }
 }

--- a/src/main/java/io/pinecone/clients/PineconeDataPlaneClient.java
+++ b/src/main/java/io/pinecone/clients/PineconeDataPlaneClient.java
@@ -1,0 +1,241 @@
+package io.pinecone.clients;
+
+import com.google.protobuf.Struct;
+import io.pinecone.exceptions.PineconeValidationException;
+import io.pinecone.proto.*;
+
+import java.util.List;
+
+import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
+
+public interface PineconeDataPlaneClient<T, U, V, W, X, Y> {
+    // default methods
+    default UpsertRequest validateUpsertRequest(String id,
+                                                List<Float> values,
+                                                List<Long> sparseIndices,
+                                                List<Float> sparseValues,
+                                                Struct metadata,
+                                                String namespace) {
+        UpsertRequest.Builder upsertRequest = UpsertRequest.newBuilder();
+
+        if (id == null || id.isEmpty() || values == null || values.isEmpty()) {
+            throw new PineconeValidationException("Invalid upsert request. Please ensure that both id and values are " +
+                    "provided.");
+        }
+
+        Vector.Builder vectorBuilder = Vector.newBuilder()
+                .setId(id)
+                .addAllValues(values);
+
+        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
+            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and" +
+                    " values are present.");
+        }
+        if (sparseIndices != null) {
+            if (sparseIndices.size() != sparseValues.size()) {
+                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices" +
+                        " and values are of the same length.");
+            }
+            vectorBuilder.setSparseValues(SparseValues.newBuilder()
+                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
+                    .addAllValues(sparseValues)
+                    .build());
+        }
+
+        if (metadata != null) {
+            vectorBuilder.setMetadata(metadata);
+        }
+
+        upsertRequest.addVectors(vectorBuilder.build());
+
+        if (namespace != null) {
+            upsertRequest.setNamespace(namespace);
+        }
+        return upsertRequest.build();
+    }
+
+    default QueryRequest validateQueryRequest(int topK,
+                                              List<Float> vector,
+                                              List<Long> sparseIndices,
+                                              List<Float> sparseValues,
+                                              String id,
+                                              String namespace,
+                                              Struct filter,
+                                              boolean includeValues,
+                                              boolean includeMetadata) {
+        QueryRequest.Builder queryRequest = QueryRequest.newBuilder();
+
+        if (id != null && !id.isEmpty() && vector != null && !vector.isEmpty()) {
+            throw new PineconeValidationException("Invalid query request. Cannot query with both vector id and vector" +
+                    " values.");
+        }
+
+        if (id != null && !id.isEmpty()) {
+            queryRequest.setId(id);
+        }
+
+        if (namespace != null) {
+            queryRequest.setNamespace(namespace);
+        }
+
+        queryRequest.setTopK(topK)
+                .setIncludeValues(includeValues)
+                .setIncludeMetadata(includeMetadata);
+
+        if (filter != null) {
+            queryRequest.setFilter(filter);
+        }
+
+        if (vector != null && !vector.isEmpty()) {
+            queryRequest.addAllVector(vector);
+        }
+
+        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
+            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and" +
+                    " values are present.");
+        }
+
+        if (sparseIndices != null) {
+            if (sparseIndices.size() != sparseValues.size()) {
+                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices" +
+                        " and values are of the same length.");
+            }
+            queryRequest.setSparseVector(SparseValues.newBuilder()
+                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
+                    .addAllValues(sparseValues)
+                    .build());
+        }
+        return queryRequest.build();
+    }
+
+    default FetchRequest validateFetchRequest(List<String> ids, String namespace) {
+        FetchRequest.Builder fetchRequest = FetchRequest.newBuilder();
+
+        if (ids == null || ids.isEmpty()) {
+            throw new PineconeValidationException("Invalid fetch request. Vector ids must be present");
+        }
+
+        fetchRequest.addAllIds(ids);
+
+        if (namespace != null) {
+            fetchRequest.setNamespace(namespace);
+        }
+        return fetchRequest.build();
+    }
+
+    default UpdateRequest validateUpdateRequest(String id,
+                                                List<Float> values,
+                                                Struct metadata,
+                                                String namespace,
+                                                List<Long> sparseIndices,
+                                                List<Float> sparseValues) {
+        UpdateRequest.Builder updateRequest = UpdateRequest.newBuilder();
+
+        if (id == null) {
+            throw new PineconeValidationException("Invalid update request. Vector id must be present");
+        }
+        updateRequest.setId(id);
+
+        if (values != null) {
+            updateRequest.addAllValues(values);
+        }
+
+        if (metadata != null) {
+            updateRequest.setSetMetadata(metadata);
+        }
+
+        if (namespace != null) {
+            updateRequest.setNamespace(namespace);
+        }
+
+        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
+            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and" +
+                    " values are present.");
+        }
+
+        if (sparseIndices != null) {
+            if (sparseIndices.size() != sparseValues.size()) {
+                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices" +
+                        " and values are of the same length.");
+            }
+            updateRequest.setSparseValues(SparseValues.newBuilder()
+                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
+                    .addAllValues(sparseValues)
+                    .build());
+        }
+        return updateRequest.build();
+    }
+
+    default DeleteRequest validateDeleteRequest(List<String> ids,
+                                                boolean deleteAll,
+                                                String namespace,
+                                                Struct filter) {
+        DeleteRequest.Builder deleteRequest = DeleteRequest.newBuilder().setDeleteAll(deleteAll);
+
+        if (ids != null && !ids.isEmpty()) {
+            deleteRequest.addAllIds(ids);
+        }
+
+        if (namespace != null) {
+            deleteRequest.setNamespace(namespace);
+        }
+
+        if (filter != null) {
+            deleteRequest.setFilter(filter);
+        }
+        return deleteRequest.build();
+    }
+
+    default DescribeIndexStatsRequest validateDescribeIndexStatsRequest(Struct filter) {
+        DescribeIndexStatsRequest.Builder describeIndexStatsRequest = DescribeIndexStatsRequest.newBuilder();
+
+        if (filter != null) {
+            describeIndexStatsRequest.setFilter(filter);
+        }
+        return describeIndexStatsRequest.build();
+    }
+
+    T upsert(String id, List<Float> values);
+
+    T upsert(String id, List<Float> values, String namespace);
+
+    T upsert(String id, List<Float> values, List<Long> sparseIndices, List<Float> sparseValues, Struct metadata,
+             String namespace);
+
+    U queryByVectorId(int topK, String id);
+
+    U queryByVectorId(int topK, String id, String namespace);
+
+    U queryByVectorId(int topK, String id, String namespace, Struct filter);
+
+    U queryByVectorId(int topK, String id, String namespace, Struct filter, boolean includeValues,
+                      boolean includeMetadata);
+
+    U query(int topK, List<Float> vector, List<Long> sparseIndices, List<Float> sparseValues, String id,
+            String namespace, Struct filter, boolean includeValues, boolean includeMetadata);
+
+    V fetch(List<String> ids);
+
+    V fetch(List<String> ids, String namespace);
+
+    W update(String id, List<Float> values);
+
+    W update(String id, List<Float> values, String namespace);
+
+    W update(String id, List<Float> values, Struct metadata, String namespace, List<Long> sparseIndices,
+             List<Float> sparseValues);
+
+    X deleteByIds(List<String> ids);
+
+    X deleteByIds(List<String> ids, String namespace);
+
+    X deleteByFilter(Struct filter);
+
+    X deleteByFilter(Struct filter, String namespace);
+
+    X deleteAll(String namespace);
+
+    X delete(List<String> ids, boolean deleteAll, String namespace, Struct filter);
+
+    Y describeIndexStats(Struct filter);
+}

--- a/src/main/java/io/pinecone/clients/PineconeFutureDataPlaneClient.java
+++ b/src/main/java/io/pinecone/clients/PineconeFutureDataPlaneClient.java
@@ -12,7 +12,10 @@ import java.util.List;
 
 import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
 
-public class PineconeFutureDataPlaneClient {
+public class PineconeFutureDataPlaneClient implements PineconeDataPlaneClient<ListenableFuture<UpsertResponse>,
+        ListenableFuture<QueryResponseWithUnsignedIndices>, ListenableFuture<FetchResponse>,
+        ListenableFuture<UpdateResponse>, ListenableFuture<DeleteResponse>,
+        ListenableFuture<DescribeIndexStatsResponse>> {
 
     private final VectorServiceGrpc.VectorServiceFutureStub futureStub;
 
@@ -24,264 +27,157 @@ public class PineconeFutureDataPlaneClient {
         this.futureStub = futureStub;
     }
 
+    @Override
     public ListenableFuture<UpsertResponse> upsert(String id,
                                                    List<Float> values) {
         return upsert(id, values, null, null, null, null);
     }
 
+    @Override
     public ListenableFuture<UpsertResponse> upsert(String id,
                                                    List<Float> values,
                                                    String namespace) {
         return upsert(id, values, null, null, null, namespace);
     }
 
+    @Override
     public ListenableFuture<UpsertResponse> upsert(String id,
                                                    List<Float> values,
                                                    List<Long> sparseIndices,
                                                    List<Float> sparseValues,
                                                    com.google.protobuf.Struct metadata,
                                                    String namespace) {
-        UpsertRequest.Builder upsertRequest = UpsertRequest.newBuilder();
+        UpsertRequest upsertRequest = validateUpsertRequest(id, values, sparseIndices, sparseValues, metadata, namespace);
 
-        if (id == null || id.isEmpty() || values == null || values.isEmpty()) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both id and values are provided.");
-        }
-
-        Vector.Builder vectorBuilder = Vector.newBuilder()
-                .setId(id)
-                .addAllValues(values);
-
-        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are present.");
-        }
-        if (sparseIndices != null) {
-            if (sparseIndices.size() != sparseValues.size()) {
-                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are of the same length.");
-            }
-            vectorBuilder.setSparseValues(SparseValues.newBuilder()
-                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
-                    .addAllValues(sparseValues)
-                    .build());
-        }
-
-        if (metadata != null) {
-            vectorBuilder.setMetadata(metadata);
-        }
-
-        upsertRequest.addVectors(vectorBuilder.build());
-
-        if (namespace != null) {
-            upsertRequest.setNamespace(namespace);
-        }
-
-        return futureStub.upsert(upsertRequest.build());
+        return futureStub.upsert(upsertRequest);
     }
 
+    @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> query(int topK,
-                                                 List<Float> vector,
-                                                 List<Long> sparseIndices,
-                                                 List<Float> sparseValues,
-                                                 String id,
-                                                 String namespace,
-                                                 Struct filter,
-                                                 boolean includeValues,
-                                                 boolean includeMetadata) {
-        QueryRequest.Builder queryRequest = QueryRequest.newBuilder();
+                                                                    List<Float> vector,
+                                                                    List<Long> sparseIndices,
+                                                                    List<Float> sparseValues,
+                                                                    String id,
+                                                                    String namespace,
+                                                                    Struct filter,
+                                                                    boolean includeValues,
+                                                                    boolean includeMetadata) {
+        QueryRequest queryRequest = validateQueryRequest(topK, vector, sparseIndices, sparseValues, id, namespace, filter, includeValues, includeMetadata);
 
-        if (id != null && !id.isEmpty() && vector != null && !vector.isEmpty()) {
-            throw new PineconeValidationException("Invalid query request. Cannot query with both vector id and vector values.");
-        }
-
-        if (id != null && !id.isEmpty()) {
-            queryRequest.setId(id);
-        }
-
-        if (namespace != null) {
-            queryRequest.setNamespace(namespace);
-        }
-
-        queryRequest.setTopK(topK)
-                .setIncludeValues(includeValues)
-                .setIncludeMetadata(includeMetadata);
-
-        if (filter != null) {
-            queryRequest.setFilter(filter);
-        }
-
-        if (vector != null && !vector.isEmpty()) {
-            queryRequest.addAllVector(vector);
-        }
-
-        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are present.");
-        }
-
-        if (sparseIndices != null) {
-            if (sparseIndices.size() != sparseValues.size()) {
-                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are of the same length.");
-            }
-            queryRequest.setSparseVector(SparseValues.newBuilder()
-                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
-                    .addAllValues(sparseValues)
-                    .build());
-        }
-
-        ListenableFuture<QueryResponse> queryResponseFuture = futureStub.query(queryRequest.build());
+        ListenableFuture<QueryResponse> queryResponseFuture = futureStub.query(queryRequest);
 
         return Futures.transform(queryResponseFuture,
                 QueryResponseWithUnsignedIndices::new, MoreExecutors.directExecutor());
     }
 
+    @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
-                                                           String id,
-                                                           String namespace,
-                                                           Struct filter,
-                                                           boolean includeValues,
-                                                           boolean includeMetadata) {
+                                                                              String id,
+                                                                              String namespace,
+                                                                              Struct filter,
+                                                                              boolean includeValues,
+                                                                              boolean includeMetadata) {
         return query(topK, null, null, null, id, namespace, filter, includeValues, includeMetadata);
     }
 
+    @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
-                                                           String id,
-                                                           String namespace,
-                                                           Struct filter) {
+                                                                              String id,
+                                                                              String namespace,
+                                                                              Struct filter) {
         return query(topK, null, null, null, id, namespace, filter, false, false);
     }
 
+    @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
-                                                           String id,
-                                                           String namespace) {
+                                                                              String id,
+                                                                              String namespace) {
         return query(topK, null, null, null, id, namespace, null, false, false);
     }
 
+    @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
-                                                           String id) {
+                                                                              String id) {
         return query(topK, null, null, null, id, null, null, false, false);
     }
 
+    @Override
     public ListenableFuture<FetchResponse> fetch(List<String> ids) {
         return fetch(ids, null);
     }
 
+    @Override
     public ListenableFuture<FetchResponse> fetch(List<String> ids,
                                                  String namespace) {
-        FetchRequest.Builder fetchRequest = FetchRequest.newBuilder();
+        FetchRequest fetchRequest = validateFetchRequest(ids, namespace);
 
-        if (ids == null || ids.isEmpty()) {
-            throw new PineconeValidationException("Invalid fetch request. Vector ids must be present");
-        }
-
-        fetchRequest.addAllIds(ids);
-
-        if (namespace != null) {
-            fetchRequest.setNamespace(namespace);
-        }
-
-        return futureStub.fetch(fetchRequest.build());
+        return futureStub.fetch(fetchRequest);
     }
 
+    @Override
     public ListenableFuture<UpdateResponse> update(String id,
                                                    List<Float> values) {
         return update(id, values, null, null, null, null);
     }
 
+    @Override
     public ListenableFuture<UpdateResponse> update(String id,
                                                    List<Float> values,
                                                    String namespace) {
         return update(id, values, null, namespace, null, null);
     }
 
+    @Override
     public ListenableFuture<UpdateResponse> update(String id,
                                                    List<Float> values,
                                                    Struct metadata,
                                                    String namespace,
                                                    List<Long> sparseIndices,
                                                    List<Float> sparseValues) {
-        UpdateRequest.Builder updateRequest = UpdateRequest.newBuilder();
+        UpdateRequest updateRequest = validateUpdateRequest(id, values, metadata, namespace, sparseIndices, sparseValues);
 
-        if (id == null) {
-            throw new PineconeValidationException("Invalid update request. Vector id must be present");
-        }
-        updateRequest.setId(id);
-
-        if (values != null) {
-            updateRequest.addAllValues(values);
-        }
-
-        if (metadata != null) {
-            updateRequest.setSetMetadata(metadata);
-        }
-
-        if (namespace != null) {
-            updateRequest.setNamespace(namespace);
-        }
-
-        if ((sparseIndices != null && sparseValues == null) || (sparseIndices == null && sparseValues != null)) {
-            throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are present.");
-        }
-
-        if (sparseIndices != null) {
-            if (sparseIndices.size() != sparseValues.size()) {
-                throw new PineconeValidationException("Invalid upsert request. Please ensure that both sparse indices and values are of the same length.");
-            }
-            updateRequest.setSparseValues(SparseValues.newBuilder()
-                    .addAllIndices(convertUnsigned32IntToSigned32Int(sparseIndices))
-                    .addAllValues(sparseValues)
-                    .build());
-        }
-
-        return futureStub.update(updateRequest.build());
+        return futureStub.update(updateRequest);
     }
 
+    @Override
     public ListenableFuture<DeleteResponse> deleteByIds(List<String> ids, String namespace) {
         return delete(ids, false, namespace, null);
     }
 
+    @Override
     public ListenableFuture<DeleteResponse> deleteByIds(List<String> ids) {
         return delete(ids, false, null, null);
     }
 
+    @Override
     public ListenableFuture<DeleteResponse> deleteByFilter(Struct filter, String namespace) {
         return delete(null, false, namespace, filter);
     }
 
+    @Override
     public ListenableFuture<DeleteResponse> deleteByFilter(Struct filter) {
         return delete(null, false, null, filter);
     }
 
+    @Override
     public ListenableFuture<DeleteResponse> deleteAll(String namespace) {
         return delete(null, true, namespace, null);
     }
 
+    @Override
     public ListenableFuture<DeleteResponse> delete(List<String> ids,
-                                 boolean deleteAll,
-                                 String namespace,
-                                 Struct filter) {
-        DeleteRequest.Builder deleteRequest = DeleteRequest.newBuilder().setDeleteAll(deleteAll);
+                                                   boolean deleteAll,
+                                                   String namespace,
+                                                   Struct filter) {
+        DeleteRequest deleteRequest = validateDeleteRequest(ids, deleteAll, namespace, filter);
 
-        if (ids != null && !ids.isEmpty()) {
-            deleteRequest.addAllIds(ids);
-        }
-
-        if (namespace != null) {
-            deleteRequest.setNamespace(namespace);
-        }
-
-        if (filter != null) {
-            deleteRequest.setFilter(filter);
-        }
-
-        return futureStub.delete(deleteRequest.build());
+        return futureStub.delete(deleteRequest);
     }
 
-
+    @Override
     public ListenableFuture<DescribeIndexStatsResponse> describeIndexStats(Struct filter) {
-        DescribeIndexStatsRequest.Builder describeIndexStatsRequest = DescribeIndexStatsRequest.newBuilder();
+        DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(filter);
 
-        if (filter != null) {
-            describeIndexStatsRequest.setFilter(filter);
-        }
-
-        return futureStub.describeIndexStats(describeIndexStatsRequest.build());
+        return futureStub.describeIndexStats(describeIndexStatsRequest);
     }
 }

--- a/src/main/java/io/pinecone/clients/PineconeFutureDataPlaneClient.java
+++ b/src/main/java/io/pinecone/clients/PineconeFutureDataPlaneClient.java
@@ -4,15 +4,14 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Struct;
+import io.pinecone.commons.PineconeDataPlaneInterface;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 
 import java.util.List;
 
-import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
-
-public class PineconeFutureDataPlaneClient implements PineconeDataPlaneClient<ListenableFuture<UpsertResponse>,
+public class PineconeFutureDataPlaneClient implements PineconeDataPlaneInterface<ListenableFuture<UpsertResponse>,
         ListenableFuture<QueryResponseWithUnsignedIndices>, ListenableFuture<FetchResponse>,
         ListenableFuture<UpdateResponse>, ListenableFuture<DeleteResponse>,
         ListenableFuture<DescribeIndexStatsResponse>> {
@@ -47,7 +46,8 @@ public class PineconeFutureDataPlaneClient implements PineconeDataPlaneClient<Li
                                                    List<Float> sparseValues,
                                                    com.google.protobuf.Struct metadata,
                                                    String namespace) {
-        UpsertRequest upsertRequest = validateUpsertRequest(id, values, sparseIndices, sparseValues, metadata, namespace);
+        UpsertRequest upsertRequest = validateUpsertRequest(id, values, sparseIndices, sparseValues, metadata,
+                namespace);
 
         return futureStub.upsert(upsertRequest);
     }
@@ -62,7 +62,8 @@ public class PineconeFutureDataPlaneClient implements PineconeDataPlaneClient<Li
                                                                     Struct filter,
                                                                     boolean includeValues,
                                                                     boolean includeMetadata) {
-        QueryRequest queryRequest = validateQueryRequest(topK, vector, sparseIndices, sparseValues, id, namespace, filter, includeValues, includeMetadata);
+        QueryRequest queryRequest = validateQueryRequest(topK, vector, sparseIndices, sparseValues, id, namespace,
+                filter, includeValues, includeMetadata);
 
         ListenableFuture<QueryResponse> queryResponseFuture = futureStub.query(queryRequest);
 
@@ -134,7 +135,8 @@ public class PineconeFutureDataPlaneClient implements PineconeDataPlaneClient<Li
                                                    String namespace,
                                                    List<Long> sparseIndices,
                                                    List<Float> sparseValues) {
-        UpdateRequest updateRequest = validateUpdateRequest(id, values, metadata, namespace, sparseIndices, sparseValues);
+        UpdateRequest updateRequest = validateUpdateRequest(id, values, metadata, namespace, sparseIndices,
+                sparseValues);
 
         return futureStub.update(updateRequest);
     }

--- a/src/main/java/io/pinecone/commons/PineconeDataPlaneInterface.java
+++ b/src/main/java/io/pinecone/commons/PineconeDataPlaneInterface.java
@@ -1,4 +1,4 @@
-package io.pinecone.clients;
+package io.pinecone.commons;
 
 import com.google.protobuf.Struct;
 import io.pinecone.exceptions.PineconeValidationException;
@@ -8,7 +8,7 @@ import java.util.List;
 
 import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
 
-public interface PineconeDataPlaneClient<T, U, V, W, X, Y> {
+public interface PineconeDataPlaneInterface<T, U, V, W, X, Y> {
     // default methods
     default UpsertRequest validateUpsertRequest(String id,
                                                 List<Float> values,


### PR DESCRIPTION
## Problem
Currently, we have two flavors of classes for dealing with `blocking` and `future` behavior for gRPC data plane calls:

- `PineconeBlockingDataPlaneClient`
- `PineconeFutureDataPlaneClient`

Ultimately, both of these classes conform to the same interface for wrapping data plane calls, and both classes have internal logic for validating the arguments passed to these requests that's duplicated across both classes:

PineconeBlockingDataPlaneClient | PineconeFutureDataPlaneClient
-- | --
upsert(String id,                                 List<Float> values) | upsert(String id,                                                   List<Float> values)
upsert(String id,                                 List<Float> values,                                 String namespace) | upsert(String id,                                                   List<Float> values,                                                   String namespace)
upsert(String id,                                 List<Float> values,                                 List<Long> sparseIndices,                                 List<Float> sparseValues,                                 com.google.protobuf.Struct metadata,                                 String namespace) | upsert(String id,                                                   List<Float> values,                                                   List<Long> sparseIndices,                                                   List<Float> sparseValues,                                                   com.google.protobuf.Struct metadata,                                                   String namespace)
queryByVectorId(int topK,                                         String id,                                         String namespace,                                         Struct filter,                                         boolean includeValues,                                         boolean includeMetadata) | queryByVectorId(int topK,                                                           String id,                                                           String namespace,                                                           Struct filter,                                                           boolean includeValues,                                                           boolean includeMetadata)
queryByVectorId(int topK,                                         String id,                                         String namespace,                                         Struct filter) | queryByVectorId(int topK,                                                           String id,                                                           String namespace,                                                           Struct filter)
queryByVectorId(int topK,                                         String id,                                         String namespace) | queryByVectorId(int topK,                                                           String id,                                                           String namespace)
queryByVectorId(int topK,                                         String id) | queryByVectorId(int topK,                                                           String id)
query(int topK,                               List<Float> vector,                               List<Long> sparseIndices,                               List<Float> sparseValues,                               String id,                               String namespace,                               Struct filter,                               boolean includeValues,                               boolean includeMetadata) | query(int topK,                                                 List<Float> vector,                                                 List<Long> sparseIndices,                                                 List<Float> sparseValues,                                                 String id,                                                 String namespace,                                                 Struct filter,                                                 boolean includeValues,                                                 boolean includeMetadata)
fetch(List<String> ids) | fetch(List<String> ids)
fetch(List<String> ids,                               String namespace) | fetch(List<String> ids,                                                 String namespace)
update(String id,                                 List<Float> values) | update(String id,                                                   List<Float> values)
update(String id,                                 List<Float> values,                                 String namespace) | update(String id,                                                   List<Float> values,                                                   String namespace)
update(String id,                                 List<Float> values,                                 Struct metadata,                                 String namespace,                                 List<Long> sparseIndices,                                 List<Float> sparseValues) | update(String id,                                                   List<Float> values,                                                   Struct metadata,                                                   String namespace,                                                   List<Long> sparseIndices,                                                   List<Float> sparseValues)
deleteByIds(List<String> ids, String namespace) | deleteByIds(List<String> ids, String namespace)
deleteByIds(List<String> ids) | deleteByIds(List<String> ids)
deleteByFilter(Struct filter, String namespace) | deleteByFilter(Struct filter, String namespace)
deleteByFilter(Struct filter) | deleteByFilter(Struct filter)
deleteAll(String namespace) | deleteAll(String namespace)
delete(List<String> ids,                                 boolean deleteAll,                                 String namespace,                                 Struct filter) | delete(List<String> ids,                                 boolean deleteAll,                                 String namespace,                                 Struct filter)
describeIndexStats(Struct filter) | describeIndexStats(Struct filter)

## Solution
Unify the two data plane wrapper classes with a `PineconeDataPlaneClient` interface.

This interface has default methods for dealing with validation steps for each core dataplane operation:
- `upsert`
- `query`
- `fetch`
- `update`
- `delete`
- `describeIndexStats`

The interface also has stubs for the various overloaded functions that are used to improve the development experience for consumers since Java 8 doesn't support optional arguments. Keeping this contract in an interface allows us to define the expected shape in one place, and avoid needing to validate consistency across the two files.

The interface takes in 6 generic types to represent the return types for each "group" of data plane operations. The reason for this is `PineconeBlockingDataPlaneClient` and `PineconeFutureDataPlaneClient` have different return types where the blocking class returns the response objects directly, and the future class returns `ListenableFuture<T>`. Using generics, this gives us the flexibility to define our own return types for each group of operations:
- `upsert` - `T`
- `query` - `U`
- `fetch` - `V`
- `update` - `W`
- `delete` - `X`
- `describeIndexStats` - `Z`

## Type of Change
- [X] None of the above: refactoring / abstraction

## Test Plan
The classes remain the same, so integration tests and builds should pass as normal.
