### PR TITLE
Update gRPC version to 1.60.2 to address vulnerability concerns and fix data plane integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ sourceSets {
     }
 }
 
-def grpcVersion = '1.58.0'
+def grpcVersion = '1.60.2'
 
 dependencies {
     api "io.grpc:grpc-protobuf:${grpcVersion}"
@@ -46,16 +46,16 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
     implementation 'com.google.code.gson:gson:2.9.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
     implementation 'io.gsonfire:gson-fire:1.8.5'
     implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
     implementation 'com.google.protobuf:protobuf-java:3.25.2'
     compileOnly "org.apache.tomcat:annotations-api:6.0.53" // necessary for Java 9+
 
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"
     testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation 'org.mockito:mockito-inline:4.8.0'

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -35,9 +35,10 @@ public class IndexManager {
         }
 
         for (IndexModel indexModel : indexModels) {
-            if (indexModel.getDimension() == dimension
-                && (indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_POD) && indexModel.getSpec().getPod() != null)
-                || (indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_SERVERLESS) && indexModel.getSpec().getServerless() != null)
+            // Sparse-dense is only supported with DOTPRODUCT
+            if (indexModel.getDimension() == dimension && indexModel.getMetric() == IndexMetric.DOTPRODUCT
+                && ((indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_POD) && indexModel.getSpec().getPod() != null)
+                || (indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_SERVERLESS) && indexModel.getSpec().getServerless() != null))
             ) {
                 return indexModel.getName();
             }
@@ -63,7 +64,7 @@ public class IndexManager {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest()
                 .name(indexName)
                 .dimension(dimension)
-                .metric(IndexMetric.DOTPRODUCT)
+                .metric(IndexMetric.DOTPRODUCT) // Sparse-dense is only supported with DOTPRODUCT
                 .spec(createIndexRequestSpec);
         pinecone.createIndex(createIndexRequest);
 

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -75,7 +75,7 @@ public class UpdateFetchAndQueryServerlessTest {
         }
 
         // wait sometime for the vectors to be upserted
-         Thread.sleep(120000);
+         Thread.sleep(90000);
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -74,7 +74,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     namespace);
         }
 
-        // wait sometime for the vectors to be upserted
+        // wait sometime for the vectors to be updated
          Thread.sleep(90000);
     }
 

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -76,7 +76,7 @@ public class UpsertAndQueryServerlessTest {
         index.upsert(vectors, namespace);
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(120000);
+        Thread.sleep(90000);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -171,7 +171,7 @@ public class UpsertAndQueryServerlessTest {
         asyncIndex.upsert(vectors, namespace).get();
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(120000);
+        Thread.sleep(90000);
 
         // Query by vector to verify
         assertWithRetry(() -> {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -23,41 +23,43 @@ import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpsertDescribeIndexStatsAndDeletePodTest {
-    private static Pinecone pineconeClient;
-    private static String indexName;
-    private static Index indexClient;
-    private static AsyncIndex asyncIndexClient;
+    private static Index index;
+    private static AsyncIndex asyncIndex;
     private static final int dimension = 3;
     private static final Struct nullFilterStruct = null;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         AbstractMap.SimpleEntry<String, Pinecone> indexAndClient = createIndexIfNotExistsDataPlane(dimension, IndexModelSpec.SERIALIZED_NAME_POD);
-        indexName = indexAndClient.getKey();
-        pineconeClient = indexAndClient.getValue();
-        indexClient = pineconeClient.createIndexConnection(indexName);
-        asyncIndexClient = pineconeClient.createAsyncIndexConnection(indexName);
+        String indexName = indexAndClient.getKey();
+        Pinecone pineconeClient = indexAndClient.getValue();
+        index = pineconeClient.createIndexConnection(indexName);
+        asyncIndex = pineconeClient.createAsyncIndexConnection(indexName);
     }
 
     @Test
     public void upsertVectorsAndDeleteByIdSyncTest() throws InterruptedException {
         // Upsert vectors with required parameters
+        int dimension = 3;
+        Struct emptyFilterStruct = null;
         int numOfVectors = 3;
+
         String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
-        int vectorCount = 0;
         for (String id : upsertIds) {
-            UpsertResponse upsertResponse = indexClient.upsert(id,
+            index.upsert(id,
                     generateVectorValuesByDimension(dimension),
                     namespace);
-            vectorCount += upsertResponse.getUpsertedCount();
         }
 
-        int actualVectorCount = vectorCount;
+        int actualVectorCount = numOfVectors;
+
+        // wait sometime for the vectors to be upserted
+        Thread.sleep(10000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = indexClient.describeIndexStats(null);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
 
             // verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
@@ -65,14 +67,15 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
 
         // Delete 1 vector
         List<String> idsToDelete = new ArrayList<>(3);
-        idsToDelete.add(upsertIds.get(0));
-        indexClient.delete(idsToDelete, false, namespace, nullFilterStruct);
-        vectorCount -= idsToDelete.size();
-        int testSingleDeletedVectorCount = vectorCount;
+        String vectorIdToDelete = upsertIds.get(0);
+        idsToDelete.add(vectorIdToDelete);
+        index.delete(idsToDelete, false, namespace, emptyFilterStruct);
+        numOfVectors -= idsToDelete.size();
+        int testSingleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = indexClient.describeIndexStats(nullFilterStruct);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
             // Verify the updated vector count should be 1 less than previous vector count since number of vectors deleted = 1
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testSingleDeletedVectorCount);
         });
@@ -84,18 +87,18 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         idsToDelete.add(upsertIds.get(2));
 
         // Delete multiple vectors
-        indexClient.delete(idsToDelete, false, namespace, null);
+        index.delete(idsToDelete, false, namespace, null);
 
         // Update startVectorCount
-        vectorCount -= idsToDelete.size();
-        int testMultipleDeletedVectorCount = vectorCount;
+        numOfVectors -= idsToDelete.size();
+        int testMultipleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = indexClient.describeIndexStats(nullFilterStruct);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        });
+        }, 4);
     }
 
     @Test
