### PR TITLE
Abstract away Request objs in the ConfigureIndex method

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
       run: gradle clean build
 
     - name: Run integration tests
-      run: gradle integrationTest
+      run: gradle integrationTest --info
       env:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -1,12 +1,16 @@
 package io.pinecone.integration.controlPlane.pod;
 
 import io.pinecone.clients.Pinecone;
-import io.pinecone.exceptions.PineconeForbiddenException;
 import io.pinecone.exceptions.PineconeBadRequestException;
+import io.pinecone.exceptions.PineconeForbiddenException;
 import io.pinecone.exceptions.PineconeNotFoundException;
 import io.pinecone.helpers.TestIndexResourcesManager;
-import org.junit.jupiter.api.*;
-import org.openapitools.client.model.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openapitools.client.model.IndexModel;
+import org.openapitools.client.model.IndexModelStatus;
+import org.openapitools.client.model.PodSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,125 +20,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ConfigureIndexTest {
     private static final Logger logger = LoggerFactory.getLogger(ConfigureIndexTest.class);
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
-    private static Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static String indexName;
 
     @BeforeAll
-    public static void setUp() throws InterruptedException {;
+    public static void setUp() throws InterruptedException {
         indexName = indexManager.getPodIndexName();
-    }
-
-    @AfterEach
-    public void afterEach() throws InterruptedException {
-        waitUntilIndexStateIsReady(indexName);
-    }
-
-    @Test
-    public void configureIndexWithInvalidIndexName() {
-        ConfigureIndexRequestSpecPod pod = new ConfigureIndexRequestSpecPod();
-        ConfigureIndexRequestSpec spec = new ConfigureIndexRequestSpec().pod(pod);
-        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest().spec(spec);
-
-        try {
-            controlPlaneClient.configureIndex("non-existent-index", configureIndexRequest);
-
-            fail("Expected to throw PineconeNotFoundException");
-        } catch (PineconeNotFoundException expected) {
-            assertTrue(expected.getLocalizedMessage().toLowerCase().contains("not found"));
-        }
-    }
-
-    @Test
-    public void configureIndexExceedingQuota() {
-        ConfigureIndexRequestSpecPod pod = new ConfigureIndexRequestSpecPod().replicas(400);
-        ConfigureIndexRequestSpec spec = new ConfigureIndexRequestSpec().pod(pod);
-        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest().spec(spec);
-        try {
-            controlPlaneClient.configureIndex(indexName, configureIndexRequest);
-
-            fail("Expected to throw PineconeForbiddenException");
-        } catch (PineconeForbiddenException expected) {
-            assertTrue(expected.getLocalizedMessage().contains("quota"));
-        }
-    }
-
-    @Test
-    public void scaleUpAndDown() throws InterruptedException {
-        // Verify the starting state
-        IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
-        assertNotNull(indexModel.getSpec().getPod());
-        assertEquals(1, indexModel.getSpec().getPod().getReplicas());
-
-        // Scale up for the test
-        ConfigureIndexRequestSpecPod upPod = new ConfigureIndexRequestSpecPod().replicas(3);
-        ConfigureIndexRequestSpec upSpec = new ConfigureIndexRequestSpec().pod(upPod);
-        ConfigureIndexRequest upConfigureIndexRequest = new ConfigureIndexRequest().spec(upSpec);
-
-        // Verify the scaled up replicas
-        assertWithRetry(() -> {
-            controlPlaneClient.configureIndex(indexName, upConfigureIndexRequest);
-            PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
-            assertNotNull(podSpec);
-            assertEquals(podSpec.getReplicas(), 3);
-        });
-
-        waitUntilIndexStateIsReady(indexName);
-
-        // Scaling down
-        ConfigureIndexRequestSpecPod downPod = new ConfigureIndexRequestSpecPod().replicas(1);
-        ConfigureIndexRequestSpec downSpec = new ConfigureIndexRequestSpec().pod(downPod);
-        ConfigureIndexRequest downConfigureIndexRequest = new ConfigureIndexRequest().spec(downSpec);
-
-        // Verify replicas were scaled down
-        assertWithRetry(() -> {
-            controlPlaneClient.configureIndex(indexName, downConfigureIndexRequest);
-            PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
-            assertNotNull(podSpec);
-            assertEquals(podSpec.getReplicas(), 1);
-        });
-    }
-
-    @Test
-    public void changingBasePodType() throws InterruptedException {
-        try {
-            // Verify the starting state
-            IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
-            assertNotNull(indexModel.getSpec().getPod());
-            assertEquals(1, indexModel.getSpec().getPod().getReplicas());
-
-            // Try to change the base pod type
-            ConfigureIndexRequestSpecPod pod = new ConfigureIndexRequestSpecPod().podType("p2.x2");
-            ConfigureIndexRequestSpec spec = new ConfigureIndexRequestSpec().pod(pod);
-            ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest().spec(spec);
-            controlPlaneClient.configureIndex(indexName, configureIndexRequest);
-
-            fail("Expected to throw PineconeBadRequestException");
-        } catch (PineconeBadRequestException expected) {
-            assertTrue(expected.getMessage().contains("change pod"));
-        }
-    }
-
-    @Test
-    public void sizeIncrease() throws InterruptedException {
-        // Verify the starting state
-        IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
-        assertNotNull(indexModel.getSpec().getPod());
-        assertEquals("p1.x1", indexModel.getSpec().getPod().getPodType());
-
-        // Change the pod type to a larger one
-        ConfigureIndexRequestSpecPod pod = new ConfigureIndexRequestSpecPod().podType("p1.x2");
-        ConfigureIndexRequestSpec spec = new ConfigureIndexRequestSpec().pod(pod);
-        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest().spec(spec);
-
-        // Get the index description to verify the new pod type
-        assertWithRetry(() -> {
-            controlPlaneClient.configureIndex(indexName, configureIndexRequest);
-            PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
-            assertNotNull(podSpec);
-            assertEquals(podSpec.getPodType(), "p1.x2");
-        });
-
-        waitUntilIndexStateIsReady(indexName);
     }
 
     private static void waitUntilIndexStateIsReady(String indexName) throws InterruptedException {
@@ -151,5 +42,93 @@ public class ConfigureIndexTest {
         if (!index.getStatus().getReady()) {
             fail("Index " + indexName + " did not finish upgrading after " + timeWaited + "ms");
         }
+    }
+
+    @AfterEach
+    public void afterEach() throws InterruptedException {
+        waitUntilIndexStateIsReady(indexName);
+    }
+
+    @Test
+    public void configureIndexWithInvalidIndexName() {
+        try {
+            controlPlaneClient.configureIndex("non-existent-index", 3);
+
+            fail("Expected to throw PineconeNotFoundException");
+        } catch (PineconeNotFoundException expected) {
+            assertTrue(expected.getLocalizedMessage().toLowerCase().contains("not found"));
+        }
+    }
+
+    @Test
+    public void configureIndexExceedingQuota() {
+        try {
+            controlPlaneClient.configureIndex(indexName, 400);
+
+            fail("Expected to throw PineconeForbiddenException");
+        } catch (PineconeForbiddenException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("quota"));
+        }
+    }
+
+    @Test
+    public void scaleUpAndDown() throws InterruptedException {
+        IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
+        assertNotNull(indexModel.getSpec().getPod());
+        assertEquals(1, indexModel.getSpec().getPod().getReplicas());
+
+        // Verify the scaled up replicas
+        assertWithRetry(() -> {
+            controlPlaneClient.configureIndex(indexName, 3);
+            PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
+            assertNotNull(podSpec);
+            assertEquals(podSpec.getReplicas(), 3);
+        });
+
+        waitUntilIndexStateIsReady(indexName);
+
+        // Verify replicas were scaled down
+        assertWithRetry(() -> {
+            controlPlaneClient.configureIndex(indexName, 1);
+            PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
+            assertNotNull(podSpec);
+            assertEquals(podSpec.getReplicas(), 1);
+        });
+    }
+
+    @Test
+    public void changingBasePodType() throws InterruptedException {
+        try {
+            // Verify the starting state
+            IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
+            assertNotNull(indexModel.getSpec().getPod());
+            assertEquals(1, indexModel.getSpec().getPod().getReplicas());
+
+            // Try to change the base pod type
+            controlPlaneClient.configureIndex(indexName, "p2.x2");
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getMessage().contains("change pod"));
+        }
+    }
+
+    @Test
+    public void sizeIncrease() throws InterruptedException {
+        // Verify the starting state
+        IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
+        assertNotNull(indexModel.getSpec().getPod());
+        assertEquals("p1.x1", indexModel.getSpec().getPod().getPodType());
+
+        // Change the pod type to a larger one
+        // Get the index description to verify the new pod type
+        assertWithRetry(() -> {
+            controlPlaneClient.configureIndex(indexName, "p1.x2");
+            PodSpec podSpec = controlPlaneClient.describeIndex(indexName).getSpec().getPod();
+            assertNotNull(podSpec);
+            assertEquals(podSpec.getPodType(), "p1.x2");
+        });
+
+        waitUntilIndexStateIsReady(indexName);
     }
 }

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -50,24 +50,14 @@ public class Pinecone {
             throw new PineconeValidationException("indexName cannot be null or empty");
         }
 
