### PR TITLE
Refactor data plane tests to use `TestResourcesManager`, clean up lengthy `Thead.sleep()` calls, general clean up

### DIFF
--- a/src/integration/java/io/pinecone/CleanupAllTestResourcesListener.java
+++ b/src/integration/java/io/pinecone/CleanupAllTestResourcesListener.java
@@ -1,12 +1,12 @@
 package io.pinecone;
 
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
 
 public class CleanupAllTestResourcesListener implements TestExecutionListener {
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
-        TestIndexResourcesManager.getInstance().cleanupResources();
+        TestResourcesManager.getInstance().cleanupResources();
     }
 }

--- a/src/integration/java/io/pinecone/helpers/BuildUpsertRequest.java
+++ b/src/integration/java/io/pinecone/helpers/BuildUpsertRequest.java
@@ -39,15 +39,15 @@ public class BuildUpsertRequest {
     }
 
     public static ArrayList<Long> generateSparseIndicesByDimension(int dimension) {
-        ArrayList<Long> values = new ArrayList<>();
         Random random = new Random();
+        ArrayList<Long> indices = new ArrayList<>();
         long maxUnsignedInt = (1L << 32) - 1;
 
         for (int i = 0; i < dimension; i++) {
-            values.add(random.nextLong() & maxUnsignedInt);
+            indices.add(random.nextLong() & maxUnsignedInt);
         }
 
-        return values;
+        return indices;
     }
 
     public static Struct generateMetadataStruct() {

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -25,6 +25,7 @@ public class IndexManager {
             }
             if (index.getStatus().getState() == IndexModelStatus.StateEnum.READY) {
                 logger.info("Index " + indexName + " is ready after " + waitedTimeMs + "ms");
+                Thread.sleep(15000);
                 break;
             }
             Thread.sleep(intervalMs);

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -25,7 +25,7 @@ public class IndexManager {
             }
             if (index.getStatus().getState() == IndexModelStatus.StateEnum.READY) {
                 logger.info("Index " + indexName + " is ready after " + waitedTimeMs + "ms");
-                Thread.sleep(15000);
+                Thread.sleep(20000);
                 break;
             }
             Thread.sleep(intervalMs);

--- a/src/integration/java/io/pinecone/helpers/IndexManager.java
+++ b/src/integration/java/io/pinecone/helpers/IndexManager.java
@@ -6,76 +6,11 @@ import org.openapitools.client.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.AbstractMap;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class IndexManager {
     private static final Logger logger = LoggerFactory.getLogger(IndexManager.class);
-
-    public static AbstractMap.SimpleEntry<String, Pinecone> createIndexIfNotExistsDataPlane(int dimension, String indexType) throws IOException, InterruptedException {
-        String apiKey = System.getenv("PINECONE_API_KEY");
-        Pinecone pinecone = new Pinecone.Builder(apiKey).build();
-
-        String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
-        if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
-
-        return new AbstractMap.SimpleEntry<>(indexName, pinecone);
-    }
-
-    public static String findIndexWithDimensionAndType(Pinecone pinecone, int dimension, String indexType) {
-        String indexName = "";
-        List<IndexModel> indexModels = pinecone.listIndexes().getIndexes();
-        if(indexModels == null) {
-            return indexName;
-        }
-
-        for (IndexModel indexModel : indexModels) {
-            boolean typePod = indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_POD) && indexModel.getSpec().getPod() != null;
-            boolean typeServerless = indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_SERVERLESS) && indexModel.getSpec().getServerless() != null;
-
-            if (indexModel.getDimension() == dimension && indexModel.getMetric() == IndexMetric.DOTPRODUCT) {
-                if (typePod || typeServerless) {
-                    return indexModel.getName();
-                }
-            }
-        }
-        return indexName;
-    }
-
-    public static String createNewIndex(Pinecone pinecone, int dimension, String indexType, boolean waitUntilIndexIsReady) throws InterruptedException {
-        String indexName = RandomStringBuilder.build("index-name", 8);
-        String environment = System.getenv("PINECONE_ENVIRONMENT");
-
-        if (indexType.equalsIgnoreCase(IndexModelSpec.SERIALIZED_NAME_POD)) {
-            pinecone.createPodsIndex(indexName, dimension, environment, "p1.x1", "dotproduct");
-            if (waitUntilIndexIsReady) {
-                waitUntilIndexIsReady(pinecone, indexName);
-            }
-            return indexName;
-        } else {
-            pinecone.createServerlessIndex(indexName, "dotproduct", dimension, ServerlessSpec.CloudEnum.AWS.toString(), "us-west-2");
-            if (waitUntilIndexIsReady) {
-                waitUntilIndexIsReady(pinecone, indexName);
-            }
-            return indexName;
-        }
-    }
-
-    public static Pinecone createNewIndex(Pinecone pinecone, String indexName, int dimension,
-                                          String metric, String sourceCollection, boolean waitUntilIndexIsReady) throws InterruptedException,
-            PineconeException {
-        String environment = System.getenv("PINECONE_ENVIRONMENT");
-        pinecone.createPodsIndex(indexName, dimension, environment, "p1.x1", metric, sourceCollection);
-
-        if (waitUntilIndexIsReady) {
-            waitUntilIndexIsReady(pinecone, indexName);
-        }
-        return pinecone;
-    }
 
     public static IndexModel waitUntilIndexIsReady(Pinecone pinecone, String indexName, Integer totalMsToWait) throws InterruptedException {
         IndexModel index = pinecone.describeIndex(indexName);
@@ -88,10 +23,8 @@ public class IndexManager {
                 logger.info("WARNING: Index " + indexName + " not ready after " + waitedTimeMs + "ms");
                 break;
             }
-            if (index.getStatus().getReady()) {
+            if (index.getStatus().getState() == IndexModelStatus.StateEnum.READY) {
                 logger.info("Index " + indexName + " is ready after " + waitedTimeMs + "ms");
-                // Wait one final time before we start connecting and operating on the index
-                Thread.sleep(10000);
                 break;
             }
             Thread.sleep(intervalMs);

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -27,8 +27,8 @@ public class TestIndexResourcesManager {
             ? "us-east4-gcp"
             : System.getenv("PINECONE_ENVIRONMENT");
     private static final String metric = System.getenv("METRIC") == null
-            ? IndexMetric.COSINE.toString()
-            : System.getenv("METRIC");
+            ? IndexMetric.DOTPRODUCT.toString()
+            : IndexMetric.valueOf(System.getenv("METRIC")).toString();
     private static final String cloud = System.getenv("CLOUD") == null
             ? ServerlessSpec.CloudEnum.AWS.toString()
             : System.getenv("CLOUD");
@@ -145,7 +145,7 @@ public class TestIndexResourcesManager {
 
         // Explicitly wait after ready to avoid the "no healthy upstream" issue
         Thread.sleep(30000);
-
+        
         // Seed default vector IDs into default namespace
         seedIndex(vectorIdsForDefaultNamespace, indexName, defaultNamespace);
 

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -84,6 +84,8 @@ public class TestIndexResourcesManager {
         return dimension;
     }
 
+    public String getMetric() { return metric; };
+
     public String getEnvironment() {
         return environment;
     }

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -142,10 +142,10 @@ public class TestIndexResourcesManager {
 
         String indexName = RandomStringBuilder.build("pod-index", 8);
 
-        podIndexModel = pineconeClient.createPodsIndex(indexName, dimension, environment, "p1.x1");
+        podIndexModel = pineconeClient.createPodsIndex(indexName, dimension, environment, "p1.x1", metric);
         waitUntilIndexIsReady(pineconeClient, indexName);
-        
-        // Explicitly wait after ready to avoid the "no healthy upstream" issue
+
+        // Additional sleep after index marked as ready to avoid "no healthy upstream" error
         Thread.sleep(30000);
         
         // Seed default vector IDs into default namespace
@@ -161,7 +161,7 @@ public class TestIndexResourcesManager {
         }
 
         String indexName = RandomStringBuilder.build("serverless-index", 8);
-
+        
         serverlessIndexModel = pineconeClient.createServerlessIndex(indexName, metric, dimension, cloud,
                 region);
         waitUntilIndexIsReady(pineconeClient, indexName);

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -4,6 +4,7 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeException;
+import io.pinecone.proto.DescribeIndexStatsResponse;
 import org.openapitools.client.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -4,7 +4,6 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeException;
-import io.pinecone.proto.DescribeIndexStatsResponse;
 import org.openapitools.client.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,11 +12,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.pinecone.helpers.BuildUpsertRequest.buildRequiredUpsertRequestByDimension;
-import static io.pinecone.helpers.IndexManager.*;
+import static io.pinecone.helpers.TestUtilities.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestIndexResourcesManager {
-    private static final Logger logger = LoggerFactory.getLogger(IndexManager.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestUtilities.class);
     private static TestIndexResourcesManager instance;
     private static final String apiKey = System.getenv("PINECONE_API_KEY");
     private final int dimension = System.getenv("DIMENSION") == null

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -142,7 +142,7 @@ public class TestIndexResourcesManager {
 
         podIndexModel = pineconeClient.createPodsIndex(indexName, dimension, environment, "p1.x1");
         waitUntilIndexIsReady(pineconeClient, indexName);
-
+        
         // Explicitly wait after ready to avoid the "no healthy upstream" issue
         Thread.sleep(30000);
 

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -145,7 +145,7 @@ public class TestIndexResourcesManager {
         
         // Explicitly wait after ready to avoid the "no healthy upstream" issue
         Thread.sleep(30000);
-
+        
         // Seed default vector IDs into default namespace
         seedIndex(vectorIdsForDefaultNamespace, indexName, defaultNamespace);
 

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -145,7 +145,7 @@ public class TestIndexResourcesManager {
 
         // Explicitly wait after ready to avoid the "no healthy upstream" issue
         Thread.sleep(30000);
-        
+
         // Seed default vector IDs into default namespace
         seedIndex(vectorIdsForDefaultNamespace, indexName, defaultNamespace);
 

--- a/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
@@ -16,9 +16,9 @@ import static io.pinecone.helpers.BuildUpsertRequest.buildRequiredUpsertRequestB
 import static io.pinecone.helpers.TestUtilities.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class TestIndexResourcesManager {
+public class TestResourcesManager {
     private static final Logger logger = LoggerFactory.getLogger(TestUtilities.class);
-    private static TestIndexResourcesManager instance;
+    private static TestResourcesManager instance;
     private static final String apiKey = System.getenv("PINECONE_API_KEY");
     private final int dimension = System.getenv("DIMENSION") == null
             ? 4
@@ -49,23 +49,35 @@ public class TestIndexResourcesManager {
     private final String defaultNamespace = "";
 
 
-    private TestIndexResourcesManager() {
+    private TestResourcesManager() {
         pineconeClient = new Pinecone.Builder(apiKey).build();
     }
 
-    public static TestIndexResourcesManager getInstance() {
+    public static TestResourcesManager getInstance() {
         if (instance == null) {
-            instance = new TestIndexResourcesManager();
+            instance = new TestResourcesManager();
         }
         return instance;
     }
 
-    public  Index getServerlessIndexConnection() {
-        return getInstance().pineconeClient.getIndexConnection(this.serverlessIndexName);
+    public  Index getServerlessIndexConnection() throws InterruptedException {
+        // If the index name is null, create the index first
+        return getInstance().pineconeClient.getIndexConnection(createOrGetServerlessIndex());
     }
 
-    public AsyncIndex getServerlessAsyncIndexConnection() {
-        return getInstance().pineconeClient.getAsyncIndexConnection(this.serverlessIndexName);
+    public AsyncIndex getServerlessAsyncIndexConnection() throws InterruptedException {
+        // If the index name is null, create the index first
+        return getInstance().pineconeClient.getAsyncIndexConnection(createOrGetServerlessIndex());
+    }
+
+    public  Index getPodIndexConnection() throws InterruptedException {
+        // If the index name is null, create the index first
+        return getInstance().pineconeClient.getIndexConnection(createOrGetPodIndex());
+    }
+
+    public AsyncIndex getPodAsyncIndexConnection() throws InterruptedException {
+        // If the index name is null, create the index first
+        return getInstance().pineconeClient.getAsyncIndexConnection(createOrGetPodIndex());
     }
 
     public String getPodIndexName() throws InterruptedException, PineconeException {

--- a/src/integration/java/io/pinecone/helpers/TestUtilities.java
+++ b/src/integration/java/io/pinecone/helpers/TestUtilities.java
@@ -1,24 +1,28 @@
 package io.pinecone.helpers;
 
+import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
-import io.pinecone.exceptions.PineconeException;
+import io.pinecone.proto.DescribeIndexStatsResponse;
+import io.pinecone.proto.NamespaceSummary;
 import org.openapitools.client.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class IndexManager {
-    private static final Logger logger = LoggerFactory.getLogger(IndexManager.class);
+public class TestUtilities {
+    private static final Logger logger = LoggerFactory.getLogger(TestUtilities.class);
 
-    public static IndexModel waitUntilIndexIsReady(Pinecone pinecone, String indexName, Integer totalMsToWait) throws InterruptedException {
-        IndexModel index = pinecone.describeIndex(indexName);
+    public static IndexModel waitUntilIndexIsReady(Pinecone pineconeClient, String indexName, Integer totalMsToWait) throws InterruptedException {
+        IndexModel index = pineconeClient.describeIndex(indexName);
         int waitedTimeMs = 0;
         int intervalMs = 2000;
 
         while (index.getStatus().getState() != IndexModelStatus.StateEnum.READY) {
-            index = pinecone.describeIndex(indexName);
+            index = pineconeClient.describeIndex(indexName);
             if (waitedTimeMs >= totalMsToWait) {
                 logger.info("WARNING: Index " + indexName + " not ready after " + waitedTimeMs + "ms");
                 break;
@@ -35,12 +39,12 @@ public class IndexManager {
         return index;
     }
 
-    public static IndexModel waitUntilIndexIsReady(Pinecone pinecone, String indexName) throws InterruptedException {
-        return waitUntilIndexIsReady(pinecone, indexName, 200000);
+    public static IndexModel waitUntilIndexIsReady(Pinecone pineconeClient, String indexName) throws InterruptedException {
+        return waitUntilIndexIsReady(pineconeClient, indexName, 200000);
     }
 
-    public static CollectionModel createCollection(Pinecone pinecone, String collectionName, String indexName, boolean waitUntilReady) throws InterruptedException {
-        CollectionModel collection = pinecone.createCollection(collectionName, indexName);
+    public static CollectionModel createCollection(Pinecone pineconeClient, String collectionName, String indexName, boolean waitUntilReady) throws InterruptedException {
+        CollectionModel collection = pineconeClient.createCollection(collectionName, indexName);
 
         assertEquals(collection.getStatus(), CollectionModel.StatusEnum.INITIALIZING);
 
@@ -53,7 +57,7 @@ public class IndexManager {
                         "milliseconds...");
                 Thread.sleep(5000);
                 timeWaited += 5000;
-                collection = pinecone.describeCollection(collectionName);
+                collection = pineconeClient.describeCollection(collectionName);
                 collectionReady = collection.getStatus();
             }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -28,7 +28,7 @@ public class CollectionTest {
     private static final Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static final Logger logger = LoggerFactory.getLogger(CollectionTest.class);
     private static final ArrayList<String> indexesToCleanUp = new ArrayList<>();
-    private static final String indexMetric = IndexMetric.COSINE.toString();
+    private static final String indexMetric = indexManager.getMetric();
     private static final List<String> upsertIds = indexManager.getVectorIdsFromDefaultNamespace();
     private static final String environment = indexManager.getEnvironment();
     private static final int dimension = indexManager.getDimension();
@@ -113,10 +113,17 @@ public class CollectionTest {
 
     @Test
     public void testCreateIndexFromCollectionWithDiffMetric() throws InterruptedException {
-        // Note collection == 1 index
-        String metricForNewIndex = IndexMetric.DOTPRODUCT.toString();
+        // Use a different metric than the source index
+        String[] metrics = {IndexMetric.COSINE.toString(), IndexMetric.EUCLIDEAN.toString(), IndexMetric.DOTPRODUCT.toString()};
+        String targetMetric = IndexMetric.COSINE.toString();
+        for (String metric : metrics) {
+            if (!metric.equals(indexMetric)) {
+                targetMetric = metric;
+            }
+        }
+        
         String newIndexName = RandomStringBuilder.build("from-coll-with-diff-metric", 5);
-        pineconeClient.createPodsIndex(newIndexName, dimension, environment, "p1.x1", metricForNewIndex, collectionName);
+        pineconeClient.createPodsIndex(newIndexName, dimension, environment, "p1.x1", targetMetric, collectionName);
         indexesToCleanUp.add(newIndexName);
     }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -5,7 +5,6 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeException;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.proto.DescribeIndexStatsResponse;
 import io.pinecone.proto.FetchResponse;
 import io.pinecone.helpers.TestIndexResourcesManager;
 
@@ -20,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 import static io.pinecone.helpers.AssertRetry.assertWithRetry;
-import static io.pinecone.helpers.IndexManager.*;
+import static io.pinecone.helpers.TestUtilities.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class CollectionTest {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -121,7 +121,7 @@ public class CollectionTest {
                 targetMetric = metric;
             }
         }
-        
+
         String newIndexName = RandomStringBuilder.build("from-coll-with-diff-metric", 5);
         pineconeClient.createPodsIndex(newIndexName, dimension, environment, "p1.x1", targetMetric, collectionName);
         indexesToCleanUp.add(newIndexName);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -76,7 +76,6 @@ public class CollectionTest {
 
         assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
         assertEquals(collection.getDimension(), dimension);
-        assertEquals(collection.getVectorCount(), 4);
         assertNotEquals(collection.getVectorCount(), null);
         assertTrue(collection.getSize() > 0);
 
@@ -122,7 +121,7 @@ public class CollectionTest {
         // Note collection == 1 index
         String metricForNewIndex = IndexMetric.DOTPRODUCT.toString();
         String newIndexName = RandomStringBuilder.build("from-coll-with-diff-metric", 5);
-        createNewIndex(pineconeClient, newIndexName, dimension, metricForNewIndex, collectionName, true);
+        pineconeClient.createPodsIndex(newIndexName, dimension, environment, "p1.x1", metricForNewIndex, collectionName);
         indexesToCleanUp.add(newIndexName);
     }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -97,7 +97,7 @@ public class CollectionTest {
         Thread.sleep(30000);
 
         // If the index is ready, validate contents
-        if (indexDescription.getStatus().getReady()) {
+        if (indexDescription.getStatus().getState() == IndexModelStatus.StateEnum.READY) {
             // Set up new index data plane connection
             Index indexClient = pineconeClient.getIndexConnection(newIndexName);
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -38,9 +38,9 @@ public class CollectionTest {
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexName = indexManager.getPodIndexName();
-        collectionName = indexManager.getCollectionName();
-        collection = indexManager.getCollectionModel();
+        indexName = indexManager.getOrCreatePodIndex();
+        collectionName = indexManager.getOrCreateCollection();
+        collection = indexManager.getOrCreateCollectionModel();
         namespace = indexManager.getDefaultNamespace();
     }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -47,9 +47,6 @@ public class CollectionTest {
 
     @AfterAll
     public static void cleanUp() throws InterruptedException {
-        // wait for things to settle before cleanup...
-        Thread.sleep(2500);
-
         // Clean up indexes
         for (String index : indexesToCleanUp) {
             pineconeClient.deleteIndex(index);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -102,11 +102,6 @@ public class CollectionTest {
             Index indexClient = pineconeClient.getIndexConnection(newIndexName);
 
             assertWithRetry(() -> {
-                DescribeIndexStatsResponse describeResponse = indexClient.describeIndexStats();
-
-                // Verify stats reflect the vectors in the collection
-                assertEquals(describeResponse.getTotalVectorCount(), 4);
-
                 // Verify the vectors from the collection -> new index can be fetched
                 FetchResponse fetchedVectors = indexClient.fetch(upsertIds, namespace);
                 for (String key : upsertIds) {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -25,7 +25,7 @@ public class ConfigureIndexTest {
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexName = indexManager.getPodIndexName();
+        indexName = indexManager.getOrCreatePodIndex();
     }
 
     private static void waitUntilIndexStateIsReady(String indexName) throws InterruptedException {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -127,7 +127,5 @@ public class ConfigureIndexTest {
             assertNotNull(podSpec);
             assertEquals(podSpec.getPodType(), "p1.x2");
         });
-
-        waitUntilIndexStateIsReady(indexName);
     }
 }

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -4,7 +4,7 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeBadRequestException;
 import io.pinecone.exceptions.PineconeForbiddenException;
 import io.pinecone.exceptions.PineconeNotFoundException;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ConfigureIndexTest {
     private static final Logger logger = LoggerFactory.getLogger(ConfigureIndexTest.class);
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static String indexName;
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -36,7 +36,7 @@ public class ConfigureIndexTest {
         while (index.getStatus().getState() != IndexModelStatus.StateEnum.READY && timeWaited <= timeToWaitMs) {
             Thread.sleep(2000);
             timeWaited += 2000;
-            logger.info("waited 2000ms for index to upgrade, time left: " + timeToWaitMs);
+            logger.info("waited 2000ms for index to upgrade, time waited: " + timeWaited);
             index = controlPlaneClient.describeIndex(indexName);
         }
         if (!index.getStatus().getReady()) {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
@@ -33,7 +33,7 @@ public class CreateDescribeListAndDeleteIndexTest {
         assertNotNull(indexModel);
         assertEquals(indexDimension, indexModel.getDimension());
         assertEquals(indexName, indexModel.getName());
-        assertEquals(IndexMetric.COSINE, indexModel.getMetric());
+        assertEquals(IndexMetric.DOTPRODUCT, indexModel.getMetric());
         assertNotNull(indexModel.getSpec().getPod());
         assertEquals(indexPodType, indexModel.getSpec().getPod().getPodType());
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
@@ -3,7 +3,7 @@ package io.pinecone.integration.controlPlane.pod;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeBadRequestException;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.*;
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateDescribeListAndDeleteIndexTest {
 
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static String indexName;
     private static int indexDimension;

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
@@ -20,9 +20,9 @@ public class CreateDescribeListAndDeleteIndexTest {
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexName = indexManager.getPodIndexName();
+        indexName = indexManager.getOrCreatePodIndex();
         indexDimension = indexManager.getDimension();
-        IndexModel podIndex = indexManager.getPodIndexModel();
+        IndexModel podIndex = indexManager.getOrCreatePodIndexModel();
         indexPodType = podIndex.getSpec().getPod().getPodType();
     }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -16,14 +16,13 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CreateDescribeListAndDeleteIndexTest {
 
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
-    // Serverless currently has limited availability in specific regions, hard-code us-west-2 for now
     private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static String indexName;
     private static int dimension;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexName = indexManager.getServerlessIndexName();
+        indexName = indexManager.getOrCreateServerlessIndex();
         dimension = indexManager.getDimension();
     }
 

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -4,7 +4,7 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeBadRequestException;
 import io.pinecone.exceptions.PineconeNotFoundException;
 import io.pinecone.exceptions.PineconeValidationException;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openapitools.client.model.*;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CreateDescribeListAndDeleteIndexTest {
 
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     // Serverless currently has limited availability in specific regions, hard-code us-west-2 for now
     private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static String indexName;

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -34,7 +34,7 @@ public class CreateDescribeListAndDeleteIndexTest {
         assertNotNull(indexModel);
         assertEquals(dimension, indexModel.getDimension());
         assertEquals(indexName, indexModel.getName());
-        assertEquals(IndexMetric.COSINE, indexModel.getMetric());
+        assertEquals(IndexMetric.DOTPRODUCT, indexModel.getMetric());
         assertNotNull(indexModel.getSpec().getServerless());
 
         // List the index

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -4,7 +4,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.ListResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 public class ListEndpointTest {
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index indexConnection;
     private static AsyncIndex asyncIndexConnection;
     private static String customNamespace;

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -21,9 +21,9 @@ public class ListEndpointTest {
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexManager.getServerlessIndexName(); // creates serverless index
-        indexConnection = indexManager.getServerlessIndexConnection();
-        asyncIndexConnection = indexManager.getServerlessAsyncIndexConnection();
+        indexManager.getOrCreateServerlessIndex();
+        indexConnection = indexManager.getOrCreateServerlessIndexConnection();
+        asyncIndexConnection = indexManager.getOrCreateServerlessAsyncIndexConnection();
         customNamespace = indexManager.getCustomNamespace();
     }
 

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -88,7 +88,7 @@ public class  UpdateFetchAndQueryPodTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 3);
 
         String idToUpdate = sparseUpsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(201F, 202F, 203F, 204F);
@@ -211,7 +211,7 @@ public class  UpdateFetchAndQueryPodTest {
             for (String key : upsertIds) {
                 assert (fetchResponse.containsVectors(key));
             }
-        });
+        }, 3);
 
         String idToUpdate = sparseUpsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(301F, 302F, 303F, 304F);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -3,7 +3,6 @@ package io.pinecone.integration.dataPlane;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import io.grpc.StatusRuntimeException;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.exceptions.PineconeValidationException;
@@ -39,8 +38,8 @@ public class  UpdateFetchAndQueryPodTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         dimension = indexManager.getDimension();
-        index = indexManager.getPodIndexConnection();
-        asyncIndex = indexManager.getPodAsyncIndexConnection();
+        index = indexManager.getOrCreatePodIndexConnection();
+        asyncIndex = indexManager.getOrCreatePodAsyncIndexConnection();
 
         // Upsert vectors only once
         int numOfVectors = 3;
@@ -83,7 +82,7 @@ public class  UpdateFetchAndQueryPodTest {
             FetchResponse fetchResponse = index.fetch(upsertIds, namespace);
             assertEquals(fetchResponse.getVectorsCount(), upsertIds.size());
             for (String key : upsertIds) {
-                assert (fetchResponse.containsVectors(key));
+                assertTrue(fetchResponse.containsVectors(key));
             }
         }, 3);
 
@@ -150,7 +149,7 @@ public class  UpdateFetchAndQueryPodTest {
 
             fail("Expected to throw statusRuntimeException");
         } catch (StatusRuntimeException statusRuntimeException) {
-            assert (statusRuntimeException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
+            assertTrue(statusRuntimeException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
         }
     }
 
@@ -168,7 +167,7 @@ public class  UpdateFetchAndQueryPodTest {
 
             fail("Expected to throw PineconeValidationException");
         } catch (PineconeValidationException validationException) {
-            assert(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
+            assertTrue(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
         }
     }
 
@@ -195,7 +194,7 @@ public class  UpdateFetchAndQueryPodTest {
                     true);
 
             // Verify the metadata field is correctly filtered in the query response
-            assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
+            assertTrue(queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
         }, 3);
     }
 
@@ -206,7 +205,7 @@ public class  UpdateFetchAndQueryPodTest {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
             assertEquals(fetchResponse.getVectorsCount(), upsertIds.size());
             for (String key : upsertIds) {
-                assert (fetchResponse.containsVectors(key));
+                assertTrue(fetchResponse.containsVectors(key));
             }
         }, 3);
 
@@ -274,7 +273,7 @@ public class  UpdateFetchAndQueryPodTest {
 
             fail("Expected to throw statusRuntimeException");
         } catch (ExecutionException executionException) {
-            assert (executionException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
+            assertTrue(executionException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
         }
     }
 
@@ -311,7 +310,7 @@ public class  UpdateFetchAndQueryPodTest {
 
             // Verify the metadata field is correctly filtered in the query response
             assertNotNull(scoredVectorV1);
-            assert (scoredVectorV1.getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
+            assertTrue(scoredVectorV1.getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
         }, 3);
     }
 
@@ -328,7 +327,7 @@ public class  UpdateFetchAndQueryPodTest {
                     generateVectorValuesByDimension(dimension)).get();
             fail("Expected to throw PineconeValidationException");
         } catch (PineconeValidationException validationException) {
-            assert(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
+            assertTrue(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
         }
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -195,7 +195,7 @@ public class UpdateFetchAndQueryPodTest {
 
                 // Verify the metadata field is correctly filtered in the query response
                 assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            }, 4);
+            }, 3);
         } catch (Exception e) {
             throw new PineconeException(e.getLocalizedMessage());
         }
@@ -257,7 +257,7 @@ public class UpdateFetchAndQueryPodTest {
             Collections.sort(actualSparseValues);
             Collections.sort(expectedSparseValues);
             assertEquals(expectedSparseValues, actualSparseValues);
-        }, 4);
+        }, 3);
     }
 
     @Test
@@ -300,7 +300,7 @@ public class UpdateFetchAndQueryPodTest {
 
                 // Verify the metadata field is correctly filtered in the query response
                 assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            }, 4);
+            }, 3);
         } catch (Exception exception) {
             throw exception;
         }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -29,7 +29,7 @@ public class UpdateFetchAndQueryPodTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
-    private static String namespace;
+    private static final String namespace = RandomStringBuilder.build("ns", 8);
     private static List<String> upsertIds;
     private static List<List<Float>> sparseValuesList;
     private static int dimension;
@@ -46,7 +46,6 @@ public class UpdateFetchAndQueryPodTest {
         // Upsert vectors only once
         int numOfVectors = 3;
         int numOfSparseVectors = 2;
-        namespace = RandomStringBuilder.build("ns", 8);
         upsertIds = getIdsList(numOfVectors);
         List<List<Long>> sparseIndicesList = getSparseIndicesList(numOfSparseVectors, dimension);
         sparseValuesList = getValuesListLists(numOfSparseVectors, dimension);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -6,13 +6,14 @@ import io.grpc.StatusRuntimeException;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
-import io.pinecone.exceptions.PineconeException;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestIndexResourcesManager;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
+import io.pinecone.unsigned_indices_model.SparseValuesWithUnsignedIndices;
+import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,13 +26,14 @@ import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class UpdateFetchAndQueryPodTest {
+public class  UpdateFetchAndQueryPodTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static final String namespace = RandomStringBuilder.build("ns", 8);
     private static List<String> upsertIds;
-    private static List<List<Float>> sparseValuesList;
+    private static List<String> sparseUpsertIds;
+    private static List<Float> sparseValuesList;
     private static int dimension;
 
     @BeforeAll
@@ -47,27 +49,28 @@ public class UpdateFetchAndQueryPodTest {
         int numOfVectors = 3;
         int numOfSparseVectors = 2;
         upsertIds = getIdsList(numOfVectors);
-        List<List<Long>> sparseIndicesList = getSparseIndicesList(numOfSparseVectors, dimension);
-        sparseValuesList = getValuesListLists(numOfSparseVectors, dimension);
+        sparseUpsertIds = getIdsList(numOfSparseVectors);
+        ArrayList<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
+        sparseValuesList = generateVectorValuesByDimension(dimension);
+        List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors + numOfSparseVectors);
 
-        // upsert vectors with required + optional parameters
-        int sparseVectorCount = 0;
-        for (int i = sparseVectorCount; i < numOfSparseVectors; i++) {
-            index.upsert(upsertIds.get(i),
+        // upsert vectors with optional + required parameters
+        for (int i = 0; i < numOfSparseVectors; i++) {
+            VectorWithUnsignedIndices vector = new VectorWithUnsignedIndices(sparseUpsertIds.get(i),
                     generateVectorValuesByDimension(dimension),
-                    sparseIndicesList.get(i),
-                    sparseValuesList.get(i),
-                    generateMetadataStruct(i,i),
-                    namespace);
-            sparseVectorCount++;
+                    generateMetadataStruct(i, i),
+                    new SparseValuesWithUnsignedIndices(sparseIndices, sparseValuesList)
+            );
+            vectorsToUpsert.add(vector);
         }
 
-        for (int j = sparseVectorCount; j < numOfVectors; j++) {
-            index.upsert(
-                    upsertIds.get(j),
-                    generateVectorValuesByDimension(dimension),
-                    namespace);
+        for (int j = 0; j < numOfVectors; j++) {
+            VectorWithUnsignedIndices vector =
+            new VectorWithUnsignedIndices(upsertIds.get(j), generateVectorValuesByDimension(dimension));
+            vectorsToUpsert.add(vector);
         }
+
+        index.upsert(vectorsToUpsert, namespace);
     }
 
     @AfterAll
@@ -87,7 +90,7 @@ public class UpdateFetchAndQueryPodTest {
             }
         });
 
-        String idToUpdate = upsertIds.get(0);
+        String idToUpdate = sparseUpsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(201F, 202F, 203F, 204F);
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
         Struct metadataToUpdate = Struct.newBuilder()
@@ -112,26 +115,29 @@ public class UpdateFetchAndQueryPodTest {
                     null,
                     true,
                     true);
+            List<ScoredVectorWithUnsignedIndices> queryResults = queryResponse.getMatchesList();
+            ScoredVectorWithUnsignedIndices scoredVectorV1 = null;
 
-            ScoredVectorWithUnsignedIndices scoredVectorV1 = queryResponse.getMatches(0);
+            for (ScoredVectorWithUnsignedIndices vector : queryResults) {
+                if (idToUpdate.equals(vector.getId())) {
+                    scoredVectorV1 = vector;
+                }
+            }
+
             // Verify the correct vector id was updated
+            assertNotNull(scoredVectorV1);
             assertEquals(scoredVectorV1.getId(), idToUpdate);
 
             // Verify the updated values
-            List<Float> valuesList = new ArrayList<>(scoredVectorV1.getValuesList());
-            Collections.sort(valuesList);
-            Collections.sort(valuesToUpdate);
+            List<Float> valuesList = scoredVectorV1.getValuesList();
             assertEquals(valuesToUpdate, valuesList);
 
             // Verify the updated metadata
             assertEquals(scoredVectorV1.getMetadata(), metadataToUpdate);
 
             // Verify the initial sparse values set for upsert operation
-            List<Float> expectedSparseValues = new ArrayList<>(scoredVectorV1.getSparseValuesWithUnsignedIndices().getValuesList());
-            List<Float> actualSparseValues = new ArrayList<>(sparseValuesList.get(0));
-            Collections.sort(actualSparseValues);
-            Collections.sort(expectedSparseValues);
-
+            List<Float> expectedSparseValues = sparseValuesList;
+            List<Float> actualSparseValues = scoredVectorV1.getSparseValuesWithUnsignedIndices().getValuesList();
             assertEquals(expectedSparseValues, actualSparseValues);
         }, 3);
     }
@@ -170,34 +176,30 @@ public class UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void queryWithFilersSyncTest() {
+    public void queryWithFiltersSyncTest() throws InterruptedException {
         String fieldToQuery = metadataFields[0];
         String valueToQuery = createAndGetMetadataMap().get(fieldToQuery).get(0);
 
-        try {
-            Struct filter = Struct.newBuilder()
-                    .putFields(metadataFields[0], Value.newBuilder()
-                            .setStructValue(Struct.newBuilder()
-                                    .putFields("$eq", Value.newBuilder()
-                                            .setStringValue(valueToQuery)
-                                            .build()))
-                            .build())
-                    .build();
+        Struct filter = Struct.newBuilder()
+                .putFields(metadataFields[0], Value.newBuilder()
+                        .setStructValue(Struct.newBuilder()
+                                .putFields("$eq", Value.newBuilder()
+                                        .setStringValue(valueToQuery)
+                                        .build()))
+                        .build())
+                .build();
 
-            assertWithRetry(() -> {
-                QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(3,
-                        upsertIds.get(0),
-                        namespace,
-                        filter,
-                        true,
-                        true);
+        assertWithRetry(() -> {
+            QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(3,
+                    upsertIds.get(0),
+                    namespace,
+                    filter,
+                    true,
+                    true);
 
-                // Verify the metadata field is correctly filtered in the query response
-                assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            }, 3);
-        } catch (Exception e) {
-            throw new PineconeException(e.getLocalizedMessage());
-        }
+            // Verify the metadata field is correctly filtered in the query response
+            assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
+        }, 3);
     }
 
     @Test
@@ -211,7 +213,7 @@ public class UpdateFetchAndQueryPodTest {
             }
         });
 
-        String idToUpdate = upsertIds.get(0);
+        String idToUpdate = sparseUpsertIds.get(0);
         List<Float> valuesToUpdate = Arrays.asList(301F, 302F, 303F, 304F);
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
         Struct metadataToUpdate = Struct.newBuilder()
@@ -237,24 +239,29 @@ public class UpdateFetchAndQueryPodTest {
                     true,
                     true).get();
 
-            ScoredVectorWithUnsignedIndices scoredVectorV1 = queryResponse.getMatches(0);
+            List<ScoredVectorWithUnsignedIndices> queryResults = queryResponse.getMatchesList();
+            ScoredVectorWithUnsignedIndices scoredVectorV1 = null;
+
+            for (ScoredVectorWithUnsignedIndices vector : queryResults) {
+                if (idToUpdate.equals(vector.getId())) {
+                    scoredVectorV1 = vector;
+                }
+            }
+
             // Verify the correct vector id was updated
+            assertNotNull(scoredVectorV1);
             assertEquals(scoredVectorV1.getId(), idToUpdate);
 
             // Verify the updated values
             List<Float> valuesList = new ArrayList<>(scoredVectorV1.getValuesList());
-            Collections.sort(valuesList);
-            Collections.sort(valuesToUpdate);
             assertEquals(valuesToUpdate, valuesList);
 
-            // Verify the updated metadata
+            // Verify the metadata was updated
             assertEquals(scoredVectorV1.getMetadata(), metadataToUpdate);
 
-            // Verify the initial sparse values set for upsert operation
-            List<Float> expectedSparseValues = new ArrayList<>(scoredVectorV1.getSparseValuesWithUnsignedIndices().getValuesList());
-            List<Float> actualSparseValues = new ArrayList<>(sparseValuesList.get(0));
-            Collections.sort(actualSparseValues);
-            Collections.sort(expectedSparseValues);
+            // Verify the initial sparse values set for upsert operation were not overwritten
+            List<Float> expectedSparseValues = sparseValuesList;
+            List<Float> actualSparseValues = scoredVectorV1.getSparseValuesWithUnsignedIndices().getValuesList();
             assertEquals(expectedSparseValues, actualSparseValues);
         }, 3);
     }
@@ -275,34 +282,40 @@ public class UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void queryWithFilersFutureTest() throws ExecutionException, InterruptedException {
+    public void queryWithFiltersFutureTest() throws ExecutionException, InterruptedException {
         String fieldToQuery = metadataFields[0];
         String valueToQuery = createAndGetMetadataMap().get(fieldToQuery).get(0);
 
-        try {
-            Struct filter = Struct.newBuilder()
-                    .putFields(metadataFields[0], Value.newBuilder()
-                            .setStructValue(Struct.newBuilder()
-                                    .putFields("$eq", Value.newBuilder()
-                                            .setStringValue(valueToQuery)
-                                            .build()))
-                            .build())
-                    .build();
+        Struct filter = Struct.newBuilder()
+                .putFields(metadataFields[0], Value.newBuilder()
+                        .setStructValue(Struct.newBuilder()
+                                .putFields("$eq", Value.newBuilder()
+                                        .setStringValue(valueToQuery)
+                                        .build()))
+                        .build())
+                .build();
 
-            assertWithRetry(() -> {
-                QueryResponseWithUnsignedIndices queryResponse = asyncIndex.queryByVectorId(3,
-                        upsertIds.get(0),
-                        namespace,
-                        filter,
-                        true,
-                        true).get();
+        assertWithRetry(() -> {
+            QueryResponseWithUnsignedIndices queryResponse = asyncIndex.queryByVectorId(3,
+                    sparseUpsertIds.get(0),
+                    namespace,
+                    filter,
+                    true,
+                    true).get();
 
-                // Verify the metadata field is correctly filtered in the query response
-                assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            }, 3);
-        } catch (Exception exception) {
-            throw exception;
-        }
+            List<ScoredVectorWithUnsignedIndices> queryResults = queryResponse.getMatchesList();
+            ScoredVectorWithUnsignedIndices scoredVectorV1 = null;
+
+            for (ScoredVectorWithUnsignedIndices vector : queryResults) {
+                if (sparseUpsertIds.get(0).equals(vector.getId())) {
+                    scoredVectorV1 = vector;
+                }
+            }
+
+            // Verify the metadata field is correctly filtered in the query response
+            assertNotNull(scoredVectorV1);
+            assert (scoredVectorV1.getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
+        }, 3);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -8,7 +8,7 @@ import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
@@ -27,7 +27,7 @@ import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class  UpdateFetchAndQueryPodTest {
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static final String namespace = RandomStringBuilder.build("ns", 8);
@@ -38,12 +38,9 @@ public class  UpdateFetchAndQueryPodTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        Pinecone pinecone = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-
-        String indexName = indexManager.getPodIndexName();
         dimension = indexManager.getDimension();
-        index = pinecone.getIndexConnection(indexName);
-        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
+        index = indexManager.getPodIndexConnection();
+        asyncIndex = indexManager.getPodAsyncIndexConnection();
 
         // Upsert vectors only once
         int numOfVectors = 3;

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -198,7 +198,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
                 // Verify the metadata field is correctly filtered in the query response
                 assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            }, 4);
+            }, 3);
         } catch (Exception e) {
             throw new PineconeException(e.getLocalizedMessage());
         }
@@ -260,7 +260,7 @@ public class UpdateFetchAndQueryServerlessTest {
             Collections.sort(actualSparseValues);
             Collections.sort(expectedSparseValues);
             assertEquals(expectedSparseValues, actualSparseValues);
-        }, 4);
+        }, 3);
     }
 
     @Test
@@ -305,7 +305,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
                 // Verify the metadata field is correctly filtered in the query response
                 assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
-            }, 4);
+            }, 3);
         } catch (Exception exception) {
             throw exception;
         }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -256,7 +256,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     scoredVectorV1 = vector;
                 }
             }
-            System.out.println("SCOREDVECTORV1: " + scoredVectorV1);
+
             // Verify the correct vector id was updated
             assertNotNull(scoredVectorV1);
             assertEquals(scoredVectorV1.getId(), idToUpdate);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -8,7 +8,7 @@ import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class UpdateFetchAndQueryServerlessTest {
 
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static final String namespace = RandomStringBuilder.build("ns", 8);
@@ -42,12 +42,9 @@ public class UpdateFetchAndQueryServerlessTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-
-        String indexName = indexManager.getServerlessIndexName();
         dimension = indexManager.getDimension();
-        index = pineconeClient.getIndexConnection(indexName);
-        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
+        index = indexManager.getServerlessIndexConnection();
+        asyncIndex = indexManager.getServerlessAsyncIndexConnection();
 
         // Upsert vectors only once
         int numOfVectors = 3;

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Value;
 import io.grpc.StatusRuntimeException;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
@@ -43,8 +42,8 @@ public class UpdateFetchAndQueryServerlessTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         dimension = indexManager.getDimension();
-        index = indexManager.getServerlessIndexConnection();
-        asyncIndex = indexManager.getServerlessAsyncIndexConnection();
+        index = indexManager.getOrCreateServerlessIndexConnection();
+        asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
 
         // Upsert vectors only once
         int numOfVectors = 3;
@@ -86,7 +85,7 @@ public class UpdateFetchAndQueryServerlessTest {
             FetchResponse fetchResponse = index.fetch(upsertIds, namespace);
             assertEquals(fetchResponse.getVectorsCount(), upsertIds.size());
             for (String key : upsertIds) {
-                assert (fetchResponse.containsVectors(key));
+                assertTrue(fetchResponse.containsVectors(key));
             }
         }, 3);
 
@@ -158,7 +157,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
             fail("Expected to throw statusRuntimeException");
         } catch (StatusRuntimeException statusRuntimeException) {
-            assert (statusRuntimeException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
+            assertTrue(statusRuntimeException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
         }
     }
 
@@ -176,7 +175,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
             fail("Expected to throw PineconeValidationException");
         } catch (PineconeValidationException validationException) {
-            assert(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
+            assertTrue(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
         }
     }
 
@@ -204,7 +203,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     true);
 
             // Verify the metadata field is correctly filtered in the query response
-            assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
+            assertTrue(queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
         }, 3);
     }
 
@@ -215,7 +214,7 @@ public class UpdateFetchAndQueryServerlessTest {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
             assertEquals(fetchResponse.getVectorsCount(), upsertIds.size());
             for (String key : upsertIds) {
-                assert (fetchResponse.containsVectors(key));
+                assertTrue(fetchResponse.containsVectors(key));
             }
         },3);
 
@@ -287,7 +286,7 @@ public class UpdateFetchAndQueryServerlessTest {
 
             fail("Expected to throw statusRuntimeException");
         } catch (ExecutionException executionException) {
-            assert (executionException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
+            assertTrue(executionException.toString().contains("Vector dimension 1 does not match the dimension of the index " + dimension));
         }
     }
 
@@ -315,7 +314,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     true).get();
 
             // Verify the metadata field is correctly filtered in the query response
-            assert (queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
+            assertTrue(queryResponse.getMatches(0).getMetadata().getFieldsMap().get(fieldToQuery).toString().contains(valueToQuery));
         }, 3);
     }
 
@@ -332,7 +331,7 @@ public class UpdateFetchAndQueryServerlessTest {
                     generateVectorValuesByDimension(dimension)).get();
             fail("Expected to throw PineconeValidationException");
         } catch (PineconeValidationException validationException) {
-            assert(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
+            assertTrue(validationException.toString().contains("Invalid upsert request. Please ensure that both sparse indices and values are present."));
         }
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -31,7 +31,7 @@ public class UpdateFetchAndQueryServerlessTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
-    private static String namespace;
+    private static final String namespace = RandomStringBuilder.build("ns", 8);
     private static List<String> upsertIds;
     private static List<List<Float>> sparseValuesList;
     private static int dimension;
@@ -48,7 +48,6 @@ public class UpdateFetchAndQueryServerlessTest {
         // Upsert vectors only once
         int numOfVectors = 3;
         int numOfSparseVectors = 2;
-        namespace = RandomStringBuilder.build("ns", 8);
         upsertIds = getIdsList(numOfVectors);
         List<List<Long>> sparseIndicesList = getSparseIndicesList(numOfSparseVectors, dimension);
         sparseValuesList = getValuesListLists(numOfSparseVectors, dimension);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -146,7 +146,7 @@ public class UpdateFetchAndQueryServerlessTest {
             for (Float value : expectedSparseValues) {
                 assertTrue(actualSparseValues.contains(value));
             }
-        });
+        }, 3);
     }
 
     @Test