@@ -104,25 +107,22 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
 
-        int vectorCount = 0;
         // Upsert vectors with required + optional and custom metadata parameters
         for (int i=0; i<upsertIds.size(); i++) {
-            UpsertResponse upsertResponse = indexClient.upsert(upsertIds.get(i),
+            UpsertResponse upsertResponse = index.upsert(upsertIds.get(i),
                     generateVectorValuesByDimension(dimension),
                     generateSparseIndicesByDimension(dimension),
                     generateVectorValuesByDimension(dimension),
                     generateMetadataStruct(i, i),
                     namespace);
-            vectorCount += upsertResponse.getUpsertedCount();
         }
 
-        int actualVectorCount = vectorCount;
         // Verify the vectors are upserts
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = indexClient.describeIndexStats(nullFilterStruct);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(nullFilterStruct);
             // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
+            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), numOfVectors);
         });
 
         String fieldToDelete = metadataFields[0];
@@ -137,40 +137,41 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
                 .build();
 
         // Delete by filtering
-        indexClient.delete(new ArrayList<>(), false, namespace, filterStruct);
+        index.delete(new ArrayList<>(), false, namespace, filterStruct);
 
         // Update startVectorCount
-        int updatedVectorCount = actualVectorCount - 1;
+        int updatedVectorCount = numOfVectors - 1;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = indexClient.describeIndexStats(nullFilterStruct);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(nullFilterStruct);
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), updatedVectorCount);
         });
     }
 
-    // ToDo: Update when future stub changes are in
     @Test
     public void upsertVectorsAndDeleteByIdFutureTest() throws InterruptedException, ExecutionException {
         // Upsert vectors with required parameters
+        int dimension = 3;
+        Struct emptyFilterStruct = null;
         int numOfVectors = 3;
         String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
-
-        int vectorCount = 0;
         for (String id : upsertIds) {
-            UpsertResponse upsertResponse = asyncIndexClient.upsert(id,
+            asyncIndex.upsert(id,
                     generateVectorValuesByDimension(dimension),
                     namespace).get();
-            vectorCount += upsertResponse.getUpsertedCount();
         }
 
-        int actualVectorCount = vectorCount;
+        int actualVectorCount = numOfVectors;
+
+        // wait sometime for the vectors to be upserted
+        Thread.sleep(10000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndexClient.describeIndexStats(null).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
 
             // verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
@@ -178,14 +179,15 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
 
         // Delete 1 vector
         List<String> idsToDelete = new ArrayList<>(3);
-        idsToDelete.add(upsertIds.get(0));
-        asyncIndexClient.delete(idsToDelete, false, namespace, nullFilterStruct);
-        vectorCount -= idsToDelete.size();
-        int testSingleDeletedVectorCount = vectorCount;
+        String vectorIdToDelete = upsertIds.get(0);
+        idsToDelete.add(vectorIdToDelete);
+        asyncIndex.delete(idsToDelete, false, namespace, emptyFilterStruct);
+        numOfVectors -= idsToDelete.size();
+        int testSingleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndexClient.describeIndexStats(nullFilterStruct).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count should be 1 less than previous vector count since number of vectors deleted = 1
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testSingleDeletedVectorCount);
         });
