### PR TITLE
Add concurrent HashMap for storing indexNames and connection objects

### DIFF
--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -122,7 +122,7 @@ public class IndexManager {
         // wait a bit more before we connect...
         Thread.sleep(5000);
 
-        return pinecone.createIndexConnection(indexName);
+        return pinecone.getIndexConnection(indexName);
     }
 
     public static CollectionModel createCollection(Pinecone pinecone, String collectionName, String indexName, boolean waitUntilReady) throws InterruptedException {

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -181,7 +181,7 @@ public class TestIndexResourcesManager {
 
     private void seedIndex(List<String> vectorIds, String indexName) throws InterruptedException {
         // Build upsert request
-        Index indexClient = pineconeClient.createIndexConnection(indexName);
+        Index indexClient = pineconeClient.getIndexConnection(indexName);
         indexClient.upsert(buildRequiredUpsertRequestByDimension(vectorIds, dimension), "");
 
         // Wait for record freshness

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -2,7 +2,6 @@ package io.pinecone.integration.controlPlane.pod;
 
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
-import io.pinecone.configs.*;
 import io.pinecone.exceptions.PineconeException;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.proto.*;
@@ -139,7 +138,7 @@ public class CollectionTest {
         // If the index is ready, validate contents
         if (indexDescription.getStatus().getReady()) {
             // Set up new index data plane connection
-            Index indexClient = pineconeClient.createIndexConnection(newIndexName);
+            Index indexClient = pineconeClient.getIndexConnection(newIndexName);
 
             assertWithRetry(() -> {
                 DescribeIndexStatsResponse describeResponse = indexClient.describeIndexStats();

--- a/src/integration/java/io/pinecone/integration/dataPlane/QueryErrorTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/QueryErrorTest.java
@@ -2,7 +2,6 @@ package io.pinecone.integration.dataPlane;
 
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.VectorServiceGrpc;
@@ -26,7 +25,6 @@ public class QueryErrorTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         PineconeConnection connectionMock = mock(PineconeConnection.class);
-        Pinecone pineconeMock = mock(Pinecone.class);
 
         VectorServiceGrpc.VectorServiceBlockingStub stubMock = mock(VectorServiceGrpc.VectorServiceBlockingStub.class);
         VectorServiceGrpc.VectorServiceFutureStub asyncStubMock = mock(VectorServiceGrpc.VectorServiceFutureStub.class);
@@ -34,8 +32,8 @@ public class QueryErrorTest {
         when(connectionMock.getBlockingStub()).thenReturn(stubMock);
         when(connectionMock.getAsyncStub()).thenReturn(asyncStubMock);
 
-        index = new Index(pineconeMock, connectionMock, "some-index-name");
-        asyncIndex = new AsyncIndex(pineconeMock, connectionMock, "some-index-name");
+        index = new Index(connectionMock, "some-index-name");
+        asyncIndex = new AsyncIndex(connectionMock, "some-index-name");
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/QueryErrorTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/QueryErrorTest.java
@@ -2,6 +2,7 @@ package io.pinecone.integration.dataPlane;
 
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
+import io.pinecone.clients.Pinecone;
 import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.VectorServiceGrpc;
@@ -25,6 +26,7 @@ public class QueryErrorTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         PineconeConnection connectionMock = mock(PineconeConnection.class);
+        Pinecone pineconeMock = mock(Pinecone.class);
 
         VectorServiceGrpc.VectorServiceBlockingStub stubMock = mock(VectorServiceGrpc.VectorServiceBlockingStub.class);
         VectorServiceGrpc.VectorServiceFutureStub asyncStubMock = mock(VectorServiceGrpc.VectorServiceFutureStub.class);
@@ -32,8 +34,8 @@ public class QueryErrorTest {
         when(connectionMock.getBlockingStub()).thenReturn(stubMock);
         when(connectionMock.getAsyncStub()).thenReturn(asyncStubMock);
 
-        index = new Index(connectionMock);
-        asyncIndex = new AsyncIndex(connectionMock);
+        index = new Index(pineconeMock, connectionMock, "some-index-name");
+        asyncIndex = new AsyncIndex(pineconeMock, connectionMock, "some-index-name");
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -42,8 +42,8 @@ public class UpdateFetchAndQueryPodTest {
 
         String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
         if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
-        index = pinecone.createIndexConnection(indexName);
-        asyncIndex = pinecone.createAsyncIndexConnection(indexName);
+        index = pinecone.getIndexConnection(indexName);
+        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
 
         // Upsert vectors only once
         int numOfVectors = 3;

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -44,8 +44,8 @@ public class UpdateFetchAndQueryServerlessTest {
 
         String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
         if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
-        index = pinecone.createIndexConnection(indexName);
-        asyncIndex = pinecone.createAsyncIndexConnection(indexName);
+        index = pinecone.getIndexConnection(indexName);
+        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
 
         // Upsert vectors only once
         int numOfVectors = 3;

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -35,8 +35,8 @@ public class UpsertAndQueryPodTest {
         AbstractMap.SimpleEntry<String, Pinecone> indexAndClient = createIndexIfNotExistsDataPlane(dimension, IndexModelSpec.SERIALIZED_NAME_POD);
         indexName = indexAndClient.getKey();
         pineconeClient = indexAndClient.getValue();
-        indexClient = pineconeClient.createIndexConnection(indexName);
-        asyncIndexClient = pineconeClient.createAsyncIndexConnection(indexName);
+        indexClient = pineconeClient.getIndexConnection(indexName);
+        asyncIndexClient = pineconeClient.getAsyncIndexConnection(indexName);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -40,8 +40,8 @@ public class UpsertAndQueryServerlessTest {
 
         String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
         if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
-        index = pinecone.createIndexConnection(indexName);
-        asyncIndex = pinecone.createAsyncIndexConnection(indexName);
+        index = pinecone.getIndexConnection(indexName);
+        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -33,8 +33,8 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         AbstractMap.SimpleEntry<String, Pinecone> indexAndClient = createIndexIfNotExistsDataPlane(dimension, IndexModelSpec.SERIALIZED_NAME_POD);
         String indexName = indexAndClient.getKey();
         Pinecone pineconeClient = indexAndClient.getValue();
-        index = pineconeClient.createIndexConnection(indexName);
-        asyncIndex = pineconeClient.createAsyncIndexConnection(indexName);
+        index = pineconeClient.getIndexConnection(indexName);
+        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -35,8 +35,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
 
         String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
         if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
-        index = pinecone.createIndexConnection(indexName);
-        asyncIndex = pinecone.createAsyncIndexConnection(indexName);
+        index = pinecone.getIndexConnection(indexName);
+        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertErrorTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertErrorTest.java
@@ -2,7 +2,6 @@ package io.pinecone.integration.dataPlane;
 
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.PineconeException;
 import io.pinecone.exceptions.PineconeValidationException;
@@ -29,7 +28,6 @@ public class UpsertErrorTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         PineconeConnection connectionMock = mock(PineconeConnection.class);
-        Pinecone pineconeMock = mock(Pinecone.class);
 
         VectorServiceGrpc.VectorServiceBlockingStub stubMock = mock(VectorServiceGrpc.VectorServiceBlockingStub.class);
         VectorServiceGrpc.VectorServiceFutureStub asyncStubMock = mock(VectorServiceGrpc.VectorServiceFutureStub.class);
@@ -37,8 +35,8 @@ public class UpsertErrorTest {
         when(connectionMock.getBlockingStub()).thenReturn(stubMock);
         when(connectionMock.getAsyncStub()).thenReturn(asyncStubMock);
 
-        index = new Index(pineconeMock, connectionMock, "some-index-name");
-        asyncIndex = new AsyncIndex(pineconeMock, connectionMock, "some-index-name");
+        index = new Index(connectionMock, "some-index-name");
+        asyncIndex = new AsyncIndex(connectionMock, "some-index-name");
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertErrorTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertErrorTest.java
@@ -2,6 +2,7 @@ package io.pinecone.integration.dataPlane;
 
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
+import io.pinecone.clients.Pinecone;
 import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.PineconeException;
 import io.pinecone.exceptions.PineconeValidationException;
@@ -28,6 +29,7 @@ public class UpsertErrorTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         PineconeConnection connectionMock = mock(PineconeConnection.class);
+        Pinecone pineconeMock = mock(Pinecone.class);
 
         VectorServiceGrpc.VectorServiceBlockingStub stubMock = mock(VectorServiceGrpc.VectorServiceBlockingStub.class);
         VectorServiceGrpc.VectorServiceFutureStub asyncStubMock = mock(VectorServiceGrpc.VectorServiceFutureStub.class);
@@ -35,8 +37,8 @@ public class UpsertErrorTest {
         when(connectionMock.getBlockingStub()).thenReturn(stubMock);
         when(connectionMock.getAsyncStub()).thenReturn(asyncStubMock);
 
-        index = new Index(connectionMock);
-        asyncIndex = new AsyncIndex(connectionMock);
+        index = new Index(pineconeMock, connectionMock, "some-index-name");
+        asyncIndex = new AsyncIndex(pineconeMock, connectionMock, "some-index-name");
     }
 
     @Test

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -31,6 +31,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     private static final Logger logger = LoggerFactory.getLogger(AsyncIndex.class);
 
     public AsyncIndex(Pinecone pinecone, PineconeConnection connection, String indexName) {
+        if (pinecone == null) {
+            throw new PineconeValidationException("Pinecone object cannot be null.");
+        }
+
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
         }
@@ -221,7 +225,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     public void close() {
         try {
             logger.debug("closing channel");
-            pinecone.getConnectionsMap().remove(indexName);
+            pinecone.closeConnection(indexName);
             connection.getChannel().shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             logger.warn("Channel shutdown interrupted before termination confirmed");

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -25,13 +25,18 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     private final PineconeConnection connection;
     private final VectorServiceGrpc.VectorServiceFutureStub asyncStub;
+    private final Pinecone pinecone;
+    private final String indexName;
 
     private static final Logger logger = LoggerFactory.getLogger(AsyncIndex.class);
 
-    public AsyncIndex(PineconeConnection connection) {
+    public AsyncIndex(Pinecone pinecone, PineconeConnection connection, String indexName) {
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
         }
+
+        this.pinecone = pinecone;
+        this.indexName = indexName;
         this.connection = connection;
         this.asyncStub = connection.getAsyncStub();
     }
@@ -216,6 +221,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     public void close() {
         try {
             logger.debug("closing channel");
+            pinecone.getConnectionsMap().remove(indexName);
             connection.getChannel().shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             logger.warn("Channel shutdown interrupted before termination confirmed");

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -10,11 +10,8 @@ import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertResponse>,
         ListenableFuture<QueryResponseWithUnsignedIndices>,
@@ -25,21 +22,13 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     private final PineconeConnection connection;
     private final VectorServiceGrpc.VectorServiceFutureStub asyncStub;
-    private final Pinecone pinecone;
     private final String indexName;
 
-    private static final Logger logger = LoggerFactory.getLogger(AsyncIndex.class);
-
-    public AsyncIndex(Pinecone pinecone, PineconeConnection connection, String indexName) {
-        if (pinecone == null) {
-            throw new PineconeValidationException("Pinecone object cannot be null.");
-        }
-
+    public AsyncIndex(PineconeConnection connection, String indexName) {
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
         }
 
-        this.pinecone = pinecone;
         this.indexName = indexName;
         this.connection = connection;
         this.asyncStub = connection.getAsyncStub();
@@ -223,12 +212,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      */
     @Override
     public void close() {
-        try {
-            logger.debug("closing channel");
-            pinecone.closeConnection(indexName);
-            connection.getChannel().shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            logger.warn("Channel shutdown interrupted before termination confirmed");
-        }
+        Pinecone.closeConnection(indexName);
+        connection.close();
     }
 }

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -215,12 +215,4 @@ public class Index implements IndexInterface<UpsertResponse,
             logger.warn("Channel shutdown interrupted before termination confirmed");
         }
     }
-
-    PineconeConnection getConnection() {
-        return this.connection;
-    }
-
-    String getIndexName() {
-        return this.indexName;
-    }
 }

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -7,11 +7,8 @@ import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class Index implements IndexInterface<UpsertResponse,
         QueryResponseWithUnsignedIndices,
@@ -21,23 +18,15 @@ public class Index implements IndexInterface<UpsertResponse,
         DescribeIndexStatsResponse> {
 
     private final PineconeConnection connection;
-    private final Pinecone pinecone;
     private final String indexName;
     private final VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
 
-    private static final Logger logger = LoggerFactory.getLogger(Index.class);
-
-    public Index(Pinecone pinecone, PineconeConnection connection, String indexName) {
-        if (pinecone == null) {
-            throw new PineconeValidationException("Pinecone object cannot be null.");
-        }
-
+    public Index(PineconeConnection connection, String indexName) {
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
         }
 
         this.connection = connection;
-        this.pinecone = pinecone;
         this.indexName = indexName;
         this.blockingStub = connection.getBlockingStub();
     }
@@ -211,12 +200,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     @Override
     public void close() {
-        try {
-            logger.debug("closing channel");
-            pinecone.closeConnection(indexName);
-            connection.getChannel().shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            logger.warn("Channel shutdown interrupted before termination confirmed");
-        }
+        Pinecone.closeConnection(indexName);
+        connection.close();
     }
 }

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -28,6 +28,10 @@ public class Index implements IndexInterface<UpsertResponse,
     private static final Logger logger = LoggerFactory.getLogger(Index.class);
 
     public Index(Pinecone pinecone, PineconeConnection connection, String indexName) {
+        if (pinecone == null) {
+            throw new PineconeValidationException("Pinecone object cannot be null.");
+        }
+
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
         }
@@ -209,7 +213,7 @@ public class Index implements IndexInterface<UpsertResponse,
     public void close() {
         try {
             logger.debug("closing channel");
-            pinecone.getConnectionsMap().remove(indexName);
+            pinecone.closeConnection(indexName);
             connection.getChannel().shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             logger.warn("Channel shutdown interrupted before termination confirmed");

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -159,11 +159,12 @@ public class Pinecone {
     }
 
     public AsyncIndex getAsyncIndexConnection(String indexName) {
+        config.setHost(getIndexHost(indexName));
         PineconeConnection connection = getConnection(indexName);
         return new AsyncIndex(this, connection, indexName);
     }
 
-    private PineconeConnection getConnection(String indexName) {
+    PineconeConnection getConnection(String indexName) {
         return connectionsMap.computeIfAbsent(indexName, key -> new PineconeConnection(config));
     }
 

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -19,7 +19,7 @@ public class Pinecone {
     private final PineconeConfig config;
     private static final ConcurrentHashMap<String, PineconeConnection> connectionsMap = new ConcurrentHashMap<>();
 
-    private Pinecone(PineconeConfig config, ManageIndexesApi manageIndexesApi) {
+    Pinecone(PineconeConfig config, ManageIndexesApi manageIndexesApi) {
         this.config = config;
         this.manageIndexesApi = manageIndexesApi;
     }
@@ -152,13 +152,13 @@ public class Pinecone {
         }
     }
 
-    public Index createIndexConnection(String indexName) {
+    public Index getIndexConnection(String indexName) {
         config.setHost(getIndexHost(indexName));
         PineconeConnection connection = getConnection(indexName);
         return new Index(this, connection, indexName);
     }
 
-    public AsyncIndex createAsyncIndexConnection(String indexName) {
+    public AsyncIndex getAsyncIndexConnection(String indexName) {
         PineconeConnection connection = getConnection(indexName);
         return new AsyncIndex(this, connection, indexName);
     }

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -176,6 +176,10 @@ public class Pinecone {
         return this.describeIndex(indexName).getHost();
     }
 
+    void closeConnection(String indexName) {
+        connectionsMap.remove(indexName);
+    }
+
     private void handleApiException(ApiException apiException) throws PineconeException {
         int statusCode = apiException.getCode();
         String responseBody = apiException.getResponseBody();

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -5,6 +5,7 @@ import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.FailedRequestInfo;
 import io.pinecone.exceptions.HttpErrorMapper;
 import io.pinecone.exceptions.PineconeException;
+import io.pinecone.exceptions.PineconeValidationException;
 import okhttp3.*;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -153,15 +154,23 @@ public class Pinecone {
     }
 
     public Index getIndexConnection(String indexName) {
+        if(indexName == null || indexName.isEmpty()) {
+            throw new PineconeValidationException("Index name cannot be null or empty");
+        }
+
         config.setHost(getIndexHost(indexName));
         PineconeConnection connection = getConnection(indexName);
-        return new Index(this, connection, indexName);
+        return new Index(connection, indexName);
     }
 
     public AsyncIndex getAsyncIndexConnection(String indexName) {
+        if(indexName == null || indexName.isEmpty()) {
+            throw new PineconeValidationException("Index name cannot be null or empty");
+        }
+
         config.setHost(getIndexHost(indexName));
         PineconeConnection connection = getConnection(indexName);
-        return new AsyncIndex(this, connection, indexName);
+        return new AsyncIndex(connection, indexName);
     }
 
     PineconeConnection getConnection(String indexName) {
@@ -176,7 +185,7 @@ public class Pinecone {
         return this.describeIndex(indexName).getHost();
     }
 
-    void closeConnection(String indexName) {
+    static void closeConnection(String indexName) {
         connectionsMap.remove(indexName);
     }
 

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -6,7 +6,6 @@ import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.MetadataUtils;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeException;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.proto.VectorServiceGrpc;
@@ -43,19 +42,6 @@ public class PineconeConnection implements AutoCloseable {
         } else {
             if (config.getHost() == null || config.getHost().isEmpty()) {
                 throw new PineconeValidationException("Index-name or host is required for data plane operations");
-            }
-            channel = buildChannel(config.getHost());
-        }
-        initialize();
-    }
-
-    public PineconeConnection(PineconeConfig config, String indexName) {
-        this.config = config;
-        if (config.getCustomManagedChannel() != null) {
-            channel = config.getCustomManagedChannel();
-        } else {
-            if (config.getHost() == null || config.getHost().isEmpty()) {
-                config.setHost(getHost(config.getApiKey(), indexName));
             }
             channel = buildChannel(config.getHost());
         }
@@ -146,10 +132,5 @@ public class PineconeConnection implements AutoCloseable {
         } else {
             throw new PineconeValidationException("Index host cannot be null or empty");
         }
-    }
-
-    private static String getHost(String apiKey, String indexName) {
-        Pinecone controlPlaneClient = new Pinecone.Builder(apiKey).build();
-        return controlPlaneClient.describeIndex(indexName).getHost();
     }
 }

--- a/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -1,0 +1,73 @@
+package io.pinecone.clients;
+
+import io.pinecone.configs.PineconeConnection;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConnectionsMapTest {
+
+    @Test
+    public void testConnectionsMapConcurrency() throws InterruptedException {
+        final int numThreads = 10;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+        final Pinecone pinecone = new Pinecone.Builder("testApiKey").build();
+
+        for (int i = 0; i < numThreads; i++) {
+            executorService.submit(() -> {
+                String indexName = "testIndex";
+                Index index = pinecone.createIndexConnection(indexName);
+                PineconeConnection retrievedConnection = pinecone.getConnectionsMap().get(indexName);
+                assertEquals(index.getConnection(), retrievedConnection);
+                index.close();
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(7, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testMultiplePineconeInstances() {
+        Pinecone pinecone1 = mock(Pinecone.class);
+        Pinecone pinecone2 = mock(Pinecone.class);
+
+        assertNotSame(pinecone1, pinecone2);
+
+        // Tests for blocking indexes
+        Index index1 = mock(Index.class);
+        Index index2 = mock(Index.class);
+
+        when(pinecone1.createIndexConnection("index1")).thenReturn(index1);
+        when(pinecone2.createIndexConnection("index2")).thenReturn(index2);
+
+        Index resultIndex1 = pinecone1.createIndexConnection("index1");
+        Index resultIndex2 = pinecone2.createIndexConnection("index2");
+
+        verify(pinecone1).createIndexConnection("index1");
+        verify(pinecone2).createIndexConnection("index2");
+        assertNotSame(resultIndex1, resultIndex2);
+
+        // Tests for asyncIndexes
+        AsyncIndex asyncIndex1 = mock(AsyncIndex.class);
+        AsyncIndex asyncIndex2 = mock(AsyncIndex.class);
+
+        when(pinecone1.createAsyncIndexConnection("index1")).thenReturn(asyncIndex1);
+        when(pinecone2.createAsyncIndexConnection("index2")).thenReturn(asyncIndex2);
+
+        AsyncIndex resultAsyncIndex1 = pinecone1.createAsyncIndexConnection("index1");
+        AsyncIndex resultAsyncIndex2 = pinecone2.createAsyncIndexConnection("index2");
+
+        // Verify that the correct methods were called and the returned Index instances are not the same
+        verify(pinecone1).createAsyncIndexConnection("index1");
+        verify(pinecone2).createAsyncIndexConnection("index2");
+        assertNotSame(resultAsyncIndex1, resultAsyncIndex2);
+    }
+
+    // ToDo: add more tests
+    // verify the connection is removed when index.close() and asyncIndex.close() are called
+}

--- a/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -1,9 +1,11 @@
 package io.pinecone.clients;
 
-import io.pinecone.configs.PineconeConnection;
+import io.pinecone.configs.PineconeConfig;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.*;
+import org.mockito.Mockito;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.api.ManageIndexesApi;
+import org.openapitools.client.model.IndexModel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -12,27 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ConnectionsMapTest {
 
     @Test
-    public void testConnectionsMapConcurrency() throws InterruptedException {
-        final int numThreads = 10;
-        final ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
-        final Pinecone pinecone = new Pinecone.Builder("testApiKey").build();
-
-        for (int i = 0; i < numThreads; i++) {
-            executorService.submit(() -> {
-                String indexName = "testIndex";
-                Index index = pinecone.createIndexConnection(indexName);
-                PineconeConnection retrievedConnection = pinecone.getConnectionsMap().get(indexName);
-                assertEquals(index.getConnection(), retrievedConnection);
-                index.close();
-            });
-        }
-
-        executorService.shutdown();
-        executorService.awaitTermination(7, TimeUnit.SECONDS);
-    }
-
-    @Test
-    public void testMultiplePineconeInstances() {
+    public void testMultiplePineconeInstancesForIndexes() {
         Pinecone pinecone1 = mock(Pinecone.class);
         Pinecone pinecone2 = mock(Pinecone.class);
 
@@ -42,32 +24,95 @@ public class ConnectionsMapTest {
         Index index1 = mock(Index.class);
         Index index2 = mock(Index.class);
 
-        when(pinecone1.createIndexConnection("index1")).thenReturn(index1);
-        when(pinecone2.createIndexConnection("index2")).thenReturn(index2);
+        when(pinecone1.getIndexConnection("index1")).thenReturn(index1);
+        when(pinecone2.getIndexConnection("index2")).thenReturn(index2);
 
-        Index resultIndex1 = pinecone1.createIndexConnection("index1");
-        Index resultIndex2 = pinecone2.createIndexConnection("index2");
+        Index resultIndex1 = pinecone1.getIndexConnection("index1");
+        Index resultIndex2 = pinecone2.getIndexConnection("index2");
 
-        verify(pinecone1).createIndexConnection("index1");
-        verify(pinecone2).createIndexConnection("index2");
+        verify(pinecone1).getIndexConnection("index1");
+        verify(pinecone2).getIndexConnection("index2");
         assertNotSame(resultIndex1, resultIndex2);
+    }
+
+    @Test
+    public void testMultiplePineconeInstancesForAsyncIndexes() {
+        Pinecone pinecone1 = mock(Pinecone.class);
+        Pinecone pinecone2 = mock(Pinecone.class);
+
+        assertNotSame(pinecone1, pinecone2);
 
         // Tests for asyncIndexes
         AsyncIndex asyncIndex1 = mock(AsyncIndex.class);
         AsyncIndex asyncIndex2 = mock(AsyncIndex.class);
 
-        when(pinecone1.createAsyncIndexConnection("index1")).thenReturn(asyncIndex1);
-        when(pinecone2.createAsyncIndexConnection("index2")).thenReturn(asyncIndex2);
+        when(pinecone1.getAsyncIndexConnection("index1")).thenReturn(asyncIndex1);
+        when(pinecone2.getAsyncIndexConnection("index2")).thenReturn(asyncIndex2);
 
-        AsyncIndex resultAsyncIndex1 = pinecone1.createAsyncIndexConnection("index1");
-        AsyncIndex resultAsyncIndex2 = pinecone2.createAsyncIndexConnection("index2");
+        AsyncIndex resultAsyncIndex1 = pinecone1.getAsyncIndexConnection("index1");
+        AsyncIndex resultAsyncIndex2 = pinecone2.getAsyncIndexConnection("index2");
 
         // Verify that the correct methods were called and the returned Index instances are not the same
-        verify(pinecone1).createAsyncIndexConnection("index1");
-        verify(pinecone2).createAsyncIndexConnection("index2");
+        verify(pinecone1).getAsyncIndexConnection("index1");
+        verify(pinecone2).getAsyncIndexConnection("index2");
         assertNotSame(resultAsyncIndex1, resultAsyncIndex2);
     }
 
-    // ToDo: add more tests
-    // verify the connection is removed when index.close() and asyncIndex.close() are called
+    @Test
+    public void testConnectionRemovedOnIndexClose() throws ApiException {
+        String host = "some-host";
+        String indexName = "test-index";
+        ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
+        IndexModel indexModel = new IndexModel();
+        indexModel.setHost(host);
+
+        PineconeConfig config = new PineconeConfig("testApiKey");
+        config.setHost(host);
+        Pinecone pinecone = new Pinecone(config, manageIndexesApi);
+
+        when(manageIndexesApi.describeIndex(indexName)).thenReturn(indexModel);
+
+        Index index = pinecone.getIndexConnection(indexName);
+
+        // Verify that the connection is present in the connections map
+        assertTrue(pinecone.getConnectionsMap().containsKey(indexName));
+
+        // Verify that the connections map size is 1
+        assertEquals(pinecone.getConnectionsMap().size(), 1);
+
+        // Connection should be removed from the connections map after closing it
+        index.close();
+
+        // Verify that the connection is removed from the connections map
+        assertFalse(pinecone.getConnectionsMap().containsKey(indexName));
+    }
+
+    @Test
+    public void testConnectionRemovedOnAsyncIndexClose() throws ApiException {
+        String host = "some-host";
+        String indexName = "test-index";
+        ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
+        IndexModel indexModel = new IndexModel();
+        indexModel.setHost(host);
+
+        PineconeConfig config = new PineconeConfig("testApiKey");
+        config.setHost(host);
+        Pinecone pinecone = new Pinecone(config, manageIndexesApi);
+
+        when(manageIndexesApi.describeIndex(indexName)).thenReturn(indexModel);
+
+        AsyncIndex asyncIndex = pinecone.getAsyncIndexConnection(indexName);
+
+        // Verify that the connection is present in the connections map
+        assertTrue(pinecone.getConnectionsMap().containsKey(indexName));
+
+        // Verify that the connections map size is 1
+        assertEquals(pinecone.getConnectionsMap().size(), 1);
+
+        // Connection should be removed from the connections map after closing it
+        asyncIndex.close();
+
+        // Verify that the connection is removed from the connections map
+        assertFalse(pinecone.getConnectionsMap().containsKey(indexName));
+    }
 }

--- a/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -15,53 +15,69 @@ public class ConnectionsMapTest {
 
     @Test
     public void testMultiplePineconeInstancesForIndexes() {
-        Pinecone pinecone1 = mock(Pinecone.class);
-        Pinecone pinecone2 = mock(Pinecone.class);
+        String host = "some-host";
+        ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
+        IndexModel indexModel = new IndexModel();
+        indexModel.setHost(host);
 
-        assertNotSame(pinecone1, pinecone2);
+        PineconeConfig config = new PineconeConfig("testApiKey");
+        config.setHost(host);
+        Pinecone pinecone1 = new Pinecone(config, manageIndexesApi);
+        Pinecone pinecone2 = new Pinecone(config, manageIndexesApi);
 
-        // Tests for blocking indexes
-        Index index1 = mock(Index.class);
-        Index index2 = mock(Index.class);
+        when(pinecone1.describeIndex("index1")).thenReturn(indexModel);
+        when(pinecone1.describeIndex("index2")).thenReturn(indexModel);
+        when(pinecone2.describeIndex("index1")).thenReturn(indexModel);
+        when(pinecone2.describeIndex("index2")).thenReturn(indexModel);
 
-        when(pinecone1.getIndexConnection("index1")).thenReturn(index1);
-        when(pinecone2.getIndexConnection("index2")).thenReturn(index2);
+        Index index1Pinecone1 = pinecone1.getIndexConnection("index1");
+        Index index1Pinecone2 = pinecone1.getIndexConnection("index2");
+        Index index2Pinecone1 = pinecone2.getIndexConnection("index1");
+        Index index2Pinecone2 = pinecone2.getIndexConnection("index2");
+        assertEquals(pinecone1.getConnectionsMap().size(), 2);
+        assertEquals(pinecone2.getConnectionsMap().size(), 2);
 
-        Index resultIndex1 = pinecone1.getIndexConnection("index1");
-        Index resultIndex2 = pinecone2.getIndexConnection("index2");
-
-        verify(pinecone1).getIndexConnection("index1");
-        verify(pinecone2).getIndexConnection("index2");
-        assertNotSame(resultIndex1, resultIndex2);
+        index1Pinecone1.close();
+        index2Pinecone1.close();
+        index1Pinecone2.close();
+        index2Pinecone2.close();
     }
 
     @Test
     public void testMultiplePineconeInstancesForAsyncIndexes() {
-        Pinecone pinecone1 = mock(Pinecone.class);
-        Pinecone pinecone2 = mock(Pinecone.class);
+        String host = "some-host";
+        ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
+        IndexModel indexModel = new IndexModel();
+        indexModel.setHost(host);
 
-        assertNotSame(pinecone1, pinecone2);
+        PineconeConfig config = new PineconeConfig("testApiKey");
+        config.setHost(host);
+        Pinecone pinecone1 = new Pinecone(config, manageIndexesApi);
+        Pinecone pinecone2 = new Pinecone(config, manageIndexesApi);
 
-        // Tests for asyncIndexes
-        AsyncIndex asyncIndex1 = mock(AsyncIndex.class);
-        AsyncIndex asyncIndex2 = mock(AsyncIndex.class);
+        when(pinecone1.describeIndex("index1")).thenReturn(indexModel);
+        when(pinecone1.describeIndex("index2")).thenReturn(indexModel);
+        when(pinecone1.describeIndex("index1")).thenReturn(indexModel);
+        when(pinecone1.describeIndex("index2")).thenReturn(indexModel);
 
-        when(pinecone1.getAsyncIndexConnection("index1")).thenReturn(asyncIndex1);
-        when(pinecone2.getAsyncIndexConnection("index2")).thenReturn(asyncIndex2);
+        AsyncIndex asyncIndex1Pinecone1 = pinecone1.getAsyncIndexConnection("index1");
+        AsyncIndex asyncIndex2Pinecone1 = pinecone1.getAsyncIndexConnection("index2");
+        AsyncIndex asyncIndex1Pinecone2 = pinecone2.getAsyncIndexConnection("index1");
+        AsyncIndex asyncIndex2Pinecone2 = pinecone2.getAsyncIndexConnection("index2");
+        assertEquals(pinecone2.getConnectionsMap().size(), 2);
+        assertEquals(pinecone2.getConnectionsMap().size(), 2);
 
-        AsyncIndex resultAsyncIndex1 = pinecone1.getAsyncIndexConnection("index1");
-        AsyncIndex resultAsyncIndex2 = pinecone2.getAsyncIndexConnection("index2");
-
-        // Verify that the correct methods were called and the returned Index instances are not the same
-        verify(pinecone1).getAsyncIndexConnection("index1");
-        verify(pinecone2).getAsyncIndexConnection("index2");
-        assertNotSame(resultAsyncIndex1, resultAsyncIndex2);
+        asyncIndex1Pinecone1.close();
+        asyncIndex2Pinecone1.close();
+        asyncIndex1Pinecone2.close();
+        asyncIndex2Pinecone2.close();
     }
 
     @Test
     public void testConnectionRemovedOnIndexClose() throws ApiException {
         String host = "some-host";
         String indexName = "test-index";
+
         ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
         IndexModel indexModel = new IndexModel();
         indexModel.setHost(host);

--- a/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/test/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -1,11 +1,14 @@
 package io.pinecone.clients;
 
 import io.pinecone.configs.PineconeConfig;
+import io.pinecone.configs.PineconeConnection;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.api.ManageIndexesApi;
 import org.openapitools.client.model.IndexModel;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -19,23 +22,35 @@ public class ConnectionsMapTest {
         ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
         IndexModel indexModel = new IndexModel();
         indexModel.setHost(host);
-
         PineconeConfig config = new PineconeConfig("testApiKey");
         config.setHost(host);
+
+        // Create two pinecone objects
         Pinecone pinecone1 = new Pinecone(config, manageIndexesApi);
         Pinecone pinecone2 = new Pinecone(config, manageIndexesApi);
 
+        // We don't want to hit the servers for describeIndex()
         when(pinecone1.describeIndex("index1")).thenReturn(indexModel);
         when(pinecone1.describeIndex("index2")).thenReturn(indexModel);
         when(pinecone2.describeIndex("index1")).thenReturn(indexModel);
         when(pinecone2.describeIndex("index2")).thenReturn(indexModel);
 
+        // Create two pinecone objects with 2 index connections per pinecone object
         Index index1Pinecone1 = pinecone1.getIndexConnection("index1");
         Index index1Pinecone2 = pinecone1.getIndexConnection("index2");
         Index index2Pinecone1 = pinecone2.getIndexConnection("index1");
         Index index2Pinecone2 = pinecone2.getIndexConnection("index2");
-        assertEquals(pinecone1.getConnectionsMap().size(), 2);
-        assertEquals(pinecone2.getConnectionsMap().size(), 2);
+
+        ConcurrentHashMap<String, PineconeConnection> concurrentHashMap1 = pinecone1.getConnectionsMap();
+        ConcurrentHashMap<String, PineconeConnection> concurrentHashMap2 = pinecone1.getConnectionsMap();
+
+        // Verify that both pinecone objects are of size 2
+        assertEquals(concurrentHashMap1.size(), 2);
+        assertEquals(concurrentHashMap2.size(), 2);
+
+        // Verify that the contents and refer to the same object instance
+        assertEquals(concurrentHashMap1, concurrentHashMap2);
+        assertSame(concurrentHashMap1, concurrentHashMap2);
 
         index1Pinecone1.close();
         index2Pinecone1.close();
@@ -49,23 +64,35 @@ public class ConnectionsMapTest {
         ManageIndexesApi manageIndexesApi = Mockito.mock(ManageIndexesApi.class);
         IndexModel indexModel = new IndexModel();
         indexModel.setHost(host);
-
         PineconeConfig config = new PineconeConfig("testApiKey");
         config.setHost(host);
+
+        // Create two pinecone objects
         Pinecone pinecone1 = new Pinecone(config, manageIndexesApi);
         Pinecone pinecone2 = new Pinecone(config, manageIndexesApi);
 
+        // We don't want to hit the servers for describeIndex()
         when(pinecone1.describeIndex("index1")).thenReturn(indexModel);
         when(pinecone1.describeIndex("index2")).thenReturn(indexModel);
         when(pinecone1.describeIndex("index1")).thenReturn(indexModel);
         when(pinecone1.describeIndex("index2")).thenReturn(indexModel);
 
+        // Create two pinecone objects with 2 index connections per pinecone object
         AsyncIndex asyncIndex1Pinecone1 = pinecone1.getAsyncIndexConnection("index1");
         AsyncIndex asyncIndex2Pinecone1 = pinecone1.getAsyncIndexConnection("index2");
         AsyncIndex asyncIndex1Pinecone2 = pinecone2.getAsyncIndexConnection("index1");
         AsyncIndex asyncIndex2Pinecone2 = pinecone2.getAsyncIndexConnection("index2");
-        assertEquals(pinecone2.getConnectionsMap().size(), 2);
-        assertEquals(pinecone2.getConnectionsMap().size(), 2);
+
+        ConcurrentHashMap<String, PineconeConnection> concurrentHashMap1 = pinecone1.getConnectionsMap();
+        ConcurrentHashMap<String, PineconeConnection> concurrentHashMap2 = pinecone1.getConnectionsMap();
+
+        // Verify that both pinecone objects are of size 2
+        assertEquals(concurrentHashMap1.size(), 2);
+        assertEquals(concurrentHashMap2.size(), 2);
+
+        // Verify that the contents and refer to the same object instance
+        assertEquals(concurrentHashMap1, concurrentHashMap2);
+        assertSame(concurrentHashMap1, concurrentHashMap2);
 
         asyncIndex1Pinecone1.close();
         asyncIndex2Pinecone1.close();


### PR DESCRIPTION
## Problem

Everytime createIndexConnection() or createAsyncConnection() is called, we are internally calling describeIndex() to get index host which is required for creating blocking or async stubs. 

## Solution

Create a singleton ConcurrentHashMap of indexName (key) and PineconeConnection (value) such that every time the PineconeConnection object is instantiated, the indexName along with the corresponding PineconeConnection is stored into the HashMap. The entry is removed when the connection object is closed. 
Also for readability reasons, @ssmith-pc suggested to update the `createIndexConnection()` and `createAsyncIndexConnection()` methods to `getIndexConnection()` and `getAsyncConnection()` methods.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

Added unit tests and ran integration tests.