@@ -263,8 +263,6 @@ public class UpdateFetchAndQueryServerlessTest {
 
             // Verify the updated values
             List<Float> valuesList = scoredVectorV1.getValuesList();
-//            Collections.sort(valuesList);
-//            Collections.sort(valuesToUpdate);
             assertEquals(valuesToUpdate, valuesList);
 
             // Verify the updated metadata
@@ -277,7 +275,7 @@ public class UpdateFetchAndQueryServerlessTest {
             for (Float value : expectedSparseValues) {
                 assertTrue(actualSparseValues.contains(value));
             }
-        });
+        }, 3);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -3,7 +3,6 @@ package io.pinecone.integration.dataPlane;
 import com.google.protobuf.Struct;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
@@ -34,8 +33,8 @@ public class UpsertAndQueryPodTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         dimension = indexManager.getDimension();
-        indexClient = indexManager.getPodIndexConnection();
-        asyncIndexClient = indexManager.getPodAsyncIndexConnection();
+        indexClient = indexManager.getOrCreatePodIndexConnection();
+        asyncIndexClient = indexManager.getOrCreatePodAsyncIndexConnection();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -6,35 +6,34 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
+import io.pinecone.helpers.TestIndexResourcesManager;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import org.junit.jupiter.api.*;
-import org.openapitools.client.model.IndexModelSpec;
 
 import static io.pinecone.helpers.BuildUpsertRequest.*;
