### PR TITLE
Add Create Index Error + Optional-argument integration tests for Pod + Serverless

### DIFF
--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -54,7 +54,7 @@ public class IndexManager {
             CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).podType("p1.x1");
             createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
         } else {
-            // Serverless currently has limited availability in specific regions, hardcode us-west-2 for now
+            // Serverless currently has limited availability in specific regions, hard-code us-west-2 for now
             ServerlessSpec serverlessSpec =
                     new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("us-west-2");
             createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -112,7 +112,7 @@ public class IndexManager {
         return pinecone;
     }
 
-    public static Index createNewIndexAndConnect(Pinecone pinecone, String indexName, int dimension, IndexMetric metric, CreateIndexRequestSpec spec) throws InterruptedException, PineconeException {
+    public static Index createNewIndexAndConnectSync(Pinecone pinecone, String indexName, int dimension, IndexMetric metric, CreateIndexRequestSpec spec) throws InterruptedException, PineconeException {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest().name(indexName).dimension(dimension).metric(metric).spec(spec);
         pinecone.createIndex(createIndexRequest);
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -44,7 +44,7 @@ public class CollectionTest {
         CreateIndexRequestSpecPod podSpec =
                 new CreateIndexRequestSpecPod().pods(1).podType("p1.x1").replicas(1).environment(environment);
         CreateIndexRequestSpec spec = new CreateIndexRequestSpec().pod(podSpec);
-        Index indexClient = createNewIndexAndConnect(pineconeClient, indexName, dimension,
+        Index indexClient = createNewIndexAndConnectSync(pineconeClient, indexName, dimension,
                 indexMetric, spec);
         indexesToCleanUp.add(indexName);
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
@@ -1,51 +1,181 @@
 package io.pinecone.integration.controlPlane.pod;
 
 import io.pinecone.clients.Pinecone;
+import io.pinecone.exceptions.PineconeBadRequestException;
+import io.pinecone.exceptions.PineconeUnmappedHttpException;
 import io.pinecone.helpers.RandomStringBuilder;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.Random;
+
+import static io.pinecone.helpers.IndexManager.waitUntilIndexIsReady;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateDescribeListAndDeleteIndexTest {
-    private Pinecone controlPlaneClient;
-    private final String apiKey = System.getenv("PINECONE_API_KEY");
-    private final String environment = System.getenv("PINECONE_ENVIRONMENT");
+    private static final String environment = System.getenv("PINECONE_ENVIRONMENT");
+    private static final String indexName = RandomStringBuilder.build("create-index", 8);
+    private static Pinecone controlPlaneClient = new Pinecone(System.getenv("PINECONE_API_KEY"));
 
-    @BeforeEach
-    public void setUp() {
-        controlPlaneClient = new Pinecone(apiKey);
-    }
-
-    @Test
-    public void createAndDelete() throws InterruptedException {
-        String indexName = RandomStringBuilder.build("index-name", 8);
+    @BeforeAll
+    public static void setUp() throws InterruptedException {
+        // Create the index
         CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).podType("p1.x1");
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
-
-        // Create the index
         CreateIndexRequest createIndexRequest = new CreateIndexRequest()
                 .name(indexName)
                 .metric(IndexMetric.COSINE)
                 .dimension(10)
                 .spec(createIndexRequestSpec);
         controlPlaneClient.createIndex(createIndexRequest);
+        waitUntilIndexIsReady(controlPlaneClient, indexName);
+    }
 
+    @AfterAll
+    public static void cleanUp() {
+        // Delete the index
+        controlPlaneClient.deleteIndex(indexName);
+    }
+
+    @Test
+    public void describeAndListIndex() {
         // Describe the index
         IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
         assertNotNull(indexModel);
         assertEquals(10, indexModel.getDimension());
         assertEquals(indexName, indexModel.getName());
         assertEquals(IndexMetric.COSINE, indexModel.getMetric());
+        assertNotNull(indexModel.getSpec().getPod());
+        assertEquals("p1.x1", indexModel.getSpec().getPod().getPodType());
 
         // List the index
         IndexList indexList = controlPlaneClient.listIndexes();
         assertNotNull(indexList.getIndexes());
+        assertTrue(indexList.getIndexes().stream().anyMatch(index -> indexName.equals(index.getName())));
+    }
 
-        // Delete the index
-        controlPlaneClient.deleteIndex(indexName);
-        Thread.sleep(3500);
+    @Test
+    public void createIndexWithPodsAndPodType() {
+        String podIndexName = RandomStringBuilder.build("create-pod", 8);
+        CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).pods(2).podType(
+                "p1.x2");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name(podIndexName)
+                .metric(IndexMetric.COSINE)
+                .dimension(10)
+                .spec(createIndexRequestSpec);
+
+        IndexModel createdIndex = controlPlaneClient.createIndex(createIndexRequest);
+        assertEquals(createdIndex.getName(), podIndexName);
+        assertEquals(createdIndex.getSpec().getPod().getPods(), 2);
+        assertEquals(createdIndex.getSpec().getPod().getPodType(), "p1.x2");
+        assertEquals(createdIndex.getStatus().getReady(), false);
+        assertEquals(createdIndex.getStatus().getState(), IndexModelStatus.StateEnum.INITIALIZING);
+
+        controlPlaneClient.deleteIndex(podIndexName);
+    }
+
+    @Test
+    public void createIndexWithInvalidName() {
+        CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).podType("p1.x1");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("Invalid-name")
+                .metric(IndexMetric.COSINE)
+                .dimension(10)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("must consist of lower case alphanumeric characters or" +
+                    " '-'"));
+        }
+    }
+
+    @Test
+    public void createIndexWithInvalidDimension() {
+        CreateIndexRequestSpecPod podSpec = new CreateIndexRequestSpecPod().environment(environment).podType("p1.x1");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-dimension")
+                .metric(IndexMetric.COSINE)
+                .dimension(-1)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeUnmappedHttpException");
+        } catch (PineconeUnmappedHttpException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("dimension: invalid value"));
+        }
+    }
+
+    @Test
+    public void createIndexWithInvalidPods() {
+        CreateIndexRequestSpecPod podSpec =
+                new CreateIndexRequestSpecPod().environment(environment).pods(-1).podType("p1.x1");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-pods")
+                .metric(IndexMetric.COSINE)
+                .dimension(10)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("pods"));
+            assertTrue(expected.getLocalizedMessage().contains("must be greater than 0"));
+        }
+    }
+
+    @Test
+    public void createIndexWithInvalidReplicas() {
+        CreateIndexRequestSpecPod podSpec =
+                new CreateIndexRequestSpecPod().environment(environment).pods(1).replicas(-1).podType("p1.x1");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-replicas")
+                .metric(IndexMetric.COSINE)
+                .dimension(10)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("replicas"));
+            assertTrue(expected.getLocalizedMessage().contains("must be greater than 0"));
+        }
+    }
+
+    @Test
+    public void createIndexWithInvalidPodsToShards() {
+        CreateIndexRequestSpecPod podSpec =
+                new CreateIndexRequestSpecPod().environment(environment).pods(5).replicas(2).shards(2).podType("p1.x1");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().pod(podSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-shards")
+                .metric(IndexMetric.COSINE)
+                .dimension(10)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("total pods must be divisible by number of shards"));
+        }
     }
 }

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -1,52 +1,131 @@
 package io.pinecone.integration.controlPlane.serverless;
 
 import io.pinecone.clients.Pinecone;
