### PR TITLE
Update OkHttpClient dependency version to 4.12.0 to address vulnerability issues and clean up codebase

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,7 +58,6 @@ jobs:
             { java: 8, gradle: 6.8 },
             { java: 17, gradle: 7.3.1 }
         ]
-      max-parallel: 1
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,7 +80,7 @@ jobs:
       run: gradle clean build
 
     - name: Run integration tests
-      run: gradle integrationTest --info
+      run: gradle integrationTest
       env:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     runtimeOnly 'io.netty:netty-tcnative-boringssl-static:2.0.61.Final'
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
     implementation 'com.google.code.gson:gson:2.9.1'

--- a/src/integration/java/io/pinecone/helpers/BuildUpsertRequest.java
+++ b/src/integration/java/io/pinecone/helpers/BuildUpsertRequest.java
@@ -11,7 +11,7 @@ import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 import java.util.*;
 
 public class BuildUpsertRequest {
-    // ToDo: Remove all buildUpsertRequest methods after future stub test changes are in and rename this class
+
     public static final float[][] upsertValues = {{1.0F, 2.0F, 3.0F}, {4.0F, 5.0F, 6.0F}, {7.0F, 8.0F, 9.0F}};
     public static final String[] metadataFields = new String[]{"genre", "year"};
     public static final List<Integer> sparseIndices = Arrays.asList(0, 1, 2);
@@ -90,24 +90,6 @@ public class BuildUpsertRequest {
 
         return valuesList;
     }
-
-    // ToDo: cleanup after all of the tests are completed
-//    public static List<Struct> getMetadataStruct(int metadataSize) {
-//        HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
-//
-//        List<Struct> structList = new ArrayList<>(metadataSize);
-//
-//        for (int i = 0; i < metadataSize; i++) {
-//            structList.add(Struct.newBuilder()
-//                    .putFields(metadataFields[0],
-//                            Value.newBuilder().setStringValue(metadataMap.get(metadataFields[0]).get(i % metadataSize)).build())
-//                    .putFields(metadataFields[1],
-//                            Value.newBuilder().setStringValue(metadataMap.get(metadataFields[1]).get(i % metadataSize)).build())
-//                    .build());
-//        }
-//
-//        return structList;
-//    }
 
     public static UpsertRequest buildRequiredUpsertRequest() {
         return buildRequiredUpsertRequest(new ArrayList<>(), "");

--- a/src/integration/java/io/pinecone/integration/dataPlane/QueryErrorTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/QueryErrorTest.java
@@ -1,25 +1,15 @@
 package io.pinecone.integration.dataPlane;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import io.grpc.StatusRuntimeException;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.PineconeValidationException;
-import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.proto.DescribeIndexStatsResponse;
 import io.pinecone.proto.VectorServiceGrpc;
-import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static io.pinecone.helpers.BuildUpsertRequest.generateSparseIndicesByDimension;
 import static io.pinecone.helpers.BuildUpsertRequest.generateVectorValuesByDimension;
@@ -40,7 +30,7 @@ public class QueryErrorTest {
         VectorServiceGrpc.VectorServiceFutureStub asyncStubMock = mock(VectorServiceGrpc.VectorServiceFutureStub.class);
 
         when(connectionMock.getBlockingStub()).thenReturn(stubMock);
-        when(connectionMock.getFutureStub()).thenReturn(asyncStubMock);
+        when(connectionMock.getAsyncStub()).thenReturn(asyncStubMock);
 
         index = new Index(connectionMock);
         asyncIndex = new AsyncIndex(connectionMock);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -240,7 +240,7 @@ public class UpdateFetchAndQueryServerlessTest {
         assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
 
         // wait for the vectors to be upserted
-        Thread.sleep(90);
+        Thread.sleep(90000);
 
         try {
             for (int i = 0; i < upsertIds.size(); i++) {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -316,6 +316,8 @@ public class UpdateFetchAndQueryServerlessTest {
         List<Float> updatedValues = Arrays.asList(101F, 102F, 103F);
         asyncIndex.update(idToUpdate, updatedValues, null, namespace, null, null).get();
 
+        Thread.sleep(7500);
+
         // Query by ID to verify
         assertWithRetry(() -> {
             QueryResponseWithUnsignedIndices queryResponse = asyncIndex.query(1,

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -70,7 +70,7 @@ public class UpdateFetchAndQueryServerlessTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 4);
 
         // Update required fields only
         String idToUpdate = upsertIds.get(0);
@@ -91,7 +91,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
             List<Float> queryResponseValues = queryResponse.getMatches(0).getValuesList();
             assertEquals(updatedValues, queryResponseValues);
-        });
+        }, 4);
     }
 
     @Test
@@ -133,8 +133,6 @@ public class UpdateFetchAndQueryServerlessTest {
                 assert (fetchResponse.containsVectors(key));
             }
         });
-
-        Thread.sleep(10000);
 
         String idToUpdate = upsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(101F, 102F, 103F);
@@ -182,7 +180,7 @@ public class UpdateFetchAndQueryServerlessTest {
             Collections.sort(expectedSparseValues);
 
             assertEquals(expectedSparseValues, actualSparseValues);
-        });
+        }, 4);
     }
 
     @Test
