### PR TITLE
[Chore] Build output shows which tests are run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,45 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0'
 }
 
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+tasks.withType(Test) {
+    testLogging {
+        // set options for log level LIFECYCLE
+        events TestLogEvent.FAILED,
+                TestLogEvent.PASSED,
+                TestLogEvent.SKIPPED,
+                TestLogEvent.STANDARD_OUT
+        exceptionFormat TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+
+        // set options for log level DEBUG and INFO
+        debug {
+            events TestLogEvent.STARTED,
+                    TestLogEvent.FAILED,
+                    TestLogEvent.PASSED,
+                    TestLogEvent.SKIPPED,
+                    TestLogEvent.STANDARD_ERROR,
+                    TestLogEvent.STANDARD_OUT
+            exceptionFormat TestExceptionFormat.FULL
+        }
+        info.events = debug.events
+        info.exceptionFormat = debug.exceptionFormat
+
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}
+
 javadoc {
     options.tags = [ "http.response.details:a:Http Response Details" ]
     options.addStringOption('Xdoclint:none', '-quiet')


### PR DESCRIPTION
## Problem

I wanted to gain confidence that some tests I added on another branch were actually being run in CI. The default output from `./gradlew clean build` doesn't give much insight.

## Solution

Followed instructions from this [stack overflow question](https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time) to improve the build output. 


## Before
<img width="278" alt="Screenshot 2024-04-05 at 11 09 14 PM" src="https://github.com/pinecone-io/pinecone-java-client/assets/1326365/5919c7e7-9858-404a-adce-7a364d4a3ffa">

## After

![Screenshot 2024-04-05 at 11 07 51 PM](https://github.com/pinecone-io/pinecone-java-client/assets/1326365/ad74569f-9172-41b5-9065-06bb99e5875f)

## Type of Change

- [x] Infrastructure change (CI configs, etc)
