### PR TITLE
Poll for Index ready during cleanup in `ConfigureIndexTest`

### DIFF
--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -7,12 +7,15 @@ import io.pinecone.exceptions.PineconeNotFoundException;
 import io.pinecone.helpers.RandomStringBuilder;
 import org.junit.jupiter.api.*;
 import org.openapitools.client.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static io.pinecone.helpers.IndexManager.waitUntilIndexIsReady;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConfigureIndexTest {
+    private static final Logger logger = LoggerFactory.getLogger(CollectionTest.class);
     private static Pinecone controlPlaneClient;
     private static final String indexName = RandomStringBuilder.build("configure-index", 8);;
 
@@ -153,8 +156,8 @@ public class ConfigureIndexTest {
         while (index.getStatus().getState() != IndexModelStatus.StateEnum.READY && timeWaited <= timeToWaitMs) {
             Thread.sleep(2000);
             timeWaited += 2000;
-            System.out.println("waited 2000ms for index to upgrade, time left: " + timeToWaitMs);
-            System.out.println("System model state: " + index.getStatus());
+            logger.info("waited 2000ms for index to upgrade, time left: " + timeToWaitMs);
+            logger.info("System model state: " + index.getStatus());
             index = controlPlaneClient.describeIndex(indexName);
         }
         if (!index.getStatus().getReady()) {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -30,12 +30,12 @@ public class ConfigureIndexTest {
 
     @BeforeEach
     public void beforeEach() throws InterruptedException {
-        waitUntilIndexUpgraded(indexName);
+        waitUntilIndexStateIsReady(indexName);
     }
 
     @AfterAll
     public static void cleanUp() throws InterruptedException  {
-        waitUntilIndexUpgraded(indexName);
+        waitUntilIndexStateIsReady(indexName);
         assertWithRetry(() -> controlPlaneClient.deleteIndex(indexName));
     }
 
@@ -88,7 +88,7 @@ public class ConfigureIndexTest {
             assertEquals(podSpec.getReplicas(), 3);
         });
 
-        waitUntilIndexIsReady(controlPlaneClient, indexName);
+        waitUntilIndexStateIsReady(indexName);
 
         // Scaling down
         ConfigureIndexRequestSpecPod downPod = new ConfigureIndexRequestSpecPod().replicas(1);
@@ -145,7 +145,7 @@ public class ConfigureIndexTest {
         });
     }
 
-    private static void waitUntilIndexUpgraded(String indexName) throws InterruptedException {
+    private static void waitUntilIndexStateIsReady(String indexName) throws InterruptedException {
         int timeToWaitMs = 30000;
         IndexModel index = controlPlaneClient.describeIndex(indexName);
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -147,7 +147,7 @@ public class ConfigureIndexTest {
         int timeToWaitMs = 30000;
         IndexModel index = controlPlaneClient.describeIndex(indexName);
 
-        while (index.getStatus().getState() != IndexModelStatus.StateEnum.READY || timeToWaitMs > 0) {
+        while (!index.getStatus().getReady() || timeToWaitMs > 0) {
             Thread.sleep(2000);
             timeToWaitMs -= 2000;
             index = controlPlaneClient.describeIndex(indexName);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -30,9 +30,8 @@ public class ConfigureIndexTest {
 
     @AfterAll
     public static void cleanUp() throws InterruptedException {
-        Thread.sleep(2500);
+        waitUntilIndexUpgraded(indexName);
         controlPlaneClient.deleteIndex(indexName);
-        Thread.sleep(2500);
     }
 
     @Test
@@ -96,7 +95,6 @@ public class ConfigureIndexTest {
             assertNotNull(podSpec);
             assertEquals(podSpec.getReplicas(), 1);
         });
-        waitUntilIndexUpgraded(indexName);
     }
 
     @Test
@@ -138,12 +136,11 @@ public class ConfigureIndexTest {
             assertNotNull(podSpec);
             assertEquals(podSpec.getPodType(), "p1.x2");
         });
-        waitUntilIndexUpgraded(indexName);
     }
 
     // After calling configureIndex the index needs to be upgraded which
     // can take some time. Poll for a bit until we're ready to continue operating on the index.
-    private void waitUntilIndexUpgraded(String indexName) throws InterruptedException {
+    private static void waitUntilIndexUpgraded(String indexName) throws InterruptedException {
         int timeToWaitMs = 30000;
         IndexModel index = controlPlaneClient.describeIndex(indexName);
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -36,7 +36,7 @@ public class ConfigureIndexTest {
     @AfterAll
     public static void cleanUp() throws InterruptedException  {
         waitUntilIndexUpgraded(indexName);
-        controlPlaneClient.deleteIndex(indexName);
+        assertWithRetry(() -> controlPlaneClient.deleteIndex(indexName));
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -147,17 +147,18 @@ public class ConfigureIndexTest {
 
     private static void waitUntilIndexStateIsReady(String indexName) throws InterruptedException {
         int timeToWaitMs = 30000;
+        int timeWaited = 0;
         IndexModel index = controlPlaneClient.describeIndex(indexName);
 
-        while (index.getStatus().getState() != IndexModelStatus.StateEnum.READY && timeToWaitMs > 0) {
+        while (index.getStatus().getState() != IndexModelStatus.StateEnum.READY && timeWaited <= timeToWaitMs) {
             Thread.sleep(2000);
-            timeToWaitMs -= 2000;
+            timeWaited += 2000;
             System.out.println("waited 2000ms for index to upgrade, time left: " + timeToWaitMs);
             System.out.println("System model state: " + index.getStatus());
             index = controlPlaneClient.describeIndex(indexName);
         }
         if (!index.getStatus().getReady()) {
-            fail("Index " + indexName + " did not finish upgrading after " + timeToWaitMs + "ms");
+            fail("Index " + indexName + " did not finish upgrading after " + timeWaited + "ms");
         }
     }
 }


### PR DESCRIPTION
## Problem
We've started seeing consistent failures with the `ConfigureIndexTest`. 

The issue we're seeing is we're trying to delete the index before it has finished upgrading:
![Screenshot 2024-03-27 at 11 45 30 AM](https://github.com/pinecone-io/pinecone-java-client/assets/119623786/405c85b6-a58e-4751-827d-b9f29de43c02)

```
io.pinecone.exceptions.PineconeBadRequestException: {"error":{"code":"INVALID_ARGUMENT","message":"Bad request: Cannot delete an index that is upgrading"},"status":400}
	at io.pinecone.exceptions.HttpErrorMapper.mapHttpStatusError(HttpErrorMapper.java:9)
	at io.pinecone.clients.Pinecone.handleApiException(Pinecone.java:167)
	at io.pinecone.clients.Pinecone.deleteIndex(Pinecone.java:111)
	at io.pinecone.integration.controlPlane.pod.ConfigureIndexTest.cleanUp(ConfigureIndexTest.java:34)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        ...
```
Initially, I tried implementing polling using `waitUntilIndexIsReady()` before each test and when cleaning up the index to make sure we're not trying to operate on an `Upgrading` index. I noticed that there are times when an index is marked as `ready:true` but `state=Initializing` which seems to cause problems.

## Solution
I've added a `waitUntilIndexUpgraded` function to `ConfigureIndexTest`. This ensures that we're waiting for the index to return to a `Ready` state before sending additional requests or deleting.

![Screenshot 2024-03-27 at 12 03 34 PM](https://github.com/pinecone-io/pinecone-java-client/assets/119623786/0dc3356d-74aa-4679-a7e2-33f95c8a6e20)

## Type of Change
- [X] Infrastructure change (CI configs, testing)

## Test Plan

Describe specific steps for validating this change.
