### PR TITLE
Fix Collection and ConfigureIndex tests

### DIFF
--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -135,7 +135,7 @@ public class IndexManager {
             int timeWaited = 0;
             CollectionModel.StatusEnum collectionReady = collection.getStatus();
             while (collectionReady != CollectionModel.StatusEnum.READY && timeWaited < 120000) {
-                logger.info("Waiting for collection" + collectionName + " to be ready. Waited " + timeWaited + " milliseconds...");
+                logger.info("Waiting for collection " + collectionName + " to be ready. Waited " + timeWaited + " milliseconds...");
                 Thread.sleep(5000);
                 timeWaited += 5000;
                 collection = controlPlaneClient.describeCollection(collectionName);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -23,7 +23,6 @@ import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static org.junit.jupiter.api.Assertions.*;
 
-@Disabled("Disable the entire class")
 public class CollectionTest {
     private static final String indexName = RandomStringBuilder.build("collection-test", 8);
     private static final String collectionName = RandomStringBuilder.build("collection-test", 8);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -20,65 +20,81 @@ import static io.pinecone.helpers.IndexManager.createNewIndexAndConnect;
 import static io.pinecone.helpers.IndexManager.waitUntilIndexIsReady;
 import static io.pinecone.helpers.IndexManager.createCollection;
 import static io.pinecone.helpers.BuildUpsertRequest.*;
+import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Disabled("Disable the entire class")
 public class CollectionTest {
-
-    private static PineconeControlPlaneClient controlPlaneClient;
     private static final String indexName = RandomStringBuilder.build("collection-test", 8);
+    private static final String collectionName = RandomStringBuilder.build("collection-test", 8);
     private static final ArrayList<String> indexes = new ArrayList<>();
-    private static final ArrayList<String> collections = new ArrayList<>();
     private static final IndexMetric indexMetric = IndexMetric.COSINE;
     private static final List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
     private static final String namespace = RandomStringBuilder.build("ns", 8);
     private static final String apiKey = System.getenv("PINECONE_API_KEY");
     private static final String environment = System.getenv("PINECONE_ENVIRONMENT");
     private static final int dimension = 4;
-
     private static final Logger logger = LoggerFactory.getLogger(CollectionTest.class);
+    private static PineconeControlPlaneClient controlPlaneClient;
+    private static CollectionModel collection;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
         controlPlaneClient = new PineconeControlPlaneClient(apiKey);
-        CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().pods(1).podType("p1.x1").replicas(1).environment(environment);
+
+        // Create and upsert to index
+        CreateIndexRequestSpecPod podSpec =
+                new CreateIndexRequestSpecPod().pods(1).podType("p1.x1").replicas(1).environment(environment);
         CreateIndexRequestSpec spec = new CreateIndexRequestSpec().pod(podSpec);
-        PineconeConnection dataPlaneConnection = createNewIndexAndConnect(controlPlaneClient, indexName, dimension, indexMetric, spec);
+        PineconeConnection dataPlaneConnection = createNewIndexAndConnect(controlPlaneClient, indexName, dimension,
+                indexMetric, spec);
         VectorServiceGrpc.VectorServiceBlockingStub blockingStub = dataPlaneConnection.getBlockingStub();
         indexes.add(indexName);
 
-        blockingStub.upsert(buildRequiredUpsertRequestByDimension(upsertIds, dimension, namespace));
+        // Sometimes we see grpc failures when upserting so quickly after creating, so retry
+        assertWithRetry(() -> blockingStub.upsert(buildRequiredUpsertRequestByDimension(upsertIds, dimension,
+                namespace)), 1);
         dataPlaneConnection.close();
 
+        // Create collection from index
+        collection = createCollection(controlPlaneClient, collectionName, indexName, true);
+        assertEquals(collection.getName(), collectionName);
+        assertEquals(collection.getEnvironment(), environment);
+        assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
     }
 
     @AfterAll
     public static void cleanUp() throws InterruptedException {
         // wait for things to settle before cleanup...
         Thread.sleep(2500);
+
         // Clean up indexes
         for (String index : indexes) {
             controlPlaneClient.deleteIndex(index);
         }
-        // Clean up collections
-        for (String collection : collections) {
-            controlPlaneClient.deleteCollection(collection);
-        }
+
+        // Verify we can delete the collection
+        controlPlaneClient.deleteCollection(collectionName);
         Thread.sleep(2500);
+
+        List<CollectionModel> collectionList = controlPlaneClient.listCollections().getCollections();
+        if (collectionList != null) {
+            boolean isCollectionDeleted = true;
+            for (CollectionModel col : collectionList) {
+                if (col.getName().equals(collectionName)) {
+                    isCollectionDeleted = false;
+                    break;
+                }
+            }
+
+            if (!isCollectionDeleted) {
+                fail("Collection " + collectionName + " was not successfully deleted");
+            }
+        }
     }
 
     @Test
-    public void testIndexToCollectionHappyPath() throws InterruptedException {
-        String collectionName = RandomStringBuilder.build("collection-test", 8);
-
-        // Create collection from index
-        CollectionModel collection = createCollection(controlPlaneClient, collectionName, indexName, true);
-        collections.add(collectionName);
-
-        assertEquals(collection.getName(), collectionName);
-        assertEquals(collection.getEnvironment(), environment);
-        assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
-
+    public void testIndexFromCollectionHappyPath() throws InterruptedException {
         // Verify collection is listed
         List<CollectionModel> collectionList = controlPlaneClient.listCollections().getCollections();
         boolean collectionFound = false;
@@ -108,12 +124,15 @@ public class CollectionTest {
         String newIndexName = RandomStringBuilder.build("index-from-col", 5);
         logger.info("Creating index " + newIndexName + " from collection " + collectionName);
 
-        CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).sourceCollection(collectionName);
+        CreateIndexRequestSpecPod podSpec =
+                new CreateIndexRequestSpecPod().environment(environment).sourceCollection(collectionName);
         CreateIndexRequestSpec spec = new CreateIndexRequestSpec().pod(podSpec);
-        CreateIndexRequest newCreateIndexRequest = new CreateIndexRequest().name(newIndexName).dimension(dimension).metric(indexMetric).spec(spec);
+        CreateIndexRequest newCreateIndexRequest =
+                new CreateIndexRequest().name(newIndexName).dimension(dimension).metric(indexMetric).spec(spec);
         controlPlaneClient.createIndex(newCreateIndexRequest);
         indexes.add(newIndexName);
-        logger.info("Index " + newIndexName + " created from collection " + collectionName + ". Waiting until index is ready...");
+        logger.info("Index " + newIndexName + " created from collection " + collectionName + ". Waiting until index " +
+                "is ready...");
         waitUntilIndexIsReady(controlPlaneClient, newIndexName, 250000);
         // wait a bit more to make sure index is ready...
         Thread.sleep(30000);
@@ -127,57 +146,29 @@ public class CollectionTest {
         PineconeConfig config = new PineconeConfig(apiKey);
         PineconeConnection connection = new PineconeConnection(config, indexName);
         VectorServiceGrpc.VectorServiceBlockingStub newIndexBlockingStub = connection.getBlockingStub();
-        DescribeIndexStatsResponse describeResponse = newIndexBlockingStub.describeIndexStats(DescribeIndexStatsRequest.newBuilder().build());
 
-        // Verify stats reflect the vectors in the collection
-        assertEquals(describeResponse.getTotalVectorCount(), 3);
+        assertWithRetry(() -> {
+            DescribeIndexStatsResponse describeResponse = newIndexBlockingStub.describeIndexStats(DescribeIndexStatsRequest.newBuilder().build());
 
-        // Verify the vectors from the collection -> new index can be fetched
-        FetchResponse fetchedVectors = newIndexBlockingStub.fetch(FetchRequest.newBuilder().addAllIds(upsertIds).setNamespace(namespace).build());
+            // Verify stats reflect the vectors in the collection
+            assertEquals(describeResponse.getTotalVectorCount(), 3);
 
-        for (String key : upsertIds) {
-            assert (fetchedVectors.containsVectors(key));
-        }
+            // Verify the vectors from the collection -> new index can be fetched
+            FetchResponse fetchedVectors =
+                    newIndexBlockingStub.fetch(FetchRequest.newBuilder().addAllIds(upsertIds).setNamespace(namespace).build());
 
-        // Verify we can delete the collection
-        controlPlaneClient.deleteCollection(collectionName);
-        collections.remove(collectionName);
-        Thread.sleep(2500);
-
-        collectionList = controlPlaneClient.listCollections().getCollections();
-
-
-        if (collectionList != null) {
-            boolean isCollectionDeleted = true;
-            for (CollectionModel col : collectionList) {
-                if (col.getName().equals(collectionName)) {
-                    isCollectionDeleted = false;
-                    break;
-                }
+            for (String key : upsertIds) {
+                assert (fetchedVectors.containsVectors(key));
             }
-
-            if (!isCollectionDeleted) {
-                fail("Collection " + collectionName + " was not successfully deleted");
-            }
-        }
+        }, 1);
 
         connection.close();
     }
 
     @Test
     public void testIndexFromDifferentMetricCollection() throws InterruptedException {
-        String collectionName = RandomStringBuilder.build("collection-test", 8);
-
-        // Create collection from index
-        CollectionModel collection = createCollection(controlPlaneClient, collectionName, indexName, true);
-        collections.add(collectionName);
-
-        assertEquals(collection.getName(), collectionName);
-        assertEquals(collection.getEnvironment(), environment);
-        assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
-
         // Use a different metric than the source index
-        IndexMetric[] metrics = { IndexMetric.COSINE, IndexMetric.EUCLIDEAN, IndexMetric.DOTPRODUCT };
+        IndexMetric[] metrics = {IndexMetric.COSINE, IndexMetric.EUCLIDEAN, IndexMetric.DOTPRODUCT};
         IndexMetric targetMetric = IndexMetric.COSINE;
         for (IndexMetric metric : metrics) {
             if (!metric.equals(indexMetric)) {
@@ -186,9 +177,11 @@ public class CollectionTest {
         }
 
         String newIndexName = RandomStringBuilder.build("from-coll", 8);
-        CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).sourceCollection(collectionName);
+        CreateIndexRequestSpecPod podSpec =
+                new CreateIndexRequestSpecPod().environment(environment).sourceCollection(collectionName);
         CreateIndexRequestSpec spec = new CreateIndexRequestSpec().pod(podSpec);
-        PineconeConnection dataPlaneConnection = createNewIndexAndConnect(controlPlaneClient, newIndexName, dimension, targetMetric, spec);
+        PineconeConnection dataPlaneConnection = createNewIndexAndConnect(controlPlaneClient, newIndexName, dimension
+                , targetMetric, spec);
         indexes.add(newIndexName);
 
         IndexModel newIndex = controlPlaneClient.describeIndex(newIndexName);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -17,7 +17,6 @@ import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsControlPlan
 import static io.pinecone.helpers.IndexManager.isIndexReady;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("Disable the entire class")
 public class ConfigureIndexTest {
     private static PineconeControlPlaneClient controlPlaneClient;
     private static String indexName;

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -29,6 +29,12 @@ public class ConfigureIndexTest {
         indexName = createIndexIfNotExistsControlPlane(controlPlaneClient, 5, IndexModelSpec.SERIALIZED_NAME_POD);
     }
 
+    @AfterAll
+    public static void cleanUp() throws InterruptedException {
+        controlPlaneClient.deleteIndex(indexName);
+        Thread.sleep(3500);
+    }
+
     @Test
     public void configureIndexWithInvalidIndexName() {
         ConfigureIndexRequestSpecPod pod = new ConfigureIndexRequestSpecPod();
@@ -137,10 +143,6 @@ public class ConfigureIndexTest {
             });
         } catch (Exception exception) {
             throw new PineconeException("Test failed: " + exception.getLocalizedMessage());
-        } finally {
-            // Delete this index since it'll be unused for future tests
-            controlPlaneClient.deleteIndex(indexName);
-            Thread.sleep(3500);
         }
     }
 }


### PR DESCRIPTION
## Problem
Currently, `CollectionTest`, and `ConfigureIndexTest` are very flakey. Collections tests take a long while to run due to the need to spin up a collection, wait until it's ready, and then creating an index and waiting until that's ready.

`ConfigureIndexTest` deletes the index as a part of the final `@Test` in the file, but it doesn't seem like the order of execution is guaranteed, so deleting an index like this may cause issues: https://www.baeldung.com/junit-5-test-order

## Solution
- Update `CollectionTest` to create a single collection from the initial index that's shared across both tests. Previously we were creating a collection for each test, which is not ultimately necessary and is very time-consuming. Also, use `assertWithRetry()` to retry upserting and describing index stats. These calls seemingly have a tendency to flake when made against a newly created index. Retrying a few times if we have an error on the initial pass seems to help here.
- `ConfigureIndexTest` has a `finally` clause in the last `@Test` in the file deletes the index. Given we set up with `@BeforeAll` and the execution order is not guaranteed unless we specify, it feels like it makes more sense to clean things up in `@AfterAll`, which seems to resolve the issue with the test itself.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] None of the above: (integration tests)

## Test Plan
Validate integration runs in CI. Runs should overall be a few minutes faster, and less prone to failing on these specific tests.
