### PR TITLE
[Chore] Bump GHA gradle action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: ${{ matrix.versions.java}}
         
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: ${{ matrix.versions.gradle }}
 
@@ -61,7 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: ${{ matrix.versions.java}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,7 @@ jobs:
         java-version: ${{ matrix.versions.java}}
         
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: ${{ matrix.versions.gradle }}
     - name: Setup gradle.properties
@@ -83,5 +83,3 @@ jobs:
       env:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
-
-


### PR DESCRIPTION
## Problem

There are warnings appearing in the build summary due to a deprecated node version being used by one of our actions

![Screenshot 2024-04-06 at 1 20 01 AM](https://github.com/pinecone-io/pinecone-java-client/assets/1326365/7fa2de71-8016-4e36-b793-88017f1820d6)

## Solution

Update to a more current gradle setup action

## Type of Change

- [x] Infrastructure change (CI configs, etc)