+import io.pinecone.exceptions.PineconeBadRequestException;
+import io.pinecone.exceptions.PineconeException;
+import io.pinecone.exceptions.PineconeNotFoundException;
+import io.pinecone.exceptions.PineconeUnmappedHttpException;
 import io.pinecone.helpers.RandomStringBuilder;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.*;
 
 import static io.pinecone.helpers.IndexManager.waitUntilIndexIsReady;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateDescribeListAndDeleteIndexTest {
-    private Pinecone controlPlaneClient;
-
-    @BeforeEach
-    public void setUp() {
-        controlPlaneClient = new Pinecone(System.getenv("PINECONE_API_KEY"));
-    }
-
-    @Test
-    public void createAndDelete() throws InterruptedException {
-        String indexName = RandomStringBuilder.build("index-name", 8);
+    private static Pinecone controlPlaneClient = new Pinecone(System.getenv("PINECONE_API_KEY"));
+    private static final String indexName = RandomStringBuilder.build("create-index", 8);
+    @BeforeAll
+    public static void setUp() throws InterruptedException {
+        // Create the index
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("us-west-2");
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
-
-        // Create the index
         CreateIndexRequest createIndexRequest = new CreateIndexRequest()
                 .name(indexName)
                 .metric(IndexMetric.COSINE)
                 .dimension(10)
                 .spec(createIndexRequestSpec);
         controlPlaneClient.createIndex(createIndexRequest);
-
         waitUntilIndexIsReady(controlPlaneClient, indexName);
+    }
 
+    @AfterAll
+    public static void cleanUp() {
+        // Delete the index
+        controlPlaneClient.deleteIndex(indexName);
+    }
+
+    @Test
+    public void describeAndListIndex() {
         // Describe the index
         IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
         assertNotNull(indexModel);
         assertEquals(10, indexModel.getDimension());
         assertEquals(indexName, indexModel.getName());
         assertEquals(IndexMetric.COSINE, indexModel.getMetric());
+        assertNotNull(indexModel.getSpec().getServerless());
 
         // List the index
         IndexList indexList = controlPlaneClient.listIndexes();
         assertNotNull(indexList.getIndexes());
+        assertTrue(indexList.getIndexes().stream().anyMatch(index -> indexName.equals(index.getName())));
+    }
 
-        // Delete the index
-        controlPlaneClient.deleteIndex(indexName);
-        Thread.sleep(3500);
+    @Test
+    public void createIndexWithInvalidName() {
+        ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("us-west-2");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("Invalid-name")
+                .metric(IndexMetric.COSINE)
+                .dimension(10)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("must consist of lower case alphanumeric characters or '-'"));
+        }
+    }
+
+    @Test
+    public void createIndexWithInvalidDimension() {
+        ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("us-west-2");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-dimension")
+                .metric(IndexMetric.COSINE)
+                .dimension(-1)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeUnmappedHttpException");
+        } catch (PineconeUnmappedHttpException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("dimension: invalid value"));
+        }
+    }
+
+    @Test
+    public void createIndexInvalidCloud() {
+        ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AZURE).region("us-west-2");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-cloud")
+                .metric(IndexMetric.COSINE)
+                .dimension(1)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeNotFoundException");
+        } catch (PineconeNotFoundException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("not found"));
+        }
+    }
+
+    @Test
+    public void createIndexInvalidRegion() {
+        ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("invalid-region");
+        CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("invalid-region")
+                .metric(IndexMetric.COSINE)
+                .dimension(1)
+                .spec(createIndexRequestSpec);
+
+        try {
+            controlPlaneClient.createIndex(createIndexRequest);
+
+            fail("Expected to throw PineconeNotFoundException");
+        } catch (PineconeNotFoundException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("not found"));
+        }
     }
 }


### PR DESCRIPTION
## Problem
The `createIndex` integration tests are somewhat minimal and we've wanted to add thorough testing for error-cases, and optional configuration arguments for both pod and serverless indexes.

## Solution
Update `integration.controlPlane.pod.CreateDescribeAndDeleteIndexTest` and `integration.controlPlane.serverless.CreateDescribeAndDeleteIndexTest` to include additional tests validating error-conditions, and creating indexes with optional arguments.

## Type of Change
- [X] Infrastructure change (CI configs, etc) 

## Test Plan
run `gradle integrationTest` or validate the tests are run as part of the `pr` workflow in GitHub CI.