-        // Set default values if parameters are not provided
-        String defaultPodType = "p1.x1";
-        int defaultReplicas = 1;
+        if (podType == null && replicas == null) {
+            throw new PineconeValidationException("Must provide either podType or replicas");
+        }
 
         // If you pass a # replicas, but they're < 1, throw an exception
         if (replicas != null) {
             if (replicas < 1) {
                 throw new PineconeValidationException("Number of replicas must be >= 1");
-            }
-        }
-
-        // If you pass some random string that's not an actual podType, throw an exception
-        if (podType != null && !podType.isEmpty()) {
-            if (!podType.startsWith("s") && !podType.startsWith("p")) {
-                throw new PineconeValidationException("podType must start with 's' or 'p'");
-            }
-            if (!podType.endsWith("1") && !podType.endsWith("2") && !podType.endsWith("4") && !podType.endsWith("8")) {
-                throw new PineconeValidationException("podType must end with either 1, 2, 3, or 4");
             }
         }
 

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -22,48 +22,6 @@ public class Pinecone {
         this.manageIndexesApi = manageIndexesApi;
     }
 
-    public static class Builder {
-        // Required parameters
-        private final String apiKey;
-
-        // Optional parameters
-        private String sourceTag;
-        private OkHttpClient okHttpClient = new OkHttpClient();
-
-        public Builder(String apiKey) {
-            this.apiKey = apiKey;
-        }
-
-        public Builder withSourceTag(String sourceTag) {
-            this.sourceTag = sourceTag;
-            return this;
-        }
-
-        public Builder withOkHttpClient(OkHttpClient okHttpClient) {
-            this.okHttpClient = okHttpClient;
-            return this;
-        }
-
-        public Pinecone build() {
-            PineconeConfig clientConfig = new PineconeConfig(apiKey);
-            clientConfig.setSourceTag(sourceTag);
-            clientConfig.validate();
-
-            ApiClient apiClient = new ApiClient(okHttpClient);
-            apiClient.setApiKey(clientConfig.getApiKey());
-            apiClient.setUserAgent(clientConfig.getUserAgent());
-
-            if (Boolean.parseBoolean(System.getenv("PINECONE_DEBUG"))) {
-                apiClient.setDebugging(true);
-            }
-
-            ManageIndexesApi manageIndexesApi = new ManageIndexesApi();
-            manageIndexesApi.setApiClient(apiClient);
-
-            return new Pinecone(clientConfig, manageIndexesApi);
-        }
-    }
-
     public IndexModel createIndex(CreateIndexRequest createIndexRequest) throws PineconeValidationException {
         if (createIndexRequest == null) {
             throw new PineconeValidationException("CreateIndexRequest object cannot be null");

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -22,6 +22,48 @@ public class Pinecone {
         this.manageIndexesApi = manageIndexesApi;
     }
 
+    public static class Builder {
+        // Required parameters
+        private final String apiKey;
+
+        // Optional parameters
+        private String sourceTag;
+        private OkHttpClient okHttpClient = new OkHttpClient();
+
+        public Builder(String apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        public Builder withSourceTag(String sourceTag) {
+            this.sourceTag = sourceTag;
+            return this;
+        }
+
+        public Builder withOkHttpClient(OkHttpClient okHttpClient) {
+            this.okHttpClient = okHttpClient;
+            return this;
+        }
+
+        public Pinecone build() {
+            PineconeConfig clientConfig = new PineconeConfig(apiKey);
+            clientConfig.setSourceTag(sourceTag);
+            clientConfig.validate();
+
+            ApiClient apiClient = new ApiClient(okHttpClient);
+            apiClient.setApiKey(clientConfig.getApiKey());
+            apiClient.setUserAgent(clientConfig.getUserAgent());
+
+            if (Boolean.parseBoolean(System.getenv("PINECONE_DEBUG"))) {
+                apiClient.setDebugging(true);
+            }
+
+            ManageIndexesApi manageIndexesApi = new ManageIndexesApi();
+            manageIndexesApi.setApiClient(apiClient);
+
+            return new Pinecone(clientConfig, manageIndexesApi);
+        }
+    }
+
     public IndexModel createIndex(CreateIndexRequest createIndexRequest) throws PineconeValidationException {
         if (createIndexRequest == null) {
             throw new PineconeValidationException("CreateIndexRequest object cannot be null");

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -89,23 +89,6 @@ public class Pinecone {
         return indexModel;
     }
 
-//    public IndexModel configureIndexOld(String indexName, ConfigureIndexRequest configureIndexRequest) throws PineconeValidationException {
-//        if (configureIndexRequest == null) {
-//            throw new PineconeValidationException("ConfigureIndexRequest object cannot be null");
-//        }
-//        if (indexName == null || indexName.isEmpty()) {
-//            throw new PineconeValidationException("Index name cannot be null or empty");
-//        }
-//
-//        IndexModel indexModel = null;
-//        try {
-//            indexModel = manageIndexesApi.configureIndex(indexName, configureIndexRequest);
-//        } catch (ApiException apiException) {
-//            handleApiException(apiException);
-//        }
-//        return indexModel;
-//    }
-
     // Overloaded method with indexName and replicas
     public IndexModel configureIndex(String indexName, Integer replicas) throws PineconeValidationException {
         return configureIndex(indexName, null, replicas);

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -249,21 +249,6 @@ public class PineconeIndexOperationsTest {
         PineconeValidationException thrownZeroReplicas = assertThrows(PineconeValidationException.class,
                 () -> client.configureIndex("testPodIndex", 0));
         assertEquals("Number of replicas must be >= 1", thrownZeroReplicas.getMessage());
-
-        // Test for String podType
-        assertThrows(PineconeValidationException.class,
-                () -> client.configureIndex("testPodIndex", "2"));
-
-        // Test for invalid podType prefix
-        PineconeValidationException thrownInvalidPodTypePrefix = assertThrows(PineconeValidationException.class,
-                () -> client.configureIndex("testPodIndex", "z8", 1));
-        assertEquals("podType must start with 's' or 'p'", thrownInvalidPodTypePrefix.getMessage());
-
-        // Test for invalid podType suffix
-        PineconeValidationException thrownInvalidPodTypeSuffix = assertThrows(PineconeValidationException.class,
-                () -> client.configureIndex("testPodIndex", "p9", 1));
-        assertEquals("podType must end with either 1, 2, 3, or 4", thrownInvalidPodTypeSuffix.getMessage());
-
     }
 
     @Test

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -231,11 +231,8 @@ public class PineconeIndexOperationsTest {
         Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
         IndexModel configuredIndex = client.configureIndex("testPodIndex", 3);
 
-//        verify(mockClient, times(1)).newCall(requestCaptor.capture());
         verify(mockCall, times(1)).execute();
         assertEquals(expectedConfiguredIndex, configuredIndex);
-//        assertEquals(requestCaptor.getValue().method(), "PATCH");
-//        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes/testIndex");
 
         // Test for empty string for index name
         PineconeValidationException thrownEmptyIndexName = assertThrows(PineconeValidationException.class,

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
 
 public class PineconeIndexOperationsTest {
     private static final Gson gson = new Gson();
@@ -218,10 +217,6 @@ public class PineconeIndexOperationsTest {
         String podIndexJsonString = new String(Files.readAllBytes(Paths.get(filePath)));
         IndexModel expectedConfiguredIndex = gson.fromJson(podIndexJsonString, IndexModel.class);
 
-        ConfigureIndexRequestSpecPod pod = new ConfigureIndexRequestSpecPod().podType("s1.x2").replicas(3);
-        ConfigureIndexRequestSpec spec = new ConfigureIndexRequestSpec().pod(pod);
-        ConfigureIndexRequest configureIndexRequest = new ConfigureIndexRequest().spec(spec);
-
         Call mockCall = mock(Call.class);
         when(mockCall.execute()).thenReturn(new Response.Builder()
                 .request(new Request.Builder().url("http://localhost").build())
@@ -234,31 +229,44 @@ public class PineconeIndexOperationsTest {
         OkHttpClient mockClient = mock(OkHttpClient.class);
         when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
         Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
-        IndexModel configuredIndex = client.configureIndex("testIndex", configureIndexRequest);
+        IndexModel configuredIndex = client.configureIndex("testPodIndex", 3);
 
-        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
-
-        verify(mockClient, times(1)).newCall(requestCaptor.capture());
+//        verify(mockClient, times(1)).newCall(requestCaptor.capture());
         verify(mockCall, times(1)).execute();
         assertEquals(expectedConfiguredIndex, configuredIndex);
-        assertEquals(requestCaptor.getValue().method(), "PATCH");
-        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes/testIndex");
+//        assertEquals(requestCaptor.getValue().method(), "PATCH");
+//        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes/testIndex");
 
         // Test for empty string for index name
         PineconeValidationException thrownEmptyIndexName = assertThrows(PineconeValidationException.class,
                 () -> client.configureIndex("",
-                configureIndexRequest));
-        assertEquals("Index name cannot be null or empty", thrownEmptyIndexName.getMessage());
+                        3));
+        assertEquals("indexName cannot be null or empty", thrownEmptyIndexName.getMessage());
 
         // Test for null as index name
         PineconeValidationException thrownNullIndexName = assertThrows(PineconeValidationException.class, () -> client.configureIndex(null,
-                configureIndexRequest));
-        assertEquals("Index name cannot be null or empty", thrownNullIndexName.getMessage());
+                3));
+        assertEquals("indexName cannot be null or empty", thrownNullIndexName.getMessage());
 
-        // Test for null as configureIndexRequest
-        PineconeValidationException thrownNullRequestObj = assertThrows(PineconeValidationException.class,
-                () -> client.configureIndex("testIndex", null));
-        assertEquals("ConfigureIndexRequest object cannot be null", thrownNullRequestObj.getMessage());
+        // Test for invalid number of replicas
+        PineconeValidationException thrownZeroReplicas = assertThrows(PineconeValidationException.class,
+                () -> client.configureIndex("testPodIndex", 0));
+        assertEquals("Number of replicas must be >= 1", thrownZeroReplicas.getMessage());
+
+        // Test for String podType
+        assertThrows(PineconeValidationException.class,
+                () -> client.configureIndex("testPodIndex", "2"));
+
+        // Test for invalid podType prefix
+        PineconeValidationException thrownInvalidPodTypePrefix = assertThrows(PineconeValidationException.class,
+                () -> client.configureIndex("testPodIndex", "z8", 1));
+        assertEquals("podType must start with 's' or 'p'", thrownInvalidPodTypePrefix.getMessage());
+
+        // Test for invalid podType suffix
+        PineconeValidationException thrownInvalidPodTypeSuffix = assertThrows(PineconeValidationException.class,
+                () -> client.configureIndex("testPodIndex", "p9", 1));
+        assertEquals("podType must end with either 1, 2, 3, or 4", thrownInvalidPodTypeSuffix.getMessage());
+
     }
 
     @Test


### PR DESCRIPTION
## Problem

Currently, when users call the `ConfigureIndex` method (in `Pinecone.java`), they have to pass a `ConfigureIndexRequest` object. This object in turn, needs to be created with a `ConfigureIndexRequestSpec` object, which itself needs to be created with a `ConfigureIndexRequestSpec`, WHICH THEN needs to be created with a `ConfigureIndexRequestSpecPod` object.

This is hella cumbersome.

## Solution

This PR abstracts away these Request objects, so the user doesn't have to deal with them at all. Instead, the user can simply call the `ConfigureIndex` method 1 of 2 ways:
- `ConfigureIndex("indexName", someNumberOfReplicas)`
- `ConfigureIndex("indexName", "somePodType")`

Relevant Asana ticket: https://app.asana.com/0/1203260648987893/1206994598304485/f

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Unit tests and updated integration tests included in PR.