@@ -197,18 +199,18 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         idsToDelete.add(upsertIds.get(2));
 
         // Delete multiple vectors
-        asyncIndexClient.delete(idsToDelete, false, namespace, null);
+        asyncIndex.delete(idsToDelete, false, namespace, null);
 
         // Update startVectorCount
-        vectorCount -= idsToDelete.size();
-        int testMultipleDeletedVectorCount = vectorCount;
+        numOfVectors -= idsToDelete.size();
+        int testMultipleDeletedVectorCount = numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndexClient.describeIndexStats(nullFilterStruct).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        });
+        }, 4);
     }
 
     @Test
@@ -217,25 +219,22 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
 
-        int vectorCount = 0;
         // Upsert vectors with required + optional and custom metadata parameters
         for (int i=0; i<upsertIds.size(); i++) {
-            UpsertResponse upsertResponse = asyncIndexClient.upsert(upsertIds.get(i),
+            UpsertResponse upsertResponse = asyncIndex.upsert(upsertIds.get(i),
                     generateVectorValuesByDimension(dimension),
                     generateSparseIndicesByDimension(dimension),
                     generateVectorValuesByDimension(dimension),
                     generateMetadataStruct(i, i),
                     namespace).get();
-            vectorCount += upsertResponse.getUpsertedCount();
         }
 
-        int actualVectorCount = vectorCount;
         // Verify the vectors are upserts
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndexClient.describeIndexStats(nullFilterStruct).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(nullFilterStruct).get();
             // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
+            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), numOfVectors);
         });
 
         String fieldToDelete = metadataFields[0];
@@ -250,14 +249,14 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
                 .build();
 
         // Delete by filtering
-        asyncIndexClient.delete(new ArrayList<>(), false, namespace, filterStruct).get();
+        asyncIndex.delete(new ArrayList<>(), false, namespace, filterStruct).get();
 
         // Update startVectorCount
-        int updatedVectorCount = actualVectorCount - 1;
+        int updatedVectorCount = numOfVectors - 1;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndexClient.describeIndexStats(nullFilterStruct).get();
+            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(nullFilterStruct).get();
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), updatedVectorCount);
         });

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -63,7 +63,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         int actualVectorCount = numOfVectors;
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(120000);
+        Thread.sleep(90000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
@@ -126,7 +126,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         int actualVectorCount = numOfVectors;
 
         // wait sometime for the vectors to be upserted
-        Thread.sleep(120000);
+        Thread.sleep(90000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count


### PR DESCRIPTION
## Problem
1. The gRPC netty version 1.58.0 has vulnerability. 
2. I was still seeing some failing CI tests for data plane operations.

## Solution

Updated the following dependencies version from 1.58.0 to 1.60.2.
"io.grpc:grpc-protobuf"
"io.grpc:grpc-stub"
"io.grpc:grpc-netty"

Compatibility matrix for `grpc-netty` and `netty-tcnative-boringssl-static` can be found here: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty

Also as a part of this PR, I have reduced the delay that is set after upserting vectors in the integration tests to 90 seconds instead of 120 seconds and for updateAndQueryPodTest, I have followed the same pattern as serverless indexes to upsert once and run all of the tests after the upsertion. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: (explain here)
Dependencies were updated so it doesn't qualify for bug fix but instead security fix.

## Test Plan

Ran integration tests on local a good couple of times and on the CI. Fixing configure index test is in flight and will be a future PR from @austin-denoble.