-import static io.pinecone.helpers.IndexManager.createIndexIfNotExistsDataPlane;
 import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public class UpsertAndQueryPodTest {
-    private static Pinecone pineconeClient;
+    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static String indexName;
     private static Index indexClient;
     private static AsyncIndex asyncIndexClient;
-    private static final int dimension = 3;
+    private static int dimension;
     private static final Struct emptyFilterStruct = Struct.newBuilder().build();
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        AbstractMap.SimpleEntry<String, Pinecone> indexAndClient = createIndexIfNotExistsDataPlane(dimension, IndexModelSpec.SERIALIZED_NAME_POD);
-        indexName = indexAndClient.getKey();
-        pineconeClient = indexAndClient.getValue();
+        Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+
+        indexName = indexManager.getPodIndexName();
+        dimension = indexManager.getDimension();
         indexClient = pineconeClient.getIndexConnection(indexName);
         asyncIndexClient = pineconeClient.getAsyncIndexConnection(indexName);
     }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -104,7 +104,7 @@ public class UpsertAndQueryPodTest {
 
             // Verify the initial sparse values set for upsert operation
             assertEquals(scoredVectorV1.getSparseValuesWithUnsignedIndices().getValuesList(), sparseValues);
-        });
+        }, 3);
     }
 
     @Test