@@ -199,8 +197,6 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace);
         }
 
-        Thread.sleep(10000);
-
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = index.fetch(upsertIds, namespace);
@@ -208,7 +204,7 @@ public class UpdateFetchAndQueryServerlessTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 4);
 
         // Update required fields only but with incorrect values dimension
         String idToUpdate = upsertIds.get(0);
@@ -247,8 +243,6 @@ public class UpdateFetchAndQueryServerlessTest {
                         namespace);
             }
 
-            Thread.sleep(10000);
-
             Struct filter = Struct.newBuilder()
                     .putFields(metadataFields[0], Value.newBuilder()
                             .setStructValue(Struct.newBuilder()
@@ -268,7 +262,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
                 // Verify the metadata field is correctly filtered in the query response
                 assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            });
+            }, 4);
         } catch (Exception e) {
             throw new PineconeException(e.getLocalizedMessage());
         }
@@ -304,8 +298,6 @@ public class UpdateFetchAndQueryServerlessTest {
             asyncIndex.upsert(id, generateVectorValuesByDimension(dimension), namespace).get();
         }
 
-        Thread.sleep(10000);
-
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
@@ -313,14 +305,12 @@ public class UpdateFetchAndQueryServerlessTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 4);
 
         // Update required fields only
         String idToUpdate = upsertIds.get(0);
         List<Float> updatedValues = Arrays.asList(101F, 102F, 103F);
         asyncIndex.update(idToUpdate, updatedValues, null, namespace, null, null).get();
-
-        Thread.sleep(10000);
 
         // Query by ID to verify
         assertWithRetry(() -> {
@@ -336,7 +326,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
             List<Float> queryResponseValues = queryResponse.getMatches(0).getValuesList();
             assertEquals(updatedValues, queryResponseValues);
-        });
+        }, 4);
     }
 
     @Test
@@ -370,8 +360,6 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace).get();
         }
 
-        Thread.sleep(10000);
-
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
@@ -379,7 +367,7 @@ public class UpdateFetchAndQueryServerlessTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 4);
 
         String idToUpdate = upsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(101F, 102F, 103F);
@@ -393,8 +381,6 @@ public class UpdateFetchAndQueryServerlessTest {
 
         // Update required+optional fields
         asyncIndex.update(idToUpdate, valuesToUpdate, metadataToUpdate, namespace, null, null).get();
-
-        Thread.sleep(10000);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -428,7 +414,7 @@ public class UpdateFetchAndQueryServerlessTest {
             Collections.sort(actualSparseValues);
             Collections.sort(expectedSparseValues);
             assertEquals(expectedSparseValues, actualSparseValues);
-        });
+        }, 4);
     }
 
     @Test
@@ -445,8 +431,6 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace).get();
         }
 
-        Thread.sleep(10000);
-
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
@@ -454,7 +438,7 @@ public class UpdateFetchAndQueryServerlessTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 4);
 
         // Update required fields only but with incorrect values dimension
         String idToUpdate = upsertIds.get(0);
@@ -502,8 +486,6 @@ public class UpdateFetchAndQueryServerlessTest {
                             .build())
                     .build();
 
