### PR TITLE
Add new CreateServerlessIndex method

### DIFF
--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -4,22 +4,24 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeBadRequestException;
 import io.pinecone.exceptions.PineconeNotFoundException;
 import io.pinecone.exceptions.PineconeUnmappedHttpException;
+import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.TestIndexResourcesManager;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.*;
 
-import static io.pinecone.helpers.IndexManager.waitUntilIndexIsReady;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateDescribeListAndDeleteIndexTest {
 
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
-    private static Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-    private static String indexName;
-    private static int dimension;
     // Serverless currently has limited availability in specific regions, hard-code us-west-2 for now
     private static final String serverlessRegion = "us-west-2";
+    private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static String indexName;
+    private static int dimension;
+
     @BeforeAll
     public static void setUp() throws InterruptedException {
         indexName = indexManager.getServerlessIndexName();
@@ -27,6 +29,7 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
+    @Disabled
     public void describeAndListIndex() {
         // Describe the index
         IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
@@ -43,6 +46,7 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
+    @Disabled
     public void createIndexWithInvalidName() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region(serverlessRegion);
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -62,6 +66,18 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
+    public void createServerlessIndexWithInvalidName() {
+        try {
+            controlPlaneClient.createServerlessIndex("Invalid-name", "cosine", 3, "aws", "us-west-2");
+
+            fail("Expected to throw PineconeBadRequestException");
+        } catch (PineconeBadRequestException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("Name must consist of lower case alphanumeric characters or '-'"));
+        }
+    }
+
+    @Test
+    @Disabled
     public void createIndexWithInvalidDimension() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region(serverlessRegion);
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -81,6 +97,17 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
+    public void createServerlessIndexWithInvalidDimension() {
+        try {
+            controlPlaneClient.createServerlessIndex("serverless-test-index", "cosine", -3, "aws", "us-west-2");
+            fail("Expected to throw PineconeValidationException");
+        } catch (PineconeValidationException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("Dimension must be greater than 0"));
+        }
+    }
+
+    @Test
+    @Disabled
     public void createIndexInvalidCloud() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AZURE).region(serverlessRegion);
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -100,6 +127,18 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
+    public void createServerlessIndexWithInvalidCloud() {
+        try {
+            controlPlaneClient.createServerlessIndex("serverless-test-index", "cosine", 3, "blah", "us-west-2");
+            fail("Expected to throw PineconeValidationException");
+        } catch (PineconeValidationException expected) {
+            assertTrue(expected.getLocalizedMessage().contains(String.format("Cloud must be one of %s",
+                    ServerlessSpec.CloudEnum.values())));
+        }
+    }
+
+    @Test
+    @Disabled
     public void createIndexInvalidRegion() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("invalid-region");
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -112,6 +151,16 @@ public class CreateDescribeListAndDeleteIndexTest {
         try {
             controlPlaneClient.createIndex(createIndexRequest);
 
+            fail("Expected to throw PineconeNotFoundException");
+        } catch (PineconeNotFoundException expected) {
+            assertTrue(expected.getLocalizedMessage().contains("Resource cloud: aws region: invalid-region not found"));
+        }
+    }
+
+    @Test
+    public void createServerlessIndexWithInvalidRegion() {
+        try {
+            controlPlaneClient.createServerlessIndex("serverless-test-index", "cosine", 3, "aws", "invalid-region");
             fail("Expected to throw PineconeNotFoundException");
         } catch (PineconeNotFoundException expected) {
             assertTrue(expected.getLocalizedMessage().contains("Resource cloud: aws region: invalid-region not found"));

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.*;
 
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateDescribeListAndDeleteIndexTest {
@@ -128,8 +130,7 @@ public class CreateDescribeListAndDeleteIndexTest {
             controlPlaneClient.createServerlessIndex("serverless-test-index", "cosine", 3, "blah", "us-west-2");
             fail("Expected to throw PineconeValidationException");
         } catch (PineconeValidationException expected) {
-            assertTrue(expected.getLocalizedMessage().contains(String.format("Cloud must be one of %s",
-                    ServerlessSpec.CloudEnum.values())));
+            assertTrue(expected.getLocalizedMessage().contains("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values())));
         }
     }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -29,7 +29,6 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
-    @Disabled
     public void describeAndListIndex() {
         // Describe the index
         IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
@@ -46,7 +45,6 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
-    @Disabled
     public void createIndexWithInvalidName() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region(serverlessRegion);
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -77,7 +75,6 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
-    @Disabled
     public void createIndexWithInvalidDimension() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region(serverlessRegion);
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -107,7 +104,6 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
-    @Disabled
     public void createIndexInvalidCloud() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AZURE).region(serverlessRegion);
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);
@@ -138,7 +134,6 @@ public class CreateDescribeListAndDeleteIndexTest {
     }
 
     @Test
-    @Disabled
     public void createIndexInvalidRegion() {
         ServerlessSpec serverlessSpec = new ServerlessSpec().cloud(ServerlessSpec.CloudEnum.AWS).region("invalid-region");
         CreateIndexRequestSpec createIndexRequestSpec = new CreateIndexRequestSpec().serverless(serverlessSpec);

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -40,11 +40,6 @@ public class Pinecone {
         return indexModel;
     }
 
-    public <E extends Enum<E>> boolean validateEnums(String stringToValidate, List<E> validEnums) {
-        return validEnums.stream()
-                .anyMatch(validEnum -> Objects.equals(stringToValidate, validEnum.toString()));
-    }
-
     public IndexModel createServerlessIndex(String indexName, String metric, int dimension, String cloud,
                                             String region) {
         if (indexName == null || indexName.isEmpty()) {
@@ -54,9 +49,12 @@ public class Pinecone {
         if (metric == null || metric.isEmpty()) {
             throw new PineconeValidationException("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()));
         }
-        List<IndexMetric> indexMetricEnums = Arrays.asList(IndexMetric.values());
-        if (!validateEnums(metric, indexMetricEnums)) {
-            throw new PineconeValidationException("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()));
+        if (!(metric == null)) {
+            try {
+                IndexMetric.fromValue(metric.toLowerCase());
+            } catch (IllegalArgumentException e) {
+                throw new PineconeValidationException("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()));
+            }
         }
 
         if (dimension < 1) {
@@ -66,9 +64,12 @@ public class Pinecone {
         if (cloud == null || cloud.isEmpty()) {
             throw new PineconeValidationException("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()));
         }
-        List<ServerlessSpec.CloudEnum> cloudEnums = Arrays.asList(ServerlessSpec.CloudEnum.values());
-        if (!validateEnums(cloud, cloudEnums)) {
-            throw new PineconeValidationException("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()));
+        if (!(cloud == null)) {
+            try {
+                ServerlessSpec.CloudEnum.fromValue(cloud.toLowerCase());
+            } catch (IllegalArgumentException e) {
+                throw new PineconeValidationException("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()));
+            }
         }
 
         if (region == null || region.isEmpty()) {

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -52,11 +52,11 @@ public class Pinecone {
         }
 
         if (metric == null || metric.isEmpty()) {
-            throw new PineconeValidationException("Metric cannot be null or empty. Must be 'euclidean', 'cosine' or 'dot-product'");
+            throw new PineconeValidationException("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()));
         }
         List<IndexMetric> indexMetricEnums = Arrays.asList(IndexMetric.values());
         if (!validateEnums(metric, indexMetricEnums)) {
-            throw new PineconeValidationException(String.format("Metric must be one of %s", IndexMetric.values()));
+            throw new PineconeValidationException("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()));
         }
 
         if (dimension < 1) {
@@ -64,12 +64,11 @@ public class Pinecone {
         }
 
         if (cloud == null || cloud.isEmpty()) {
-            throw new PineconeValidationException("Cloud cannot be null or empty.");
+            throw new PineconeValidationException("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()));
         }
         List<ServerlessSpec.CloudEnum> cloudEnums = Arrays.asList(ServerlessSpec.CloudEnum.values());
         if (!validateEnums(cloud, cloudEnums)) {
-            throw new PineconeValidationException(String.format("Cloud must be one of %s",
-                    ServerlessSpec.CloudEnum.values()));
+            throw new PineconeValidationException("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()));
         }
 
         if (region == null || region.isEmpty()) {

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -73,7 +73,7 @@ public class Pinecone {
         }
 
         if (region == null || region.isEmpty()) {
-            throw new PineconeValidationException("Region cannot be null or empty.");
+            throw new PineconeValidationException("Region cannot be null or empty");
         }
 
         // Convert user string for "metric" arg into IndexMetric

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -24,7 +24,6 @@ public class Pinecone {
         this.manageIndexesApi = manageIndexesApi;
     }
 
-    // TODO: remove
     public IndexModel createIndex(CreateIndexRequest createIndexRequest) throws PineconeValidationException {
         if (createIndexRequest == null) {
             throw new PineconeValidationException("CreateIndexRequest object cannot be null");

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -2,8 +2,11 @@ package io.pinecone.clients;
 
 import io.pinecone.configs.PineconeConfig;
 import io.pinecone.configs.PineconeConnection;
-import io.pinecone.exceptions.*;
-import okhttp3.*;
+import io.pinecone.exceptions.FailedRequestInfo;
+import io.pinecone.exceptions.HttpErrorMapper;
+import io.pinecone.exceptions.PineconeException;
+import io.pinecone.exceptions.PineconeValidationException;
+import okhttp3.OkHttpClient;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.api.ManageIndexesApi;
@@ -56,7 +59,7 @@ public class Pinecone {
             throw new PineconeValidationException(String.format("Metric must be one of %s", IndexMetric.values()));
         }
 
-        if (dimension <1) {
+        if (dimension < 1) {
             throw new PineconeValidationException("Dimension must be greater than 0");
         }
 

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -60,7 +60,7 @@ public class Pinecone {
         }
 
         if (dimension < 1) {
-            throw new PineconeValidationException("Dimension must be greater than 0");
+            throw new PineconeValidationException("Dimension must be greater than 0. See limits for more info: https://docs.pinecone.io/reference/limits");
         }
 
         if (cloud == null || cloud.isEmpty()) {

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -110,11 +110,11 @@ public class PineconeIndexOperationsTest {
 
         PineconeValidationException thrownEmptyRegion = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", ""));
-        assertEquals("Region cannot be null or empty.", thrownEmptyRegion.getMessage());
+        assertEquals("Region cannot be null or empty", thrownEmptyRegion.getMessage());
 
         PineconeValidationException thrownNullRegion = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", null));
-        assertEquals("Region cannot be null or empty.", thrownNullRegion.getMessage());
+        assertEquals("Region cannot be null or empty", thrownNullRegion.getMessage());
     }
 
 

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -117,49 +117,6 @@ public class PineconeIndexOperationsTest {
         assertEquals("Region cannot be null or empty.", thrownNullRegion.getMessage());
     }
 
-    @Test
-    public void testValidateEnumsWithValidValue() throws IOException {
-        String testString = "cosine";
-        List<IndexMetric> indexMetricEnums = Arrays.asList(IndexMetric.values());
-
-        Call mockCall = mock(Call.class);
-        when(mockCall.execute()).thenReturn(new Response.Builder()
-                .request(new Request.Builder().url("http://localhost").build())
-                .protocol(Protocol.HTTP_1_1)
-                .code(200)
-                .message("OK")
-                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
-                .build());
-        OkHttpClient mockClient = mock(OkHttpClient.class);
-        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
-
-        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
-
-        boolean validationResult = client.validateEnums(testString, indexMetricEnums);
-        assertTrue(validationResult);
-    }
-
-    @Test
-    public void testValidateEnumsWithInvalidValue() throws IOException {
-        String testString = "ecosine";
-        List<IndexMetric> indexMetricEnums = Arrays.asList(IndexMetric.values());
-
-        Call mockCall = mock(Call.class);
-        when(mockCall.execute()).thenReturn(new Response.Builder()
-                .request(new Request.Builder().url("http://localhost").build())
-                .protocol(Protocol.HTTP_1_1)
-                .code(200)
-                .message("OK")
-                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
-                .build());
-        OkHttpClient mockClient = mock(OkHttpClient.class);
-        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
-
-        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
-
-        boolean validationResult = client.validateEnums(testString, indexMetricEnums);
-        assertFalse(validationResult);
-    }
 
     @Test
     public void testCreatePodIndex() throws IOException {

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -15,8 +15,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -69,31 +68,30 @@ public class PineconeIndexOperationsTest {
         client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", "us-west-2");
         verify(mockCall, times(1)).execute();
 
-        client.createServerlessIndex("testServerlessIndex2", "cosine", 3);
-        verify(mockCall, times(2)).execute();
-
-        // Breaking tests for 3 arg createServerlessIndex
         PineconeValidationException thrownEmptyIndexName = assertThrows(PineconeValidationException.class,
-                () -> client.createServerlessIndex("", "cosine", 3));
+                () -> client.createServerlessIndex("", "cosine", 3, "aws", "us-west-2"));
         assertEquals("Index name cannot be null or empty", thrownEmptyIndexName.getMessage());
 
         PineconeValidationException thrownNullIndexName = assertThrows(PineconeValidationException.class,
-                () -> client.createServerlessIndex(null, "cosine", 3));
+                () -> client.createServerlessIndex(null, "cosine", 3, "aws", "us-west-2"));
         assertEquals("Index name cannot be null or empty", thrownNullIndexName.getMessage());
 
         PineconeValidationException thrownEmptyMetric = assertThrows(PineconeValidationException.class,
-                () -> client.createServerlessIndex("testServerlessIndex", "", 3));
+                () -> client.createServerlessIndex("testServerlessIndex", "", 3, "aws", "us-west-2"));
         assertEquals("Metric cannot be null or empty. Must be 'euclidean', 'cosine' or 'dot-product'", thrownEmptyMetric.getMessage());
 
+        PineconeValidationException thrownInvalidMetric = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "blah", 3, "aws", "us-west-2"));
+        assertEquals(String.format("Metric must be one of %s", IndexMetric.values()), thrownInvalidMetric.getMessage());
+
         PineconeValidationException thrownNullMetric = assertThrows(PineconeValidationException.class,
-                () -> client.createServerlessIndex("testServerlessIndex", null, 3));
+                () -> client.createServerlessIndex("testServerlessIndex", null, 3, "aws", "us-west-2"));
         assertEquals("Metric cannot be null or empty. Must be 'euclidean', 'cosine' or 'dot-product'", thrownNullMetric.getMessage());
 
         PineconeValidationException thrownNegativeDimension = assertThrows(PineconeValidationException.class,
-                () -> client.createServerlessIndex("testServerlessIndex", "cosine", -3));
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", -3, "aws", "us-west-2"));
         assertEquals("Dimension must be greater than 0", thrownNegativeDimension.getMessage());
 
-        // Breaking tests for 5 arg createServerlessIndex
         PineconeValidationException thrownEmptyCloud = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "", "us-west-2"));
         assertEquals("Cloud cannot be null or empty.", thrownEmptyCloud.getMessage());
@@ -102,6 +100,11 @@ public class PineconeIndexOperationsTest {
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, null, "us-west-2"));
         assertEquals("Cloud cannot be null or empty.", thrownNullCloud.getMessage());
 
+        PineconeValidationException thrownInvalidCloud = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "wooooo", "us-west-2"));
+        assertEquals(String.format("Cloud must be one of %s", ServerlessSpec.CloudEnum.values()), thrownInvalidCloud.getMessage());
+
+
         PineconeValidationException thrownEmptyRegion = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", ""));
         assertEquals("Region cannot be null or empty.", thrownEmptyRegion.getMessage());
@@ -109,6 +112,50 @@ public class PineconeIndexOperationsTest {
         PineconeValidationException thrownNullRegion = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", null));
         assertEquals("Region cannot be null or empty.", thrownNullRegion.getMessage());
+    }
+
+    @Test
+    public void testValidateEnumsWithValidValue() throws IOException {
+        String testString = "cosine";
+        List<IndexMetric> indexMetricEnums = Arrays.asList(IndexMetric.values());
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
+                .build());
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+
+        boolean validationResult = client.validateEnums(testString, indexMetricEnums);
+        assertTrue(validationResult);
+    }
+
+    @Test
+    public void testValidateEnumsWithInvalidValue() throws IOException {
+        String testString = "ecosine";
+        List<IndexMetric> indexMetricEnums = Arrays.asList(IndexMetric.values());
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
+                .build());
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+
+        boolean validationResult = client.validateEnums(testString, indexMetricEnums);
+        assertFalse(validationResult);
     }
 
     @Test

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -78,32 +78,35 @@ public class PineconeIndexOperationsTest {
 
         PineconeValidationException thrownEmptyMetric = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "", 3, "aws", "us-west-2"));
-        assertEquals("Metric cannot be null or empty. Must be 'euclidean', 'cosine' or 'dot-product'", thrownEmptyMetric.getMessage());
+        assertEquals("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()), thrownEmptyMetric.getMessage());
 
         PineconeValidationException thrownInvalidMetric = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "blah", 3, "aws", "us-west-2"));
-        assertEquals(String.format("Metric must be one of %s", IndexMetric.values()), thrownInvalidMetric.getMessage());
+        assertEquals(String.format("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values())), thrownInvalidMetric.getMessage());
 
         PineconeValidationException thrownNullMetric = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", null, 3, "aws", "us-west-2"));
-        assertEquals("Metric cannot be null or empty. Must be 'euclidean', 'cosine' or 'dot-product'", thrownNullMetric.getMessage());
+        assertEquals("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()),
+            thrownNullMetric.getMessage());
 
         PineconeValidationException thrownNegativeDimension = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", -3, "aws", "us-west-2"));
-        assertEquals("Dimension must be greater than 0", thrownNegativeDimension.getMessage());
+        assertEquals("Dimension must be greater than 0. See limits for more info: https://docs.pinecone.io/reference/limits", thrownNegativeDimension.getMessage());
 
         PineconeValidationException thrownEmptyCloud = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "", "us-west-2"));
-        assertEquals("Cloud cannot be null or empty.", thrownEmptyCloud.getMessage());
+        assertEquals("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()),
+                thrownEmptyCloud.getMessage());
 
         PineconeValidationException thrownNullCloud = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, null, "us-west-2"));
-        assertEquals("Cloud cannot be null or empty.", thrownNullCloud.getMessage());
+        assertEquals("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()),
+                thrownNullCloud.getMessage());
 
         PineconeValidationException thrownInvalidCloud = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "wooooo", "us-west-2"));
-        assertEquals(String.format("Cloud must be one of %s", ServerlessSpec.CloudEnum.values()), thrownInvalidCloud.getMessage());
-
+        assertEquals("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()),
+                thrownInvalidCloud.getMessage());
 
         PineconeValidationException thrownEmptyRegion = assertThrows(PineconeValidationException.class,
                 () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", ""));


### PR DESCRIPTION
## Problem

It's currently cumbersome to force users to create `CreateIndexRequest` object, a `ServerlessSpec` object, and the required `enum`s (`IndexMetric` and `CloudEnum`. 

## Solution

This PR is a *start* on the road towards removing the `createIndex` method. 

In this PR, you will find a new method called `CreateServerlessIndex`. This is what users will use to create a serverless index. All they have to do is pass strings/ints for `indexName`, `metric`, `dimension`, `cloud`, and `region`. All validation of the inputs, transforms into `enum` objects, and construction of the `Request` objects takes place within the function itself.

Note: 
- From reading and asking ChatGPT, it seems that it's more idiomatic in Java to force users to construct the `enum`s (necessary for `metric` and `cloud`), rather than pass in strings, since constructing `enum`s directly is more type-safe and self-documenting. _However_, I think ease-of-use trumps those concerns, since we are building these SDKs primarily to increase developer experience.

LMK if you agree in the comments! 

Asana ticket: https://app.asana.com/0/1203260648987893/1206510790411726/f

## Follow-ups
- Next up will be doing the same thing, but for a new `CreatePodsIndex` method ([ticket](https://app.asana.com/0/1203260648987893/1206994598304491/f))
- After that, I will remove `CreateIndex` from the client altogether, updating unit tests and integration tests as necessary.
    - Within this PR ^, I will also make the necessary documentation updates to Rohan's README, located [here](https://github.com/pinecone-io/pinecone-java-client/blob/c3762bb3d1e34d454047e4ffec875b3a4b159e88/README.md).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Unit test & integration tests included in PR.