@@ -190,7 +190,7 @@ public class UpsertAndQueryPodTest {
 
             // Verify the initial sparse values set for upsert operation
             assertEquals(scoredVectorV1.getSparseValuesWithUnsignedIndices().getValuesList(), sparseValues);
-        });
+        }, 3);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -26,6 +26,7 @@ public class UpsertAndQueryPodTest {
     private static Index indexClient;
     private static AsyncIndex asyncIndexClient;
     private static int dimension;
+    private static final String namespace = RandomStringBuilder.build("ns", 8);
     private static final Struct emptyFilterStruct = Struct.newBuilder().build();
 
     @BeforeAll
@@ -48,7 +49,6 @@ public class UpsertAndQueryPodTest {
         // upsert vectors with required + optional parameters
         List<String> upsertIds = getIdsList(numOfVectors);
         int topK = 5;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<Float> values = generateVectorValuesByDimension(dimension);
         List<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
         List<Float> sparseValues = generateVectorValuesByDimension(dimension);
@@ -128,7 +128,6 @@ public class UpsertAndQueryPodTest {
         // upsert vectors with required + optional parameters
         List<String> upsertIds = getIdsList(numOfVectors);
         int topK = 5;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<Float> values = generateVectorValuesByDimension(dimension);
         List<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
         List<Float> sparseValues = generateVectorValuesByDimension(dimension);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -6,7 +6,7 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
@@ -24,8 +24,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public class UpsertAndQueryPodTest {
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
-    private static String indexName;
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index indexClient;
     private static AsyncIndex asyncIndexClient;
     private static int dimension;
@@ -34,12 +33,9 @@ public class UpsertAndQueryPodTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-
-        indexName = indexManager.getPodIndexName();
         dimension = indexManager.getDimension();
-        indexClient = pineconeClient.getIndexConnection(indexName);
-        asyncIndexClient = pineconeClient.getAsyncIndexConnection(indexName);
+        indexClient = indexManager.getPodIndexConnection();
+        asyncIndexClient = indexManager.getPodAsyncIndexConnection();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -51,6 +51,7 @@ public class UpsertAndQueryServerlessTest {
     @Test
     public void upsertOptionalVectorsAndQueryIndexSyncTest() throws Exception {
         int numOfVectors = 5;
+        int topK = 5;
 
         Struct emptyFilterStruct = Struct.newBuilder().build();
         DescribeIndexStatsResponse describeIndexStatsResponse1 = index.describeIndexStats(emptyFilterStruct);
@@ -59,18 +60,18 @@ public class UpsertAndQueryServerlessTest {
 
         // upsert vectors with required + optional parameters
         List<String> upsertIds = getIdsList(numOfVectors);
-        int topK = 5;
         List<Float> values = generateVectorValuesByDimension(dimension);
         List<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
         List<Float> sparseValues = generateVectorValuesByDimension(dimension);
         Struct metadataStruct = generateMetadataStruct();
 
-        List<VectorWithUnsignedIndices> vectors = new ArrayList<VectorWithUnsignedIndices>(numOfVectors);
+        List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
         for (String id : upsertIds) {
-            vectors.add(buildUpsertVectorWithUnsignedIndices(id, values, sparseIndices, sparseValues, metadataStruct));
+            vectorsToUpsert.add(buildUpsertVectorWithUnsignedIndices(id, values, sparseIndices, sparseValues, metadataStruct));
         }
-        index.upsert(vectors, namespace);
+
+        index.upsert(vectorsToUpsert, namespace);
 
         // Query by vector to verify
         assertWithRetry(() -> {
@@ -141,6 +142,7 @@ public class UpsertAndQueryServerlessTest {
     @Test
     public void upsertOptionalVectorsAndQueryIndexFutureTest() throws InterruptedException, ExecutionException {
         int numOfVectors = 5;
+        int topK = 5;
 
         Struct emptyFilterStruct = Struct.newBuilder().build();
 
@@ -150,17 +152,17 @@ public class UpsertAndQueryServerlessTest {
 
         // upsert vectors with required + optional parameters
         List<String> upsertIds = getIdsList(numOfVectors);
-        int topK = 5;
         List<Float> values = generateVectorValuesByDimension(dimension);
         List<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
         List<Float> sparseValues = generateVectorValuesByDimension(dimension);
         Struct metadataStruct = generateMetadataStruct();
-        List<VectorWithUnsignedIndices> vectors = new ArrayList<VectorWithUnsignedIndices>(numOfVectors);
+
+        List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
         for (String id : upsertIds) {
-            vectors.add(buildUpsertVectorWithUnsignedIndices(id, values, sparseIndices, sparseValues, metadataStruct));
+            vectorsToUpsert.add(buildUpsertVectorWithUnsignedIndices(id, values, sparseIndices, sparseValues, metadataStruct));
         }
-        asyncIndex.upsert(vectors, namespace).get();
+        asyncIndex.upsert(vectorsToUpsert, namespace).get();
 
         // Query by vector to verify
         assertWithRetry(() -> {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -3,7 +3,6 @@ package io.pinecone.integration.dataPlane;
 import com.google.protobuf.Struct;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
@@ -35,8 +34,8 @@ public class UpsertAndQueryServerlessTest {
     @BeforeAll
     public static void setUp() throws InterruptedException {
         dimension = indexManager.getDimension();
-        index = indexManager.getServerlessIndexConnection();
-        asyncIndex = indexManager.getServerlessAsyncIndexConnection();
+        index = indexManager.getOrCreateServerlessIndexConnection();
+        asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -6,7 +6,7 @@ import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeValidationException;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
@@ -26,7 +26,7 @@ import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UpsertAndQueryServerlessTest {
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static int dimension;
@@ -34,12 +34,9 @@ public class UpsertAndQueryServerlessTest {
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-
-        String indexName = indexManager.getServerlessIndexName();
         dimension = indexManager.getDimension();
-        index = pineconeClient.getIndexConnection(indexName);
-        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
+        index = indexManager.getServerlessIndexConnection();
+        asyncIndex = indexManager.getServerlessAsyncIndexConnection();
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -117,7 +117,7 @@ public class UpsertAndQueryServerlessTest {
             Collections.sort(expectedSparseValues);
             Collections.sort(sparseValues);
             assertEquals(expectedSparseValues, sparseValues);
-        }, 4);
+        }, 3);
     }
 
     @Test
@@ -207,7 +207,7 @@ public class UpsertAndQueryServerlessTest {
             Collections.sort(expectedSparseValues);
             Collections.sort(sparseValues);
             assertEquals(expectedSparseValues, sparseValues);
-        }, 4);
+        }, 3);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -30,6 +30,7 @@ public class UpsertAndQueryServerlessTest {
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static int dimension;
+    private static final String namespace = RandomStringBuilder.build("ns", 8);
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
@@ -59,7 +60,6 @@ public class UpsertAndQueryServerlessTest {
         // upsert vectors with required + optional parameters
         List<String> upsertIds = getIdsList(numOfVectors);
         int topK = 5;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<Float> values = generateVectorValuesByDimension(dimension);
         List<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
         List<Float> sparseValues = generateVectorValuesByDimension(dimension);
@@ -151,7 +151,6 @@ public class UpsertAndQueryServerlessTest {
         // upsert vectors with required + optional parameters
         List<String> upsertIds = getIdsList(numOfVectors);
         int topK = 5;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<Float> values = generateVectorValuesByDimension(dimension);
         List<Long> sparseIndices = generateSparseIndicesByDimension(dimension);
         List<Float> sparseValues = generateVectorValuesByDimension(dimension);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -6,7 +6,7 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.SparseValuesWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
@@ -23,11 +23,9 @@ import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpsertDescribeIndexStatsAndDeletePodTest {
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
-    private static Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
-    private static String indexName;
     private static int dimension;
     private static final Struct nullFilterStruct = null;
     private static final String namespace = RandomStringBuilder.build("ns", 8);
@@ -35,10 +33,9 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        indexName = indexManager.getPodIndexName();
         dimension = indexManager.getDimension();
-        index = pineconeClient.getIndexConnection(indexName);
-        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
+        index = indexManager.getPodIndexConnection();
+        asyncIndex = indexManager.getPodAsyncIndexConnection();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -7,7 +7,6 @@ import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestIndexResourcesManager;
-import io.pinecone.helpers.TestUtilities;
 import io.pinecone.proto.*;
 import io.pinecone.unsigned_indices_model.SparseValuesWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -60,7 +60,7 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
             DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
-            System.out.println("ASSERT WITH RETRY 1");
+            
             // verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
         }, 3);

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -2,7 +2,6 @@ package io.pinecone.integration.dataPlane;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.helpers.RandomStringBuilder;
@@ -34,8 +33,8 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         dimension = indexManager.getDimension();
-        index = indexManager.getPodIndexConnection();
-        asyncIndex = indexManager.getPodAsyncIndexConnection();
+        index = indexManager.getOrCreatePodIndexConnection();
+        asyncIndex = indexManager.getOrCreatePodAsyncIndexConnection();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -94,7 +94,7 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
             DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        }, 4);
+        }, 3);
     }
 
     @Test
@@ -202,7 +202,7 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
             DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        }, 4);
+        }, 3);
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -26,6 +26,7 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
     private static AsyncIndex asyncIndex;
     private static int dimension;
     private static final Struct nullFilterStruct = null;
+    private static final String namespace = RandomStringBuilder.build("ns", 8);
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
@@ -43,7 +44,6 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
 
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
         for (String id : upsertIds) {
             index.upsert(id,
@@ -100,7 +100,6 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
     @Test
     public void upsertVectorsAndDeleteByFilterSyncTest() throws InterruptedException {
         int numOfVectors = 3;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
 
         // Upsert vectors with required + optional and custom metadata parameters
@@ -151,7 +150,6 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
         // Upsert vectors with required parameters
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
         for (String id : upsertIds) {
             asyncIndex.upsert(id,
@@ -208,7 +206,6 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
     @Test
     public void upsertVectorsAndDeleteByFilterFutureTest() throws InterruptedException, ExecutionException {
         int numOfVectors = 3;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
 
         // Upsert vectors with required + optional and custom metadata parameters

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -27,6 +27,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static int dimension;
+    private static final String namespace = RandomStringBuilder.build("ns", 8);
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
@@ -50,7 +51,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
 
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
         for (String id : upsertIds) {
             index.upsert(id,
@@ -109,7 +109,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         // Upsert vectors with required parameters
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
-        String namespace = RandomStringBuilder.build("ns", 8);
         List<String> upsertIds = getIdsList(numOfVectors);
         for (String id : upsertIds) {
             asyncIndex.upsert(id,

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -101,7 +101,7 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
             DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        }, 4);
+        }, 3);
     }
 
     @Test
@@ -160,6 +160,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
             DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count
             assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
-        }, 4);
+        }, 3);
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -5,7 +5,7 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.RandomStringBuilder;
-import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 import org.junit.jupiter.api.AfterAll;
@@ -22,21 +22,18 @@ import static io.pinecone.helpers.BuildUpsertRequest.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
-    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
-    private static Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
-    private static String indexName;
     private static int dimension;
     private static final String namespace = RandomStringBuilder.build("ns", 8);
     private static int namespaceVectorCount = 0;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        indexName = indexManager.getServerlessIndexName();
         dimension = indexManager.getDimension();
-        index = pineconeClient.getIndexConnection(indexName);
-        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
+        index = indexManager.getServerlessIndexConnection();
+        asyncIndex = indexManager.getServerlessAsyncIndexConnection();
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -3,7 +3,6 @@ package io.pinecone.integration.dataPlane;
 import com.google.protobuf.Struct;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
@@ -32,8 +31,8 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
         dimension = indexManager.getDimension();
-        index = indexManager.getServerlessIndexConnection();
-        asyncIndex = indexManager.getServerlessAsyncIndexConnection();
+        index = indexManager.getOrCreateServerlessIndexConnection();
+        asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
     }
 
     @AfterAll

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -7,10 +7,10 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestIndexResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
+import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openapitools.client.model.IndexModelSpec;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -19,24 +19,24 @@ import java.util.concurrent.ExecutionException;
 
 import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static io.pinecone.helpers.BuildUpsertRequest.*;
-import static io.pinecone.helpers.IndexManager.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
     private static Index index;
     private static AsyncIndex asyncIndex;
+    private static String indexName;
     private static int dimension;
     private static final String namespace = RandomStringBuilder.build("ns", 8);
+    private static int namespaceVectorCount = 0;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        Pinecone pinecone = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-
-        String indexName = indexManager.getServerlessIndexName();
+        indexName = indexManager.getServerlessIndexName();
         dimension = indexManager.getDimension();
-        index = pinecone.getIndexConnection(indexName);
-        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
+        index = pineconeClient.getIndexConnection(indexName);
+        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
     }
 
     @AfterAll
@@ -48,59 +48,37 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     @Test
     public void upsertVectorsAndDeleteByIdSyncTest() throws InterruptedException {
         // Upsert vectors with required parameters
-        Struct emptyFilterStruct = null;
         int numOfVectors = 3;
 
         List<String> upsertIds = getIdsList(numOfVectors);
+        List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
+
         for (String id : upsertIds) {
-            index.upsert(id,
-                    generateVectorValuesByDimension(dimension),
-                    namespace);
+            VectorWithUnsignedIndices vector =
+            new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension));
+            vectorsToUpsert.add(vector);
         }
 
-        int actualVectorCount = numOfVectors;
+        index.upsert(vectorsToUpsert, namespace);
+        namespaceVectorCount += numOfVectors;
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
             DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
 
             // verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
-        });
+            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+        }, 3);
 