-            Thread.sleep(10000);
-
             assertWithRetry(() -> {
                 QueryResponseWithUnsignedIndices queryResponse = asyncIndex.queryByVectorId(3,
                         upsertIds.get(0),
@@ -514,7 +496,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
                 // Verify the metadata field is correctly filtered in the query response
                 assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            });
+            }, 4);
         } catch (Exception exception) {
             throw exception;
         }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -61,6 +61,8 @@ public class UpdateFetchAndQueryServerlessTest {
             index.upsert(id, generateVectorValuesByDimension(3), namespace);
         }
 
+        Thread.sleep(10000);
+
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = index.fetch(upsertIds, namespace);
@@ -132,6 +134,8 @@ public class UpdateFetchAndQueryServerlessTest {
             }
         });
 
+        Thread.sleep(10000);
+
         String idToUpdate = upsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(101F, 102F, 103F);
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
@@ -195,7 +199,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace);
         }
 
-        Thread.sleep(5000);
+        Thread.sleep(10000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -243,7 +247,7 @@ public class UpdateFetchAndQueryServerlessTest {
                         namespace);
             }
 
-            Thread.sleep(5000);
+            Thread.sleep(10000);
 
             Struct filter = Struct.newBuilder()
                     .putFields(metadataFields[0], Value.newBuilder()
@@ -300,7 +304,7 @@ public class UpdateFetchAndQueryServerlessTest {
             asyncIndex.upsert(id, generateVectorValuesByDimension(dimension), namespace).get();
         }
 
-        Thread.sleep(5000);
+        Thread.sleep(10000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -316,7 +320,7 @@ public class UpdateFetchAndQueryServerlessTest {
         List<Float> updatedValues = Arrays.asList(101F, 102F, 103F);
         asyncIndex.update(idToUpdate, updatedValues, null, namespace, null, null).get();
 
-        Thread.sleep(7500);
+        Thread.sleep(10000);
 
         // Query by ID to verify
         assertWithRetry(() -> {
@@ -366,7 +370,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace).get();
         }
 
-        Thread.sleep(5000);
+        Thread.sleep(10000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -389,6 +393,8 @@ public class UpdateFetchAndQueryServerlessTest {
 
         // Update required+optional fields
         asyncIndex.update(idToUpdate, valuesToUpdate, metadataToUpdate, namespace, null, null).get();
+
+        Thread.sleep(10000);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -439,7 +445,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace).get();
         }
 
-        Thread.sleep(5000);
+        Thread.sleep(10000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -496,7 +502,7 @@ public class UpdateFetchAndQueryServerlessTest {
                             .build())
                     .build();
 
-            Thread.sleep(5000);
+            Thread.sleep(10000);
 
             assertWithRetry(() -> {
                 QueryResponseWithUnsignedIndices queryResponse = asyncIndex.queryByVectorId(3,

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -227,7 +227,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void queryWithFilersSyncTest() {
+    public void queryWithFilersSyncTest() throws InterruptedException {
         // Upsert vectors with all parameters
         int dimension = 3;
         String fieldToQuery = metadataFields[0];
@@ -238,6 +238,9 @@ public class UpdateFetchAndQueryServerlessTest {
         List<String> upsertIds = getIdsList(numOfVectors);
         DescribeIndexStatsResponse describeIndexStatsResponse1 = index.describeIndexStats();
         assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
+
+        // wait for the vectors to be upserted
+        Thread.sleep(90);
 
         try {
             for (int i = 0; i < upsertIds.size(); i++) {
@@ -475,6 +478,9 @@ public class UpdateFetchAndQueryServerlessTest {
         List<String> upsertIds = getIdsList(numOfVectors);
         DescribeIndexStatsResponse describeIndexStatsResponse1 = asyncIndex.describeIndexStats(null).get();
         assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
+
+        // wait for the vectors to be upserted
+        Thread.sleep(90000);
 
         try {
             for (int i = 0; i < upsertIds.size(); i++) {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -239,9 +239,6 @@ public class UpdateFetchAndQueryServerlessTest {
         DescribeIndexStatsResponse describeIndexStatsResponse1 = index.describeIndexStats();
         assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
 
-        // wait for the vectors to be upserted
-        Thread.sleep(90000);
-
         try {
             for (int i = 0; i < upsertIds.size(); i++) {
                 index.upsert(upsertIds.get(0),
@@ -260,6 +257,9 @@ public class UpdateFetchAndQueryServerlessTest {
                                             .build()))
                             .build())
                     .build();
+
+            // wait for the vectors to be upserted
+            Thread.sleep(90000);
 
             assertWithRetry(() -> {
                 QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(3,
@@ -479,9 +479,6 @@ public class UpdateFetchAndQueryServerlessTest {
         DescribeIndexStatsResponse describeIndexStatsResponse1 = asyncIndex.describeIndexStats(null).get();
         assertEquals(describeIndexStatsResponse1.getDimension(), dimension);
 
-        // wait for the vectors to be upserted
-        Thread.sleep(90000);
-
         try {
             for (int i = 0; i < upsertIds.size(); i++) {
                 asyncIndex.upsert(upsertIds.get(0),
@@ -500,6 +497,9 @@ public class UpdateFetchAndQueryServerlessTest {
                                             .build()))
                             .build())
                     .build();
+
+            // wait for the vectors to be upserted
+            Thread.sleep(90000);
 
             assertWithRetry(() -> {
                 QueryResponseWithUnsignedIndices queryResponse = asyncIndex.queryByVectorId(3,

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -61,7 +61,7 @@ public class UpdateFetchAndQueryServerlessTest {
             index.upsert(id, generateVectorValuesByDimension(3), namespace);
         }
 
-        Thread.sleep(10000);
+        Thread.sleep(90000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -124,6 +124,9 @@ public class UpdateFetchAndQueryServerlessTest {
                     generateVectorValuesByDimension(dimension),
                     namespace);
         }
+
+        // Wait for vectors to be upserted
+        Thread.sleep(90000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -196,6 +199,9 @@ public class UpdateFetchAndQueryServerlessTest {
                     generateVectorValuesByDimension(dimension),
                     namespace);
         }
+
+        // Wait for vectors to be upserted
+        Thread.sleep(90000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
@@ -297,6 +303,9 @@ public class UpdateFetchAndQueryServerlessTest {
         for (String id : upsertIds) {
             asyncIndex.upsert(id, generateVectorValuesByDimension(dimension), namespace).get();
         }
+
+        // Wait for vectors to be upserted
+        Thread.sleep(90000);
 
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -76,7 +76,7 @@ public class UpsertAndQueryServerlessTest {
         index.upsert(vectors, namespace);
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(7500);
+        Thread.sleep(10000);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -171,7 +171,7 @@ public class UpsertAndQueryServerlessTest {
         asyncIndex.upsert(vectors, namespace).get();
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(7500);
+        Thread.sleep(10000);
 
         // Query by vector to verify
         assertWithRetry(() -> {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -76,7 +76,7 @@ public class UpsertAndQueryServerlessTest {
         index.upsert(vectors, namespace);
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(90000);
+        Thread.sleep(120000);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -171,7 +171,7 @@ public class UpsertAndQueryServerlessTest {
         asyncIndex.upsert(vectors, namespace).get();
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(90000);
+        Thread.sleep(120000);
 
         // Query by vector to verify
         assertWithRetry(() -> {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -76,7 +76,7 @@ public class UpsertAndQueryServerlessTest {
         index.upsert(vectors, namespace);
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(10000);
+        Thread.sleep(90000);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -171,7 +171,7 @@ public class UpsertAndQueryServerlessTest {
         asyncIndex.upsert(vectors, namespace).get();
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(10000);
+        Thread.sleep(90000);
 
         // Query by vector to verify
         assertWithRetry(() -> {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -6,7 +6,6 @@ import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.proto.DescribeIndexStatsResponse;
-import io.pinecone.proto.UpsertResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -55,15 +54,13 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
-        int vectorCount = 0;
         for (String id : upsertIds) {
-            UpsertResponse upsertResponse = index.upsert(id,
+            index.upsert(id,
                     generateVectorValuesByDimension(dimension),
                     namespace);
-            vectorCount += upsertResponse.getUpsertedCount();
         }
 
-        int actualVectorCount = vectorCount;
+        int actualVectorCount = numOfVectors;
 
         // wait sometime for the vectors to be upserted
         Thread.sleep(120000);
@@ -78,10 +75,11 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         // Delete 1 vector
         List<String> idsToDelete = new ArrayList<>(3);
-        idsToDelete.add(upsertIds.get(0));
+        String vectorIdToDelete = upsertIds.get(0);
+        idsToDelete.add(vectorIdToDelete);
         index.delete(idsToDelete, false, namespace, emptyFilterStruct);
-        vectorCount -= idsToDelete.size();
-        int testSingleDeletedVectorCount = vectorCount;
+        numOfVectors -= idsToDelete.size();
+        int testSingleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
@@ -100,8 +98,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         index.delete(idsToDelete, false, namespace, null);
 
         // Update startVectorCount
-        vectorCount -= idsToDelete.size();
-        int testMultipleDeletedVectorCount = vectorCount;
+        numOfVectors -= idsToDelete.size();
+        int testMultipleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
@@ -119,15 +117,13 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         int numOfVectors = 3;
         String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
-        int vectorCount = 0;
         for (String id : upsertIds) {
-            UpsertResponse upsertResponse = asyncIndex.upsert(id,
+            asyncIndex.upsert(id,
                     generateVectorValuesByDimension(dimension),
                     namespace).get();
-            vectorCount += upsertResponse.getUpsertedCount();
         }
 
-        int actualVectorCount = vectorCount;
+        int actualVectorCount = numOfVectors;
 
         // wait sometime for the vectors to be upserted
         Thread.sleep(120000);
@@ -142,10 +138,11 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         // Delete 1 vector
         List<String> idsToDelete = new ArrayList<>(3);
-        idsToDelete.add(upsertIds.get(0));
+        String vectorIdToDelete = upsertIds.get(0);
+        idsToDelete.add(vectorIdToDelete);
         asyncIndex.delete(idsToDelete, false, namespace, emptyFilterStruct);
-        vectorCount -= idsToDelete.size();
-        int testSingleDeletedVectorCount = vectorCount;
+        numOfVectors -= idsToDelete.size();
+        int testSingleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
@@ -164,8 +161,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         asyncIndex.delete(idsToDelete, false, namespace, null);
 
         // Update startVectorCount
-        vectorCount -= idsToDelete.size();
-        int testMultipleDeletedVectorCount = vectorCount;
+        numOfVectors -= idsToDelete.size();
+        int testMultipleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -107,7 +107,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
             DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        });
+        }, 4);
     }
 
     @Test
@@ -170,6 +170,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
             DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        });
+        }, 4);
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -65,9 +65,11 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         int actualVectorCount = vectorCount;
 
+        Thread.sleep(7500);
+
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(null);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
 
             // verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
@@ -128,7 +130,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(null).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
 
             // verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
@@ -143,7 +145,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(emptyFilterStruct).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count should be 1 less than previous vector count since number of vectors deleted = 1
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testSingleDeletedVectorCount);
         });
@@ -163,7 +165,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(emptyFilterStruct).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
         });

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -66,7 +66,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         int actualVectorCount = vectorCount;
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(90000);
+        Thread.sleep(120000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
@@ -130,7 +130,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         int actualVectorCount = vectorCount;
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(90000);
+        Thread.sleep(120000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -65,7 +65,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         int actualVectorCount = vectorCount;
 
-        Thread.sleep(10000);
+        // wait sometime for the vectors to be upserted
+        Thread.sleep(90000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
@@ -128,7 +129,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         int actualVectorCount = vectorCount;
 
-        Thread.sleep(10000);
+        // wait sometime for the vectors to be upserted
+        Thread.sleep(90000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -65,7 +65,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         int actualVectorCount = vectorCount;
 
-        Thread.sleep(7500);
+        Thread.sleep(10000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
@@ -127,6 +127,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         }
 
         int actualVectorCount = vectorCount;
+
+        Thread.sleep(10000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertErrorTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertErrorTest.java
@@ -33,7 +33,7 @@ public class UpsertErrorTest {
         VectorServiceGrpc.VectorServiceFutureStub asyncStubMock = mock(VectorServiceGrpc.VectorServiceFutureStub.class);
 
         when(connectionMock.getBlockingStub()).thenReturn(stubMock);
-        when(connectionMock.getFutureStub()).thenReturn(asyncStubMock);
+        when(connectionMock.getAsyncStub()).thenReturn(asyncStubMock);
 
         index = new Index(connectionMock);
         asyncIndex = new AsyncIndex(connectionMock);

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -33,9 +33,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
         }
         this.connection = connection;
-        this.asyncStub = connection.getFutureStub();
+        this.asyncStub = connection.getAsyncStub();
     }
 
+    @Override
     public ListenableFuture<UpsertResponse> upsert(List<VectorWithUnsignedIndices> vectorList,
                                                    String namespace) {
         UpsertRequest upsertRequest = validateUpsertRequest(vectorList, namespace);

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -34,6 +34,7 @@ public class Index implements IndexInterface<UpsertResponse,
         this.blockingStub = connection.getBlockingStub();
     }
 
+    @Override
     public UpsertResponse upsert(List<VectorWithUnsignedIndices> vectorList,
                                  String namespace) {
         UpsertRequest upsertRequest = validateUpsertRequest(vectorList, namespace);

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -5,7 +5,6 @@ import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.FailedRequestInfo;
 import io.pinecone.exceptions.HttpErrorMapper;
 import io.pinecone.exceptions.PineconeException;
-import io.pinecone.exceptions.PineconeValidationException;
 import okhttp3.*;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -14,7 +13,7 @@ import org.openapitools.client.model.*;
 
 public class Pinecone {
 
-    private ManageIndexesApi manageIndexesApi;
+    private final ManageIndexesApi manageIndexesApi;
     private final PineconeConfig config;
 
     private Pinecone(PineconeConfig config, ManageIndexesApi manageIndexesApi) {

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -266,6 +266,8 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return describeIndexStatsRequest.build();
     }
 
+    T upsert(List<VectorWithUnsignedIndices> vectorList, String namespace);
+
     T upsert(String id, List<Float> values);
 
     T upsert(String id, List<Float> values, String namespace);

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -34,7 +34,7 @@ public class PineconeConnection implements AutoCloseable {
      */
     private VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
 
-    private VectorServiceGrpc.VectorServiceFutureStub futureStub;
+    private VectorServiceGrpc.VectorServiceFutureStub asyncStub;
 
     public PineconeConnection(PineconeConfig config) {
         this.config = config;
@@ -66,7 +66,7 @@ public class PineconeConnection implements AutoCloseable {
         channel.notifyWhenStateChanged(channel.getState(false), this::onConnectivityStateChanged);
         Metadata metadata = assembleMetadata(config);
         blockingStub = generateBlockingStub(metadata);
-        futureStub = generateFutureStub(metadata);
+        asyncStub = generateAsyncStub(metadata);
         logger.debug("created new PineconeConnection for channel: {}", channel);
     }
 
@@ -78,7 +78,7 @@ public class PineconeConnection implements AutoCloseable {
                 .withMaxOutboundMessageSize(DEFAULT_MAX_MESSAGE_SIZE);
     }
 
-    private VectorServiceGrpc.VectorServiceFutureStub generateFutureStub(Metadata metadata) {
+    private VectorServiceGrpc.VectorServiceFutureStub generateAsyncStub(Metadata metadata) {
         return VectorServiceGrpc
                 .newFutureStub(channel)
                 .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))
@@ -109,8 +109,8 @@ public class PineconeConnection implements AutoCloseable {
         return blockingStub;
     }
 
-    public VectorServiceGrpc.VectorServiceFutureStub getFutureStub() {
-        return futureStub;
+    public VectorServiceGrpc.VectorServiceFutureStub getAsyncStub() {
+        return asyncStub;
     }
 
     private void onConnectivityStateChanged() {


### PR DESCRIPTION
## Problem

1. Address vulnerability concerns for OkHttpClient
2. Remove unnecessary logging
3. Data plane tests were failing lately
4. Run CI integration tests in parallel
5. Cleanup codebase

## Solution

As a part of this PR, I have updated the OkHttpClient version to 4.12.0 to address the vulnerability concerns. Secondly, I have removed --info tag from integrationTest runs in CI because we don't need excessive logging. Next, I have cleaned up the code base and removed commented code from test files, and updated the data plane tests by adding a delay of 2 mins (120000 ms) for allowing vectors to upsert for serverless index test. Lastly, I have removed the constraint of running two tests in sequence. The configure index test is failing for now but @austin-denoble has an upcoming PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran integration tests locally and in CI.