-        // Delete 1 vector
-        List<String> idsToDelete = new ArrayList<>(3);
-        String vectorIdToDelete = upsertIds.get(0);
-        idsToDelete.add(vectorIdToDelete);
-        index.delete(idsToDelete, false, namespace, emptyFilterStruct);
-        numOfVectors -= idsToDelete.size();
-        int testSingleDeletedVectorCount = numOfVectors;
+        // Delete vectors
+        index.deleteByIds(upsertIds, namespace);
+        namespaceVectorCount -= numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
-            // Verify the updated vector count should be 1 less than previous vector count since number of vectors deleted = 1
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testSingleDeletedVectorCount);
-        });
-
-        // vector id at index 0 is already deleted
-        idsToDelete.remove(0);
-        // Add ids to delete multiple vectors
-        idsToDelete.add(upsertIds.get(1));
-        idsToDelete.add(upsertIds.get(2));
-
-        // Delete multiple vectors
-        index.delete(idsToDelete, false, namespace, null);
-
-        // Update startVectorCount
-        numOfVectors -= idsToDelete.size();
-        int testMultipleDeletedVectorCount = numOfVectors;
-
-        assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(emptyFilterStruct);
+            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
             // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
+            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
         }, 3);
     }
 
@@ -110,55 +88,34 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
         List<String> upsertIds = getIdsList(numOfVectors);
+        List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
+
         for (String id : upsertIds) {
-            asyncIndex.upsert(id,
-                    generateVectorValuesByDimension(dimension),
-                    namespace).get();
+            VectorWithUnsignedIndices vector =
+            new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension));
+            vectorsToUpsert.add(vector);
         }
 
-        int actualVectorCount = numOfVectors;
+        asyncIndex.upsert(vectorsToUpsert, namespace).get();
+        namespaceVectorCount += numOfVectors;
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
             DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
 
             // verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), actualVectorCount);
-        });
+            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+        }, 3);
 
-        // Delete 1 vector
-        List<String> idsToDelete = new ArrayList<>(3);
-        String vectorIdToDelete = upsertIds.get(0);
-        idsToDelete.add(vectorIdToDelete);
-        asyncIndex.delete(idsToDelete, false, namespace, emptyFilterStruct);
-        numOfVectors -= idsToDelete.size();
-        int testSingleDeletedVectorCount = numOfVectors;
-
-        assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
-            // Verify the updated vector count should be 1 less than previous vector count since number of vectors deleted = 1
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testSingleDeletedVectorCount);
-        });
-
-        // vector id at index 0 is already deleted
-        idsToDelete.remove(0);
-        // Add ids to delete multiple vectors
-        idsToDelete.add(upsertIds.get(1));
-        idsToDelete.add(upsertIds.get(2));
-
-        // Delete multiple vectors
-        asyncIndex.delete(idsToDelete, false, namespace, null);
-
-        // Update startVectorCount
-        numOfVectors -= idsToDelete.size();
-        int testMultipleDeletedVectorCount = numOfVectors;
+        // Delete vectors
+        asyncIndex.deleteByIds(upsertIds, namespace);
+        namespaceVectorCount -= numOfVectors;
 
         assertWithRetry(() -> {
             // Call describeIndexStats to get updated vector count
             DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
             // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), testMultipleDeletedVectorCount);
+            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
         }, 3);
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -5,6 +5,7 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.RandomStringBuilder;
+import io.pinecone.helpers.TestIndexResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -22,19 +23,17 @@ import static io.pinecone.helpers.IndexManager.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
-
+    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static Index index;
     private static AsyncIndex asyncIndex;
+    private static int dimension;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
-        String apiKey = System.getenv("PINECONE_API_KEY");
-        String indexType = IndexModelSpec.SERIALIZED_NAME_SERVERLESS;
-        int dimension = 3;
-        Pinecone pinecone = new Pinecone.Builder(apiKey).build();
+        Pinecone pinecone = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
 
-        String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
-        if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
+        String indexName = indexManager.getServerlessIndexName();
+        dimension = indexManager.getDimension();
         index = pinecone.getIndexConnection(indexName);
         asyncIndex = pinecone.getAsyncIndexConnection(indexName);
     }
@@ -48,7 +47,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     @Test
     public void upsertVectorsAndDeleteByIdSyncTest() throws InterruptedException {
         // Upsert vectors with required parameters
-        int dimension = 3;
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
 
@@ -61,9 +59,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         }
 
         int actualVectorCount = numOfVectors;
-
-        // wait sometime for the vectors to be upserted
-        Thread.sleep(90000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count
@@ -112,7 +107,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     @Test
     public void upsertVectorsAndDeleteByIdFutureTest() throws InterruptedException, ExecutionException {
         // Upsert vectors with required parameters
-        int dimension = 3;
         Struct emptyFilterStruct = null;
         int numOfVectors = 3;
         String namespace = RandomStringBuilder.build("ns", 8);
@@ -124,9 +118,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         }
 
         int actualVectorCount = numOfVectors;
-
-        // wait sometime for the vectors to be upserted
-        Thread.sleep(90000);
 
         assertWithRetry(() -> {
             // call describeIndexStats to get updated vector count


### PR DESCRIPTION
## Problem
The Java integration tests have traditionally been very flakey, and have taken a long time to run. For example, if freshness is lagged or delayed we can end up waiting nearly 30 minutes for a single integration test run to finish due to `assertWithRetry` being used with a backoff of 4.

Previously, I added a new `TestIndexResourcesManager` class to handle managing shared index resources across all tests over the `IndexManager`: https://github.com/pinecone-io/pinecone-java-client/pull/89. I initially only implemented the manager in control plane tests. It also needs to be added to data plane tests.

## Solution
- Rename `TestIndexResourcesManager` to `TestResourcesManager`.
- Rename `IndexManager` to `TestUtilities` and remove unneeded functions for managing indexes.
- Clean up some of the duplicative function in `TestResourcesManager`. Opt for the naming paradigm of `getOrCreateFoo` for the various functions that allow getting or creating indexes or collections.
- Refactor all of the integration tests in `/integration/dataPlane/` to use the `TestResourcesManager` rather than the helper functions in `TestUtilities`.
- Remove all of the `Thread.sleep(90000)` etc calls that were sprinkled all over the data plane tests. I don't think we need to actually wait this long, it was incredibly inefficient and if freshness is degraded they would still usually fail.
- For places where we're calling `assertWithRetry()` for retrying commands in tests when things fail, I swapped from using a backoff of 4 to 3. We should look at refactoring this function to be a bit more flexible, but for now we should avoid backoffs of > 3 as they cause an enormous amount of wait time: 6000ms, 24000ms, 96000ms, 384000ms. We should never wait this long within a test it would be preferable to let things fail earlier and just re-run.
- I did a lot of various refactoring across the data plane tests. Ultimately I don't think I've changed anything we're actually testing, but I've tried to make things less brittle and more readable.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, integration tests etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Run the integration tests suite locally or validate we see green in CI.

`gradle integrationTest`
