### PR TITLE
[Fix] [0.8.x] Accept additional properties in API JSON responses (#95)

### DIFF
--- a/src/main/java/org/openapitools/client/ApiClient.java
+++ b/src/main/java/org/openapitools/client/ApiClient.java
@@ -107,7 +107,7 @@ public class ApiClient {
     /**
      * Basic constructor with custom OkHttpClient
      *
-     * @param client a {@link OkHttpClient} object
+     * @param client a {@link okhttp3.OkHttpClient} object
      */
     public ApiClient(OkHttpClient client) {
         init();
@@ -207,7 +207,7 @@ public class ApiClient {
      *
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
-     * @throws NullPointerException when newHttpClient is null
+     * @throws java.lang.NullPointerException when newHttpClient is null
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         this.httpClient = Objects.requireNonNull(newHttpClient, "HttpClient must not be null!");
@@ -282,7 +282,7 @@ public class ApiClient {
     /**
      * <p>Getter for the field <code>keyManagers</code>.</p>
      *
-     * @return an array of {@link KeyManager} objects
+     * @return an array of {@link javax.net.ssl.KeyManager} objects
      */
     public KeyManager[] getKeyManagers() {
         return keyManagers;
@@ -304,7 +304,7 @@ public class ApiClient {
     /**
      * <p>Getter for the field <code>dateFormat</code>.</p>
      *
-     * @return a {@link DateFormat} object
+     * @return a {@link java.text.DateFormat} object
      */
     public DateFormat getDateFormat() {
         return dateFormat;
@@ -313,8 +313,8 @@ public class ApiClient {
     /**
      * <p>Setter for the field <code>dateFormat</code>.</p>
      *
-     * @param dateFormat a {@link DateFormat} object
-     * @return a {@link ApiClient} object
+     * @param dateFormat a {@link java.text.DateFormat} object
+     * @return a {@link org.openapitools.client.ApiClient} object
      */
     public ApiClient setDateFormat(DateFormat dateFormat) {
         JSON.setDateFormat(dateFormat);
@@ -324,8 +324,8 @@ public class ApiClient {
     /**
      * <p>Set SqlDateFormat.</p>
      *
-     * @param dateFormat a {@link DateFormat} object
-     * @return a {@link ApiClient} object
+     * @param dateFormat a {@link java.text.DateFormat} object
+     * @return a {@link org.openapitools.client.ApiClient} object
      */
     public ApiClient setSqlDateFormat(DateFormat dateFormat) {
         JSON.setSqlDateFormat(dateFormat);
@@ -335,8 +335,8 @@ public class ApiClient {
     /**
      * <p>Set OffsetDateTimeFormat.</p>
      *
-     * @param dateFormat a {@link DateTimeFormatter} object
-     * @return a {@link ApiClient} object
+     * @param dateFormat a {@link java.time.format.DateTimeFormatter} object
+     * @return a {@link org.openapitools.client.ApiClient} object
      */
     public ApiClient setOffsetDateTimeFormat(DateTimeFormatter dateFormat) {
         JSON.setOffsetDateTimeFormat(dateFormat);
@@ -346,8 +346,8 @@ public class ApiClient {
     /**
      * <p>Set LocalDateFormat.</p>
      *
-     * @param dateFormat a {@link DateTimeFormatter} object
-     * @return a {@link ApiClient} object
+     * @param dateFormat a {@link java.time.format.DateTimeFormatter} object
+     * @return a {@link org.openapitools.client.ApiClient} object
      */
     public ApiClient setLocalDateFormat(DateTimeFormatter dateFormat) {
         JSON.setLocalDateFormat(dateFormat);
@@ -358,7 +358,7 @@ public class ApiClient {
      * <p>Set LenientOnJson.</p>
      *
      * @param lenientOnJson a boolean
-     * @return a {@link ApiClient} object
+     * @return a {@link org.openapitools.client.ApiClient} object
      */
     public ApiClient setLenientOnJson(boolean lenientOnJson) {
         JSON.setLenientOnJson(lenientOnJson);
@@ -568,7 +568,7 @@ public class ApiClient {
     /**
      * Sets the connect timeout (in milliseconds).
      * A value of 0 means no timeout, otherwise values must be between 1 and
-     * {@link Integer#MAX_VALUE}.
+     * {@link java.lang.Integer#MAX_VALUE}.
      *
      * @param connectionTimeout connection timeout in milliseconds
      * @return Api client
@@ -590,7 +590,7 @@ public class ApiClient {
     /**
      * Sets the read timeout (in milliseconds).
      * A value of 0 means no timeout, otherwise values must be between 1 and
-     * {@link Integer#MAX_VALUE}.
+     * {@link java.lang.Integer#MAX_VALUE}.
      *
      * @param readTimeout read timeout in milliseconds
      * @return Api client
@@ -612,7 +612,7 @@ public class ApiClient {
     /**
      * Sets the write timeout (in milliseconds).
      * A value of 0 means no timeout, otherwise values must be between 1 and
-     * {@link Integer#MAX_VALUE}.
+     * {@link java.lang.Integer#MAX_VALUE}.
      *
      * @param writeTimeout connection timeout in milliseconds
      * @return Api client
@@ -852,7 +852,7 @@ public class ApiClient {
      * @param response HTTP response
      * @param returnType The type of the Java object
      * @return The deserialized Java object
-     * @throws ApiException If fail to deserialize response body, i.e. cannot read response body
+     * @throws org.openapitools.client.ApiException If fail to deserialize response body, i.e. cannot read response body
      *   or the Content-Type of the response is not supported.
      */
     @SuppressWarnings("unchecked")
@@ -913,7 +913,7 @@ public class ApiClient {
      * @param obj The Java object
      * @param contentType The request Content-Type
      * @return The serialized request body
-     * @throws ApiException If fail to serialize the given object
+     * @throws org.openapitools.client.ApiException If fail to serialize the given object
      */
     public RequestBody serialize(Object obj, String contentType) throws ApiException {
         if (obj instanceof byte[]) {
@@ -943,7 +943,7 @@ public class ApiClient {
      * Download file from the given response.
      *
      * @param response An instance of the Response object
-     * @throws ApiException If fail to read file content from response and write to disk
+     * @throws org.openapitools.client.ApiException If fail to read file content from response and write to disk
      * @return Downloaded file
      */
     public File downloadFileFromResponse(Response response) throws ApiException {
@@ -963,7 +963,7 @@ public class ApiClient {
      *
      * @param response An instance of the Response object
      * @return Prepared file for the download
-     * @throws IOException If fail to prepare file for download
+     * @throws java.io.IOException If fail to prepare file for download
      */
     public File prepareDownloadFile(Response response) throws IOException {
         String filename = null;
@@ -1007,7 +1007,7 @@ public class ApiClient {
      * @param <T> Type
      * @param call An instance of the Call object
      * @return ApiResponse&lt;T&gt;
-     * @throws ApiException If fail to execute the call
+     * @throws org.openapitools.client.ApiException If fail to execute the call
      */
     public <T> ApiResponse<T> execute(Call call) throws ApiException {
         return execute(call, null);
@@ -1022,7 +1022,7 @@ public class ApiClient {
      * @return ApiResponse object containing response status, headers and
      *   data, which is a Java object deserialized from response body and would be null
      *   when returnType is null.
-     * @throws ApiException If fail to execute the call
+     * @throws org.openapitools.client.ApiException If fail to execute the call
      */
     public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
         try {
@@ -1086,7 +1086,7 @@ public class ApiClient {
      * @param response Response
      * @param returnType Return type
      * @return Type
-     * @throws ApiException If the response has an unsuccessful status code or
+     * @throws org.openapitools.client.ApiException If the response has an unsuccessful status code or
      *                      fail to deserialize the response body
      */
     public <T> T handleResponse(Response response, Type returnType) throws ApiException {
@@ -1133,7 +1133,7 @@ public class ApiClient {
      * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP call
-     * @throws ApiException If fail to serialize the request body object
+     * @throws org.openapitools.client.ApiException If fail to serialize the request body object
      */
     public Call buildCall(String baseUrl, String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
         Request request = buildRequest(baseUrl, path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, authNames, callback);
@@ -1156,7 +1156,7 @@ public class ApiClient {
      * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP request
-     * @throws ApiException If fail to serialize the request body object
+     * @throws org.openapitools.client.ApiException If fail to serialize the request body object
      */
     public Request buildRequest(String baseUrl, String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
         // aggregate queryParams (non-collection) and collectionQueryParams into allQueryParams
@@ -1322,7 +1322,7 @@ public class ApiClient {
      * @param payload HTTP request body
      * @param method HTTP method
      * @param uri URI
-     * @throws ApiException If fails to update the parameters
+     * @throws org.openapitools.client.ApiException If fails to update the parameters
      */
     public void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams,
                                     Map<String, String> cookieParams, String payload, String method, URI uri) throws ApiException {
@@ -1342,7 +1342,7 @@ public class ApiClient {
      * @return RequestBody
      */
     public RequestBody buildRequestBodyFormEncoding(Map<String, Object> formParams) {
-        FormBody.Builder formBuilder = new FormBody.Builder();
+        okhttp3.FormBody.Builder formBuilder = new okhttp3.FormBody.Builder();
         for (Entry<String, Object> param : formParams.entrySet()) {
             formBuilder.add(param.getKey(), parameterToString(param.getValue()));
         }
@@ -1438,7 +1438,7 @@ public class ApiClient {
     private Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
-            public Response intercept(Chain chain) throws IOException {
+            public Response intercept(Interceptor.Chain chain) throws IOException {
                 final Request request = chain.request();
                 final Response originalResponse = chain.proceed(request);
                 if (request.tag() instanceof ApiCallback) {
@@ -1464,16 +1464,16 @@ public class ApiClient {
                 trustManagers = new TrustManager[]{
                         new X509TrustManager() {
                             @Override
-                            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
                             }
 
                             @Override
-                            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
                             }
 
                             @Override
-                            public X509Certificate[] getAcceptedIssuers() {
-                                return new X509Certificate[]{};
+                            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                                return new java.security.cert.X509Certificate[]{};
                             }
                         }
                 };
@@ -1533,7 +1533,7 @@ public class ApiClient {
      *
      * @param requestBody The HTTP request object
      * @return The string representation of the HTTP request body
-     * @throws ApiException If fail to serialize the request body object into a string
+     * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
     private String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {

--- a/src/main/java/org/openapitools/client/ApiException.java
+++ b/src/main/java/org/openapitools/client/ApiException.java
@@ -21,7 +21,7 @@ import java.util.List;
  * <p>ApiException class.</p>
  */
 @SuppressWarnings("serial")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
@@ -35,7 +35,7 @@ public class ApiException extends Exception {
     /**
      * <p>Constructor for ApiException.</p>
      *
-     * @param throwable a {@link Throwable} object
+     * @param throwable a {@link java.lang.Throwable} object
      */
     public ApiException(Throwable throwable) {
         super(throwable);
@@ -54,9 +54,9 @@ public class ApiException extends Exception {
      * <p>Constructor for ApiException.</p>
      *
      * @param message the error message
-     * @param throwable a {@link Throwable} object
+     * @param throwable a {@link java.lang.Throwable} object
      * @param code HTTP status code
-     * @param responseHeaders a {@link Map} of HTTP response headers
+     * @param responseHeaders a {@link java.util.Map} of HTTP response headers
      * @param responseBody the response body
      */
     public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
@@ -71,7 +71,7 @@ public class ApiException extends Exception {
      *
      * @param message the error message
      * @param code HTTP status code
-     * @param responseHeaders a {@link Map} of HTTP response headers
+     * @param responseHeaders a {@link java.util.Map} of HTTP response headers
      * @param responseBody the response body
      */
     public ApiException(String message, int code, Map<String, List<String>> responseHeaders, String responseBody) {
@@ -82,9 +82,9 @@ public class ApiException extends Exception {
      * <p>Constructor for ApiException.</p>
      *
      * @param message the error message
-     * @param throwable a {@link Throwable} object
+     * @param throwable a {@link java.lang.Throwable} object
      * @param code HTTP status code
-     * @param responseHeaders a {@link Map} of HTTP response headers
+     * @param responseHeaders a {@link java.util.Map} of HTTP response headers
      */
     public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders) {
         this(message, throwable, code, responseHeaders, null);
@@ -94,7 +94,7 @@ public class ApiException extends Exception {
      * <p>Constructor for ApiException.</p>
      *
      * @param code HTTP status code
-     * @param responseHeaders a {@link Map} of HTTP response headers
+     * @param responseHeaders a {@link java.util.Map} of HTTP response headers
      * @param responseBody the response body
      */
     public ApiException(int code, Map<String, List<String>> responseHeaders, String responseBody) {
@@ -105,7 +105,7 @@ public class ApiException extends Exception {
      * <p>Constructor for ApiException.</p>
      *
      * @param code HTTP status code
-     * @param message a {@link String} object
+     * @param message a {@link java.lang.String} object
      */
     public ApiException(int code, String message) {
         super(message);
@@ -117,7 +117,7 @@ public class ApiException extends Exception {
      *
      * @param code HTTP status code
      * @param message the error message
-     * @param responseHeaders a {@link Map} of HTTP response headers
+     * @param responseHeaders a {@link java.util.Map} of HTTP response headers
      * @param responseBody the response body
      */
     public ApiException(int code, String message, Map<String, List<String>> responseHeaders, String responseBody) {

--- a/src/main/java/org/openapitools/client/ApiResponse.java
+++ b/src/main/java/org/openapitools/client/ApiResponse.java
@@ -59,7 +59,7 @@ public class ApiResponse<T> {
     /**
      * <p>Get the <code>headers</code>.</p>
      *
-     * @return a {@link Map} of headers
+     * @return a {@link java.util.Map} of headers 
      */
     public Map<String, List<String>> getHeaders() {
         return headers;

--- a/src/main/java/org/openapitools/client/Configuration.java
+++ b/src/main/java/org/openapitools/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class Configuration {
     public static final String VERSION = "v1";
 

--- a/src/main/java/org/openapitools/client/JSON.java
+++ b/src/main/java/org/openapitools/client/JSON.java
@@ -102,6 +102,7 @@ public class JSON {
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.CreateIndexRequest.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.CreateIndexRequestSpec.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.CreateIndexRequestSpecPod.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.CreateIndexRequestSpecPodMetadataConfig.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.ErrorResponse.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.ErrorResponseError.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.IndexList.CustomTypeAdapterFactory());

--- a/src/main/java/org/openapitools/client/Pair.java
+++ b/src/main/java/org/openapitools/client/Pair.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/org/openapitools/client/StringUtil.java
+++ b/src/main/java/org/openapitools/client/StringUtil.java
@@ -16,7 +16,7 @@ package org.openapitools.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/org/openapitools/client/api/ManageIndexesApi.java
+++ b/src/main/java/org/openapitools/client/api/ManageIndexesApi.java
@@ -81,7 +81,7 @@ public class ManageIndexesApi {
 
     /**
      * Build call for configureIndex
-     * @param indexName The name of the index to configure (required)
+     * @param indexName The name of the index to configure. (required)
      * @param configureIndexRequest The desired pod type and replica configuration for the index. (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
@@ -93,9 +93,9 @@ public class ManageIndexesApi {
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call configureIndexCall(String indexName, ConfigureIndexRequest configureIndexRequest, final ApiCallback _callback) throws ApiException {
@@ -161,9 +161,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation specifies the pod type and number of replicas for an index.
-     * @param indexName The name of the index to configure (required)
+     * Configure an index
+     * This operation specifies the pod type and number of replicas for an index. It applies to pod-based indexes only. Serverless indexes scale automatically based on usage.
+     * @param indexName The name of the index to configure. (required)
      * @param configureIndexRequest The desired pod type and replica configuration for the index. (required)
      * @return IndexModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -174,9 +174,9 @@ public class ManageIndexesApi {
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public IndexModel configureIndex(String indexName, ConfigureIndexRequest configureIndexRequest) throws ApiException {
@@ -185,9 +185,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation specifies the pod type and number of replicas for an index.
-     * @param indexName The name of the index to configure (required)
+     * Configure an index
+     * This operation specifies the pod type and number of replicas for an index. It applies to pod-based indexes only. Serverless indexes scale automatically based on usage.
+     * @param indexName The name of the index to configure. (required)
      * @param configureIndexRequest The desired pod type and replica configuration for the index. (required)
      * @return ApiResponse&lt;IndexModel&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -198,9 +198,9 @@ public class ManageIndexesApi {
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<IndexModel> configureIndexWithHttpInfo(String indexName, ConfigureIndexRequest configureIndexRequest) throws ApiException {
@@ -210,9 +210,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation specifies the pod type and number of replicas for an index.
-     * @param indexName The name of the index to configure (required)
+     * Configure an index (asynchronously)
+     * This operation specifies the pod type and number of replicas for an index. It applies to pod-based indexes only. Serverless indexes scale automatically based on usage.
+     * @param indexName The name of the index to configure. (required)
      * @param configureIndexRequest The desired pod type and replica configuration for the index. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
@@ -224,9 +224,9 @@ public class ManageIndexesApi {
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call configureIndexAsync(String indexName, ConfigureIndexRequest configureIndexRequest, final ApiCallback<IndexModel> _callback) throws ApiException {
@@ -251,7 +251,7 @@ public class ManageIndexesApi {
         <tr><td> 403 </td><td> You&#39;ve exceed your collections quota. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> A collection already exists with the name provided. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createCollectionCall(CreateCollectionRequest createCollectionRequest, final ApiCallback _callback) throws ApiException {
@@ -311,8 +311,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation creates a Pinecone collection.
+     * Create a collection
+     * This operation creates a Pinecone collection.  Serverless and starter indexes do not support collections. 
      * @param createCollectionRequest The desired configuration for the collection. (required)
      * @return CollectionModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -325,7 +325,7 @@ public class ManageIndexesApi {
         <tr><td> 403 </td><td> You&#39;ve exceed your collections quota. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> A collection already exists with the name provided. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public CollectionModel createCollection(CreateCollectionRequest createCollectionRequest) throws ApiException {
@@ -334,8 +334,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation creates a Pinecone collection.
+     * Create a collection
+     * This operation creates a Pinecone collection.  Serverless and starter indexes do not support collections. 
      * @param createCollectionRequest The desired configuration for the collection. (required)
      * @return ApiResponse&lt;CollectionModel&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -348,7 +348,7 @@ public class ManageIndexesApi {
         <tr><td> 403 </td><td> You&#39;ve exceed your collections quota. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> A collection already exists with the name provided. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CollectionModel> createCollectionWithHttpInfo(CreateCollectionRequest createCollectionRequest) throws ApiException {
@@ -358,8 +358,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation creates a Pinecone collection.
+     * Create a collection (asynchronously)
+     * This operation creates a Pinecone collection.  Serverless and starter indexes do not support collections. 
      * @param createCollectionRequest The desired configuration for the collection. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
@@ -373,7 +373,7 @@ public class ManageIndexesApi {
         <tr><td> 403 </td><td> You&#39;ve exceed your collections quota. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> A collection already exists with the name provided. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createCollectionAsync(CreateCollectionRequest createCollectionRequest, final ApiCallback<CollectionModel> _callback) throws ApiException {
@@ -392,14 +392,14 @@ public class ManageIndexesApi {
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 201 </td><td> The index has been successfully created </td><td>  -  </td></tr>
+        <tr><td> 201 </td><td> The index has been successfully created. </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Index of given name already exists. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createIndexCall(CreateIndexRequest createIndexRequest, final ApiCallback _callback) throws ApiException {
@@ -459,22 +459,22 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation deploys a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.
+     * Create an index
+     * This operation deploys a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#create-a-serverless-index). 
      * @param createIndexRequest The desired configuration for the index. (required)
      * @return IndexModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 201 </td><td> The index has been successfully created </td><td>  -  </td></tr>
+        <tr><td> 201 </td><td> The index has been successfully created. </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Index of given name already exists. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public IndexModel createIndex(CreateIndexRequest createIndexRequest) throws ApiException {
@@ -483,22 +483,22 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation deploys a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.
+     * Create an index
+     * This operation deploys a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#create-a-serverless-index). 
      * @param createIndexRequest The desired configuration for the index. (required)
      * @return ApiResponse&lt;IndexModel&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 201 </td><td> The index has been successfully created </td><td>  -  </td></tr>
+        <tr><td> 201 </td><td> The index has been successfully created. </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Index of given name already exists. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<IndexModel> createIndexWithHttpInfo(CreateIndexRequest createIndexRequest) throws ApiException {
@@ -508,8 +508,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation deploys a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.
+     * Create an index (asynchronously)
+     * This operation deploys a Pinecone index. This is where you specify the measure of similarity, the dimension of vectors to be stored in the index, which cloud provider you would like to deploy with, and more.  For guidance and examples, see [Create an index](https://docs.pinecone.io/guides/indexes/create-an-index#create-a-serverless-index). 
      * @param createIndexRequest The desired configuration for the index. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
@@ -517,14 +517,14 @@ public class ManageIndexesApi {
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 201 </td><td> The index has been successfully created </td><td>  -  </td></tr>
+        <tr><td> 201 </td><td> The index has been successfully created. </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad request. The request body included invalid request parameters. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> You&#39;ve exceed your pod quota. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Unknown cloud or region when creating a serverless index. </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable entity. The request body could not be deserialized. </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Index of given name already exists. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createIndexAsync(CreateIndexRequest createIndexRequest, final ApiCallback<IndexModel> _callback) throws ApiException {
@@ -536,7 +536,7 @@ public class ManageIndexesApi {
     }
     /**
      * Build call for deleteCollection
-     * @param collectionName The name of the collection (required)
+     * @param collectionName The name of the collection. (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -545,8 +545,8 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The index has been successfully deleted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteCollectionCall(String collectionName, final ApiCallback _callback) throws ApiException {
@@ -607,9 +607,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation deletes an existing collection.
-     * @param collectionName The name of the collection (required)
+     * Delete a collection
+     * This operation deletes an existing collection.  Serverless and starter indexes do not support collections. 
+     * @param collectionName The name of the collection. (required)
      * @return String
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -617,8 +617,8 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The index has been successfully deleted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public String deleteCollection(String collectionName) throws ApiException {
@@ -627,9 +627,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation deletes an existing collection.
-     * @param collectionName The name of the collection (required)
+     * Delete a collection
+     * This operation deletes an existing collection.  Serverless and starter indexes do not support collections. 
+     * @param collectionName The name of the collection. (required)
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -637,8 +637,8 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The index has been successfully deleted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<String> deleteCollectionWithHttpInfo(String collectionName) throws ApiException {
@@ -648,9 +648,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation deletes an existing collection.
-     * @param collectionName The name of the collection (required)
+     * Delete a collection (asynchronously)
+     * This operation deletes an existing collection.  Serverless and starter indexes do not support collections. 
+     * @param collectionName The name of the collection. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -659,8 +659,8 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The index has been successfully deleted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteCollectionAsync(String collectionName, final ApiCallback<String> _callback) throws ApiException {
@@ -672,7 +672,7 @@ public class ManageIndexesApi {
     }
     /**
      * Build call for deleteIndex
-     * @param indexName The name of the index to delete (required)
+     * @param indexName The name of the index to delete. (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -681,9 +681,9 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The request to delete the index has been accepted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> There is a pending collection created from this index. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteIndexCall(String indexName, final ApiCallback _callback) throws ApiException {
@@ -743,18 +743,18 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
+     * Delete an index
      * This operation deletes an existing index.
-     * @param indexName The name of the index to delete (required)
+     * @param indexName The name of the index to delete. (required)
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The request to delete the index has been accepted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> There is a pending collection created from this index. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public void deleteIndex(String indexName) throws ApiException {
@@ -762,9 +762,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
+     * Delete an index
      * This operation deletes an existing index.
-     * @param indexName The name of the index to delete (required)
+     * @param indexName The name of the index to delete. (required)
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -772,9 +772,9 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The request to delete the index has been accepted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> There is a pending collection created from this index. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Void> deleteIndexWithHttpInfo(String indexName) throws ApiException {
@@ -783,9 +783,9 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
+     * Delete an index (asynchronously)
      * This operation deletes an existing index.
-     * @param indexName The name of the index to delete (required)
+     * @param indexName The name of the index to delete. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -794,9 +794,9 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 202 </td><td> The request to delete the index has been accepted. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> There is a pending collection created from this index. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteIndexAsync(String indexName, final ApiCallback<Void> _callback) throws ApiException {
@@ -807,17 +807,17 @@ public class ManageIndexesApi {
     }
     /**
      * Build call for describeCollection
-     * @param collectionName The name of the collection to be described (required)
+     * @param collectionName The name of the collection to be described. (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and status of the collection </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and status of the collection. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call describeCollectionCall(String collectionName, final ApiCallback _callback) throws ApiException {
@@ -877,18 +877,18 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation gets a description of a collection.
-     * @param collectionName The name of the collection to be described (required)
+     * Describe a collection
+     * This operation gets a description of a collection.  Serverless and starter indexes do not support collections. 
+     * @param collectionName The name of the collection to be described. (required)
      * @return CollectionModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and status of the collection </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and status of the collection. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public CollectionModel describeCollection(String collectionName) throws ApiException {
@@ -897,18 +897,18 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation gets a description of a collection.
-     * @param collectionName The name of the collection to be described (required)
+     * Describe a collection
+     * This operation gets a description of a collection.  Serverless and starter indexes do not support collections. 
+     * @param collectionName The name of the collection to be described. (required)
      * @return ApiResponse&lt;CollectionModel&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and status of the collection </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and status of the collection. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CollectionModel> describeCollectionWithHttpInfo(String collectionName) throws ApiException {
@@ -918,19 +918,19 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation gets a description of a collection.
-     * @param collectionName The name of the collection to be described (required)
+     * Describe a collection (asynchronously)
+     * This operation gets a description of a collection.  Serverless and starter indexes do not support collections. 
+     * @param collectionName The name of the collection to be described. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and status of the collection </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and status of the collection. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Collection not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Collection not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call describeCollectionAsync(String collectionName, final ApiCallback<CollectionModel> _callback) throws ApiException {
@@ -942,17 +942,17 @@ public class ManageIndexesApi {
     }
     /**
      * Build call for describeIndex
-     * @param indexName The name of the index to be described (required)
+     * @param indexName The name of the index to be described. (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and deployment status of the index </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and deployment status of the index. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call describeIndexCall(String indexName, final ApiCallback _callback) throws ApiException {
@@ -1012,18 +1012,18 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
+     * Describe an index
      * Get a description of an index.
-     * @param indexName The name of the index to be described (required)
+     * @param indexName The name of the index to be described. (required)
      * @return IndexModel
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and deployment status of the index </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and deployment status of the index. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public IndexModel describeIndex(String indexName) throws ApiException {
@@ -1032,18 +1032,18 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
+     * Describe an index
      * Get a description of an index.
-     * @param indexName The name of the index to be described (required)
+     * @param indexName The name of the index to be described. (required)
      * @return ApiResponse&lt;IndexModel&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and deployment status of the index </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and deployment status of the index. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<IndexModel> describeIndexWithHttpInfo(String indexName) throws ApiException {
@@ -1053,19 +1053,19 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
+     * Describe an index (asynchronously)
      * Get a description of an index.
-     * @param indexName The name of the index to be described (required)
+     * @param indexName The name of the index to be described. (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-        <tr><td> 200 </td><td> Configuration information and deployment status of the index </td><td>  -  </td></tr>
+        <tr><td> 200 </td><td> Configuration information and deployment status of the index. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 404 </td><td> Index not found </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Index not found. </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call describeIndexAsync(String indexName, final ApiCallback<IndexModel> _callback) throws ApiException {
@@ -1085,7 +1085,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the collections in your current project. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call listCollectionsCall(final ApiCallback _callback) throws ApiException {
@@ -1139,8 +1139,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation returns a list of your Pinecone collections.
+     * List collections
+     * This operation returns a list of all collections in a project.  Serverless and starter indexes do not support collections. 
      * @return CollectionList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1148,7 +1148,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the collections in your current project. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public CollectionList listCollections() throws ApiException {
@@ -1157,8 +1157,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation returns a list of your Pinecone collections.
+     * List collections
+     * This operation returns a list of all collections in a project.  Serverless and starter indexes do not support collections. 
      * @return ApiResponse&lt;CollectionList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1166,7 +1166,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the collections in your current project. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CollectionList> listCollectionsWithHttpInfo() throws ApiException {
@@ -1176,8 +1176,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation returns a list of your Pinecone collections.
+     * List collections (asynchronously)
+     * This operation returns a list of all collections in a project.  Serverless and starter indexes do not support collections. 
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -1186,7 +1186,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the collections in your current project. </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call listCollectionsAsync(final ApiCallback<CollectionList> _callback) throws ApiException {
@@ -1206,7 +1206,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the indexes that you have previously created, and which are associated with the given project </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call listIndexesCall(final ApiCallback _callback) throws ApiException {
@@ -1260,8 +1260,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation returns a list of your Pinecone indexes.
+     * List indexes
+     * This operation returns a list of all indexes in a project.
      * @return IndexList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1269,7 +1269,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the indexes that you have previously created, and which are associated with the given project </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public IndexList listIndexes() throws ApiException {
@@ -1278,8 +1278,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     * 
-     * This operation returns a list of your Pinecone indexes.
+     * List indexes
+     * This operation returns a list of all indexes in a project.
      * @return ApiResponse&lt;IndexList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1287,7 +1287,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the indexes that you have previously created, and which are associated with the given project </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<IndexList> listIndexesWithHttpInfo() throws ApiException {
@@ -1297,8 +1297,8 @@ public class ManageIndexesApi {
     }
 
     /**
-     *  (asynchronously)
-     * This operation returns a list of your Pinecone indexes.
+     * List indexes (asynchronously)
+     * This operation returns a list of all indexes in a project.
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -1307,7 +1307,7 @@ public class ManageIndexesApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> This operation returns a list of all the indexes that you have previously created, and which are associated with the given project </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized. Possible causes: Invalid API key. </td><td>  -  </td></tr>
-        <tr><td> 500 </td><td> Internal server error </td><td>  -  </td></tr>
+        <tr><td> 500 </td><td> Internal server error. </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call listIndexesAsync(final ApiCallback<IndexList> _callback) throws ApiException {

--- a/src/main/java/org/openapitools/client/auth/ApiKeyAuth.java
+++ b/src/main/java/org/openapitools/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
+++ b/src/main/java/org/openapitools/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;

--- a/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/org/openapitools/client/model/CollectionList.java
+++ b/src/main/java/org/openapitools/client/model/CollectionList.java
@@ -52,7 +52,7 @@ import org.openapitools.client.JSON;
 /**
  * The list of collections that exist in the project.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class CollectionList {
   public static final String SERIALIZED_NAME_COLLECTIONS = "collections";
   @SerializedName(SERIALIZED_NAME_COLLECTIONS)
@@ -89,6 +89,50 @@ public class CollectionList {
     this.collections = collections;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CollectionList instance itself
+   */
+  public CollectionList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +144,13 @@ public class CollectionList {
       return false;
     }
     CollectionList collectionList = (CollectionList) o;
-    return Objects.equals(this.collections, collectionList.collections);
+    return Objects.equals(this.collections, collectionList.collections)&&
+        Objects.equals(this.additionalProperties, collectionList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(collections);
+    return Objects.hash(collections, additionalProperties);
   }
 
   @Override
@@ -113,6 +158,7 @@ public class CollectionList {
     StringBuilder sb = new StringBuilder();
     sb.append("class CollectionList {\n");
     sb.append("    collections: ").append(toIndentedString(collections)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -153,14 +199,6 @@ public class CollectionList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CollectionList is not found in the empty JSON string", CollectionList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CollectionList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CollectionList` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if (jsonObj.get("collections") != null && !jsonObj.get("collections").isJsonNull()) {
         JsonArray jsonArraycollections = jsonObj.getAsJsonArray("collections");
@@ -193,6 +231,23 @@ public class CollectionList {
            @Override
            public void write(JsonWriter out, CollectionList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -200,7 +255,28 @@ public class CollectionList {
            public CollectionList read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CollectionList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/CollectionModel.java
+++ b/src/main/java/org/openapitools/client/model/CollectionModel.java
@@ -49,7 +49,7 @@ import org.openapitools.client.JSON;
 /**
  * The CollectionModel describes the configuration and status of a Pinecone collection.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class CollectionModel {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -197,7 +197,7 @@ public class CollectionModel {
   }
 
    /**
-   * The dimension of the vectors stored in each record held in the collection
+   * The dimension of the vectors stored in each record held in the collection.
    * minimum: 1
    * maximum: 2000
    * @return dimension
@@ -220,7 +220,7 @@ public class CollectionModel {
   }
 
    /**
-   * The number of records stored in the collection
+   * The number of records stored in the collection.
    * @return vectorCount
   **/
   @javax.annotation.Nullable
@@ -254,6 +254,50 @@ public class CollectionModel {
     this.environment = environment;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CollectionModel instance itself
+   */
+  public CollectionModel putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -270,12 +314,13 @@ public class CollectionModel {
         Objects.equals(this.status, collectionModel.status) &&
         Objects.equals(this.dimension, collectionModel.dimension) &&
         Objects.equals(this.vectorCount, collectionModel.vectorCount) &&
-        Objects.equals(this.environment, collectionModel.environment);
+        Objects.equals(this.environment, collectionModel.environment)&&
+        Objects.equals(this.additionalProperties, collectionModel.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, size, status, dimension, vectorCount, environment);
+    return Objects.hash(name, size, status, dimension, vectorCount, environment, additionalProperties);
   }
 
   @Override
@@ -288,6 +333,7 @@ public class CollectionModel {
     sb.append("    dimension: ").append(toIndentedString(dimension)).append("\n");
     sb.append("    vectorCount: ").append(toIndentedString(vectorCount)).append("\n");
     sb.append("    environment: ").append(toIndentedString(environment)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -337,14 +383,6 @@ public class CollectionModel {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CollectionModel.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CollectionModel` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CollectionModel.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -378,6 +416,23 @@ public class CollectionModel {
            @Override
            public void write(JsonWriter out, CollectionModel value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -385,7 +440,28 @@ public class CollectionModel {
            public CollectionModel read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CollectionModel instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/ConfigureIndexRequest.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureIndexRequest.java
@@ -50,7 +50,7 @@ import org.openapitools.client.JSON;
 /**
  * Configuration used to scale an index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ConfigureIndexRequest {
   public static final String SERIALIZED_NAME_SPEC = "spec";
   @SerializedName(SERIALIZED_NAME_SPEC)
@@ -79,6 +79,50 @@ public class ConfigureIndexRequest {
     this.spec = spec;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ConfigureIndexRequest instance itself
+   */
+  public ConfigureIndexRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +134,13 @@ public class ConfigureIndexRequest {
       return false;
     }
     ConfigureIndexRequest configureIndexRequest = (ConfigureIndexRequest) o;
-    return Objects.equals(this.spec, configureIndexRequest.spec);
+    return Objects.equals(this.spec, configureIndexRequest.spec)&&
+        Objects.equals(this.additionalProperties, configureIndexRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(spec);
+    return Objects.hash(spec, additionalProperties);
   }
 
   @Override
@@ -103,6 +148,7 @@ public class ConfigureIndexRequest {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConfigureIndexRequest {\n");
     sb.append("    spec: ").append(toIndentedString(spec)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,14 +191,6 @@ public class ConfigureIndexRequest {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ConfigureIndexRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ConfigureIndexRequest` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ConfigureIndexRequest.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -179,6 +217,23 @@ public class ConfigureIndexRequest {
            @Override
            public void write(JsonWriter out, ConfigureIndexRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -186,7 +241,28 @@ public class ConfigureIndexRequest {
            public ConfigureIndexRequest read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ConfigureIndexRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/ConfigureIndexRequestSpec.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureIndexRequestSpec.java
@@ -50,7 +50,7 @@ import org.openapitools.client.JSON;
 /**
  * ConfigureIndexRequestSpec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ConfigureIndexRequestSpec {
   public static final String SERIALIZED_NAME_POD = "pod";
   @SerializedName(SERIALIZED_NAME_POD)
@@ -79,6 +79,50 @@ public class ConfigureIndexRequestSpec {
     this.pod = pod;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ConfigureIndexRequestSpec instance itself
+   */
+  public ConfigureIndexRequestSpec putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -90,12 +134,13 @@ public class ConfigureIndexRequestSpec {
       return false;
     }
     ConfigureIndexRequestSpec configureIndexRequestSpec = (ConfigureIndexRequestSpec) o;
-    return Objects.equals(this.pod, configureIndexRequestSpec.pod);
+    return Objects.equals(this.pod, configureIndexRequestSpec.pod)&&
+        Objects.equals(this.additionalProperties, configureIndexRequestSpec.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pod);
+    return Objects.hash(pod, additionalProperties);
   }
 
   @Override
@@ -103,6 +148,7 @@ public class ConfigureIndexRequestSpec {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConfigureIndexRequestSpec {\n");
     sb.append("    pod: ").append(toIndentedString(pod)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -145,14 +191,6 @@ public class ConfigureIndexRequestSpec {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ConfigureIndexRequestSpec.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ConfigureIndexRequestSpec` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ConfigureIndexRequestSpec.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -179,6 +217,23 @@ public class ConfigureIndexRequestSpec {
            @Override
            public void write(JsonWriter out, ConfigureIndexRequestSpec value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -186,7 +241,28 @@ public class ConfigureIndexRequestSpec {
            public ConfigureIndexRequestSpec read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ConfigureIndexRequestSpec instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/ConfigureIndexRequestSpecPod.java
+++ b/src/main/java/org/openapitools/client/model/ConfigureIndexRequestSpecPod.java
@@ -49,7 +49,7 @@ import org.openapitools.client.JSON;
 /**
  * ConfigureIndexRequestSpecPod
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ConfigureIndexRequestSpecPod {
   public static final String SERIALIZED_NAME_REPLICAS = "replicas";
   @SerializedName(SERIALIZED_NAME_REPLICAS)
@@ -104,6 +104,50 @@ public class ConfigureIndexRequestSpecPod {
     this.podType = podType;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ConfigureIndexRequestSpecPod instance itself
+   */
+  public ConfigureIndexRequestSpecPod putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -116,12 +160,13 @@ public class ConfigureIndexRequestSpecPod {
     }
     ConfigureIndexRequestSpecPod configureIndexRequestSpecPod = (ConfigureIndexRequestSpecPod) o;
     return Objects.equals(this.replicas, configureIndexRequestSpecPod.replicas) &&
-        Objects.equals(this.podType, configureIndexRequestSpecPod.podType);
+        Objects.equals(this.podType, configureIndexRequestSpecPod.podType)&&
+        Objects.equals(this.additionalProperties, configureIndexRequestSpecPod.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(replicas, podType);
+    return Objects.hash(replicas, podType, additionalProperties);
   }
 
   @Override
@@ -130,6 +175,7 @@ public class ConfigureIndexRequestSpecPod {
     sb.append("class ConfigureIndexRequestSpecPod {\n");
     sb.append("    replicas: ").append(toIndentedString(replicas)).append("\n");
     sb.append("    podType: ").append(toIndentedString(podType)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -171,14 +217,6 @@ public class ConfigureIndexRequestSpecPod {
           throw new IllegalArgumentException(String.format("The required field(s) %s in ConfigureIndexRequestSpecPod is not found in the empty JSON string", ConfigureIndexRequestSpecPod.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ConfigureIndexRequestSpecPod.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ConfigureIndexRequestSpecPod` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("pod_type") != null && !jsonObj.get("pod_type").isJsonNull()) && !jsonObj.get("pod_type").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `pod_type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("pod_type").toString()));
@@ -200,6 +238,23 @@ public class ConfigureIndexRequestSpecPod {
            @Override
            public void write(JsonWriter out, ConfigureIndexRequestSpecPod value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -207,7 +262,28 @@ public class ConfigureIndexRequestSpecPod {
            public ConfigureIndexRequestSpecPod read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ConfigureIndexRequestSpecPod instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/CreateCollectionRequest.java
+++ b/src/main/java/org/openapitools/client/model/CreateCollectionRequest.java
@@ -49,7 +49,7 @@ import org.openapitools.client.JSON;
 /**
  * The configuration needed to create a Pinecone collection.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class CreateCollectionRequest {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -103,6 +103,50 @@ public class CreateCollectionRequest {
     this.source = source;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateCollectionRequest instance itself
+   */
+  public CreateCollectionRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -115,12 +159,13 @@ public class CreateCollectionRequest {
     }
     CreateCollectionRequest createCollectionRequest = (CreateCollectionRequest) o;
     return Objects.equals(this.name, createCollectionRequest.name) &&
-        Objects.equals(this.source, createCollectionRequest.source);
+        Objects.equals(this.source, createCollectionRequest.source)&&
+        Objects.equals(this.additionalProperties, createCollectionRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, source);
+    return Objects.hash(name, source, additionalProperties);
   }
 
   @Override
@@ -129,6 +174,7 @@ public class CreateCollectionRequest {
     sb.append("class CreateCollectionRequest {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    source: ").append(toIndentedString(source)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -173,14 +219,6 @@ public class CreateCollectionRequest {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateCollectionRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateCollectionRequest` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateCollectionRequest.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -211,6 +249,23 @@ public class CreateCollectionRequest {
            @Override
            public void write(JsonWriter out, CreateCollectionRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -218,7 +273,28 @@ public class CreateCollectionRequest {
            public CreateCollectionRequest read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateCollectionRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/CreateIndexRequest.java
+++ b/src/main/java/org/openapitools/client/model/CreateIndexRequest.java
@@ -51,7 +51,7 @@ import org.openapitools.client.JSON;
 /**
  * The configuration needed to create a Pinecone index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class CreateIndexRequest {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -100,7 +100,7 @@ public class CreateIndexRequest {
   }
 
    /**
-   * The dimensions of the vectors to be inserted in the index
+   * The dimensions of the vectors to be inserted in the index.
    * minimum: 1
    * maximum: 20000
    * @return dimension
@@ -157,6 +157,50 @@ public class CreateIndexRequest {
     this.spec = spec;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateIndexRequest instance itself
+   */
+  public CreateIndexRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class CreateIndexRequest {
     return Objects.equals(this.name, createIndexRequest.name) &&
         Objects.equals(this.dimension, createIndexRequest.dimension) &&
         Objects.equals(this.metric, createIndexRequest.metric) &&
-        Objects.equals(this.spec, createIndexRequest.spec);
+        Objects.equals(this.spec, createIndexRequest.spec)&&
+        Objects.equals(this.additionalProperties, createIndexRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, dimension, metric, spec);
+    return Objects.hash(name, dimension, metric, spec, additionalProperties);
   }
 
   @Override
@@ -187,6 +232,7 @@ public class CreateIndexRequest {
     sb.append("    dimension: ").append(toIndentedString(dimension)).append("\n");
     sb.append("    metric: ").append(toIndentedString(metric)).append("\n");
     sb.append("    spec: ").append(toIndentedString(spec)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -234,14 +280,6 @@ public class CreateIndexRequest {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateIndexRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateIndexRequest` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateIndexRequest.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -271,6 +309,23 @@ public class CreateIndexRequest {
            @Override
            public void write(JsonWriter out, CreateIndexRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -278,7 +333,28 @@ public class CreateIndexRequest {
            public CreateIndexRequest read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateIndexRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/CreateIndexRequestSpec.java
+++ b/src/main/java/org/openapitools/client/model/CreateIndexRequestSpec.java
@@ -49,9 +49,9 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * Spec objects describe how the index should be deployed
+ * The spec object defines how the index should be deployed.  For serverless indexes, you define only the cloud and region where the index should be hosted. For pod-based indexes, you define the environment where the index should be hosted, the pod type and size to use, and other index characteristics.  Serverless indexes are in public preview and are available only on AWS in the us-west-2 and us-east-1 regions. Test thoroughly before using serverless indexes in production. 
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class CreateIndexRequestSpec {
   public static final String SERIALIZED_NAME_SERVERLESS = "serverless";
   @SerializedName(SERIALIZED_NAME_SERVERLESS)

--- a/src/main/java/org/openapitools/client/model/CreateIndexRequestSpecPod.java
+++ b/src/main/java/org/openapitools/client/model/CreateIndexRequestSpecPod.java
@@ -21,7 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
-import org.openapitools.client.model.PodSpecMetadataConfig;
+import org.openapitools.client.model.CreateIndexRequestSpecPodMetadataConfig;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -48,9 +48,9 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * Configuration needed to deploy a pod index
+ * Configuration needed to deploy a pod-based index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class CreateIndexRequestSpecPod {
   public static final String SERIALIZED_NAME_ENVIRONMENT = "environment";
   @SerializedName(SERIALIZED_NAME_ENVIRONMENT)
@@ -74,7 +74,7 @@ public class CreateIndexRequestSpecPod {
 
   public static final String SERIALIZED_NAME_METADATA_CONFIG = "metadata_config";
   @SerializedName(SERIALIZED_NAME_METADATA_CONFIG)
-  private PodSpecMetadataConfig metadataConfig;
+  private CreateIndexRequestSpecPodMetadataConfig metadataConfig;
 
   public static final String SERIALIZED_NAME_SOURCE_COLLECTION = "source_collection";
   @SerializedName(SERIALIZED_NAME_SOURCE_COLLECTION)
@@ -191,7 +191,7 @@ public class CreateIndexRequestSpecPod {
   }
 
 
-  public CreateIndexRequestSpecPod metadataConfig(PodSpecMetadataConfig metadataConfig) {
+  public CreateIndexRequestSpecPod metadataConfig(CreateIndexRequestSpecPodMetadataConfig metadataConfig) {
     
     this.metadataConfig = metadataConfig;
     return this;
@@ -202,12 +202,12 @@ public class CreateIndexRequestSpecPod {
    * @return metadataConfig
   **/
   @javax.annotation.Nullable
-  public PodSpecMetadataConfig getMetadataConfig() {
+  public CreateIndexRequestSpecPodMetadataConfig getMetadataConfig() {
     return metadataConfig;
   }
 
 
-  public void setMetadataConfig(PodSpecMetadataConfig metadataConfig) {
+  public void setMetadataConfig(CreateIndexRequestSpecPodMetadataConfig metadataConfig) {
     this.metadataConfig = metadataConfig;
   }
 
@@ -232,6 +232,50 @@ public class CreateIndexRequestSpecPod {
     this.sourceCollection = sourceCollection;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateIndexRequestSpecPod instance itself
+   */
+  public CreateIndexRequestSpecPod putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -249,12 +293,13 @@ public class CreateIndexRequestSpecPod {
         Objects.equals(this.pods, createIndexRequestSpecPod.pods) &&
         Objects.equals(this.shards, createIndexRequestSpecPod.shards) &&
         Objects.equals(this.metadataConfig, createIndexRequestSpecPod.metadataConfig) &&
-        Objects.equals(this.sourceCollection, createIndexRequestSpecPod.sourceCollection);
+        Objects.equals(this.sourceCollection, createIndexRequestSpecPod.sourceCollection)&&
+        Objects.equals(this.additionalProperties, createIndexRequestSpecPod.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(environment, replicas, podType, pods, shards, metadataConfig, sourceCollection);
+    return Objects.hash(environment, replicas, podType, pods, shards, metadataConfig, sourceCollection, additionalProperties);
   }
 
   @Override
@@ -268,6 +313,7 @@ public class CreateIndexRequestSpecPod {
     sb.append("    shards: ").append(toIndentedString(shards)).append("\n");
     sb.append("    metadataConfig: ").append(toIndentedString(metadataConfig)).append("\n");
     sb.append("    sourceCollection: ").append(toIndentedString(sourceCollection)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -317,14 +363,6 @@ public class CreateIndexRequestSpecPod {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateIndexRequestSpecPod.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateIndexRequestSpecPod` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateIndexRequestSpecPod.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -340,7 +378,7 @@ public class CreateIndexRequestSpecPod {
       }
       // validate the optional field `metadata_config`
       if (jsonObj.get("metadata_config") != null && !jsonObj.get("metadata_config").isJsonNull()) {
-        PodSpecMetadataConfig.validateJsonElement(jsonObj.get("metadata_config"));
+        CreateIndexRequestSpecPodMetadataConfig.validateJsonElement(jsonObj.get("metadata_config"));
       }
       if ((jsonObj.get("source_collection") != null && !jsonObj.get("source_collection").isJsonNull()) && !jsonObj.get("source_collection").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `source_collection` to be a primitive type in the JSON string but got `%s`", jsonObj.get("source_collection").toString()));
@@ -362,6 +400,23 @@ public class CreateIndexRequestSpecPod {
            @Override
            public void write(JsonWriter out, CreateIndexRequestSpecPod value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -369,7 +424,28 @@ public class CreateIndexRequestSpecPod {
            public CreateIndexRequestSpecPod read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateIndexRequestSpecPod instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/CreateIndexRequestSpecPodMetadataConfig.java
+++ b/src/main/java/org/openapitools/client/model/CreateIndexRequestSpecPodMetadataConfig.java
@@ -20,9 +20,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import org.openapitools.client.model.PodSpec;
-import org.openapitools.client.model.ServerlessSpec;
+import java.util.List;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -49,60 +49,43 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * IndexModelSpec
+ * Configuration for the behavior of Pinecone&#39;s internal metadata index. By default, all metadata is indexed; when &#x60;metadata_config&#x60; is present, only specified metadata fields are indexed. These configurations are only valid for use with pod-based indexes.
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
-public class IndexModelSpec {
-  public static final String SERIALIZED_NAME_POD = "pod";
-  @SerializedName(SERIALIZED_NAME_POD)
-  private PodSpec pod;
+public class CreateIndexRequestSpecPodMetadataConfig {
+  public static final String SERIALIZED_NAME_INDEXED = "indexed";
+  @SerializedName(SERIALIZED_NAME_INDEXED)
+  private List<String> indexed;
 
-  public static final String SERIALIZED_NAME_SERVERLESS = "serverless";
-  @SerializedName(SERIALIZED_NAME_SERVERLESS)
-  private ServerlessSpec serverless;
-
-  public IndexModelSpec() {
+  public CreateIndexRequestSpecPodMetadataConfig() {
   }
 
-  public IndexModelSpec pod(PodSpec pod) {
+  public CreateIndexRequestSpecPodMetadataConfig indexed(List<String> indexed) {
     
-    this.pod = pod;
+    this.indexed = indexed;
+    return this;
+  }
+
+  public CreateIndexRequestSpecPodMetadataConfig addIndexedItem(String indexedItem) {
+    if (this.indexed == null) {
+      this.indexed = new ArrayList<>();
+    }
+    this.indexed.add(indexedItem);
     return this;
   }
 
    /**
-   * Get pod
-   * @return pod
+   * By default, all metadata is indexed; to change this behavior, use this property to specify an array of metadata fields which should be indexed.
+   * @return indexed
   **/
   @javax.annotation.Nullable
-  public PodSpec getPod() {
-    return pod;
+  public List<String> getIndexed() {
+    return indexed;
   }
 
 
-  public void setPod(PodSpec pod) {
-    this.pod = pod;
-  }
-
-
-  public IndexModelSpec serverless(ServerlessSpec serverless) {
-    
-    this.serverless = serverless;
-    return this;
-  }
-
-   /**
-   * Get serverless
-   * @return serverless
-  **/
-  @javax.annotation.Nullable
-  public ServerlessSpec getServerless() {
-    return serverless;
-  }
-
-
-  public void setServerless(ServerlessSpec serverless) {
-    this.serverless = serverless;
+  public void setIndexed(List<String> indexed) {
+    this.indexed = indexed;
   }
 
   /**
@@ -118,9 +101,9 @@ public class IndexModelSpec {
    *
    * @param key name of the property
    * @param value value of the property
-   * @return the IndexModelSpec instance itself
+   * @return the CreateIndexRequestSpecPodMetadataConfig instance itself
    */
-  public IndexModelSpec putAdditionalProperty(String key, Object value) {
+  public CreateIndexRequestSpecPodMetadataConfig putAdditionalProperty(String key, Object value) {
     if (this.additionalProperties == null) {
         this.additionalProperties = new HashMap<String, Object>();
     }
@@ -159,23 +142,21 @@ public class IndexModelSpec {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    IndexModelSpec indexModelSpec = (IndexModelSpec) o;
-    return Objects.equals(this.pod, indexModelSpec.pod) &&
-        Objects.equals(this.serverless, indexModelSpec.serverless)&&
-        Objects.equals(this.additionalProperties, indexModelSpec.additionalProperties);
+    CreateIndexRequestSpecPodMetadataConfig createIndexRequestSpecPodMetadataConfig = (CreateIndexRequestSpecPodMetadataConfig) o;
+    return Objects.equals(this.indexed, createIndexRequestSpecPodMetadataConfig.indexed)&&
+        Objects.equals(this.additionalProperties, createIndexRequestSpecPodMetadataConfig.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pod, serverless, additionalProperties);
+    return Objects.hash(indexed, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class IndexModelSpec {\n");
-    sb.append("    pod: ").append(toIndentedString(pod)).append("\n");
-    sb.append("    serverless: ").append(toIndentedString(serverless)).append("\n");
+    sb.append("class CreateIndexRequestSpecPodMetadataConfig {\n");
+    sb.append("    indexed: ").append(toIndentedString(indexed)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -199,8 +180,7 @@ public class IndexModelSpec {
   static {
     // a set of all properties/fields (JSON key names)
     openapiFields = new HashSet<String>();
-    openapiFields.add("pod");
-    openapiFields.add("serverless");
+    openapiFields.add("indexed");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -210,22 +190,18 @@ public class IndexModelSpec {
   * Validates the JSON Element and throws an exception if issues found
   *
   * @param jsonElement JSON Element
-  * @throws IOException if the JSON Element is invalid with respect to IndexModelSpec
+  * @throws IOException if the JSON Element is invalid with respect to CreateIndexRequestSpecPodMetadataConfig
   */
   public static void validateJsonElement(JsonElement jsonElement) throws IOException {
       if (jsonElement == null) {
-        if (!IndexModelSpec.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
-          throw new IllegalArgumentException(String.format("The required field(s) %s in IndexModelSpec is not found in the empty JSON string", IndexModelSpec.openapiRequiredFields.toString()));
+        if (!CreateIndexRequestSpecPodMetadataConfig.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in CreateIndexRequestSpecPodMetadataConfig is not found in the empty JSON string", CreateIndexRequestSpecPodMetadataConfig.openapiRequiredFields.toString()));
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      // validate the optional field `pod`
-      if (jsonObj.get("pod") != null && !jsonObj.get("pod").isJsonNull()) {
-        PodSpec.validateJsonElement(jsonObj.get("pod"));
-      }
-      // validate the optional field `serverless`
-      if (jsonObj.get("serverless") != null && !jsonObj.get("serverless").isJsonNull()) {
-        ServerlessSpec.validateJsonElement(jsonObj.get("serverless"));
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("indexed") != null && !jsonObj.get("indexed").isJsonNull() && !jsonObj.get("indexed").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field `indexed` to be an array in the JSON string but got `%s`", jsonObj.get("indexed").toString()));
       }
   }
 
@@ -233,16 +209,16 @@ public class IndexModelSpec {
     @SuppressWarnings("unchecked")
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-       if (!IndexModelSpec.class.isAssignableFrom(type.getRawType())) {
-         return null; // this class only serializes 'IndexModelSpec' and its subtypes
+       if (!CreateIndexRequestSpecPodMetadataConfig.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'CreateIndexRequestSpecPodMetadataConfig' and its subtypes
        }
        final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
-       final TypeAdapter<IndexModelSpec> thisAdapter
-                        = gson.getDelegateAdapter(this, TypeToken.get(IndexModelSpec.class));
+       final TypeAdapter<CreateIndexRequestSpecPodMetadataConfig> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(CreateIndexRequestSpecPodMetadataConfig.class));
 
-       return (TypeAdapter<T>) new TypeAdapter<IndexModelSpec>() {
+       return (TypeAdapter<T>) new TypeAdapter<CreateIndexRequestSpecPodMetadataConfig>() {
            @Override
-           public void write(JsonWriter out, IndexModelSpec value) throws IOException {
+           public void write(JsonWriter out, CreateIndexRequestSpecPodMetadataConfig value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
              obj.remove("additionalProperties");
              // serialize additional properties
@@ -265,12 +241,12 @@ public class IndexModelSpec {
            }
 
            @Override
-           public IndexModelSpec read(JsonReader in) throws IOException {
+           public CreateIndexRequestSpecPodMetadataConfig read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
              JsonObject jsonObj = jsonElement.getAsJsonObject();
              // store additional fields in the deserialized instance
-             IndexModelSpec instance = thisAdapter.fromJsonTree(jsonObj);
+             CreateIndexRequestSpecPodMetadataConfig instance = thisAdapter.fromJsonTree(jsonObj);
              for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
                if (!openapiFields.contains(entry.getKey())) {
                  if (entry.getValue().isJsonPrimitive()) { // primitive type
@@ -297,18 +273,18 @@ public class IndexModelSpec {
   }
 
  /**
-  * Create an instance of IndexModelSpec given an JSON string
+  * Create an instance of CreateIndexRequestSpecPodMetadataConfig given an JSON string
   *
   * @param jsonString JSON string
-  * @return An instance of IndexModelSpec
-  * @throws IOException if the JSON string is invalid with respect to IndexModelSpec
+  * @return An instance of CreateIndexRequestSpecPodMetadataConfig
+  * @throws IOException if the JSON string is invalid with respect to CreateIndexRequestSpecPodMetadataConfig
   */
-  public static IndexModelSpec fromJson(String jsonString) throws IOException {
-    return JSON.getGson().fromJson(jsonString, IndexModelSpec.class);
+  public static CreateIndexRequestSpecPodMetadataConfig fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, CreateIndexRequestSpecPodMetadataConfig.class);
   }
 
  /**
-  * Convert an instance of IndexModelSpec to an JSON string
+  * Convert an instance of CreateIndexRequestSpecPodMetadataConfig to an JSON string
   *
   * @return JSON string
   */

--- a/src/main/java/org/openapitools/client/model/ErrorResponse.java
+++ b/src/main/java/org/openapitools/client/model/ErrorResponse.java
@@ -48,9 +48,9 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * The response shape used for all error responses
+ * The response shape used for all error responses.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ErrorResponse {
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)
@@ -70,7 +70,7 @@ public class ErrorResponse {
   }
 
    /**
-   * The HTTP status code of the error
+   * The HTTP status code of the error.
    * @return status
   **/
   @javax.annotation.Nonnull
@@ -104,6 +104,50 @@ public class ErrorResponse {
     this.error = error;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ErrorResponse instance itself
+   */
+  public ErrorResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -116,12 +160,13 @@ public class ErrorResponse {
     }
     ErrorResponse errorResponse = (ErrorResponse) o;
     return Objects.equals(this.status, errorResponse.status) &&
-        Objects.equals(this.error, errorResponse.error);
+        Objects.equals(this.error, errorResponse.error)&&
+        Objects.equals(this.additionalProperties, errorResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, error);
+    return Objects.hash(status, error, additionalProperties);
   }
 
   @Override
@@ -130,6 +175,7 @@ public class ErrorResponse {
     sb.append("class ErrorResponse {\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -174,14 +220,6 @@ public class ErrorResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ErrorResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ErrorResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ErrorResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -208,6 +246,23 @@ public class ErrorResponse {
            @Override
            public void write(JsonWriter out, ErrorResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -215,7 +270,28 @@ public class ErrorResponse {
            public ErrorResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ErrorResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/ErrorResponseError.java
+++ b/src/main/java/org/openapitools/client/model/ErrorResponseError.java
@@ -47,9 +47,9 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * Detailed information about the error that occurred
+ * Detailed information about the error that occurred.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ErrorResponseError {
   /**
    * Gets or Sets code
@@ -207,6 +207,50 @@ public class ErrorResponseError {
     this.details = details;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ErrorResponseError instance itself
+   */
+  public ErrorResponseError putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -220,12 +264,13 @@ public class ErrorResponseError {
     ErrorResponseError errorResponseError = (ErrorResponseError) o;
     return Objects.equals(this.code, errorResponseError.code) &&
         Objects.equals(this.message, errorResponseError.message) &&
-        Objects.equals(this.details, errorResponseError.details);
+        Objects.equals(this.details, errorResponseError.details)&&
+        Objects.equals(this.additionalProperties, errorResponseError.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(code, message, details);
+    return Objects.hash(code, message, details, additionalProperties);
   }
 
   @Override
@@ -235,6 +280,7 @@ public class ErrorResponseError {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    details: ").append(toIndentedString(details)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -280,14 +326,6 @@ public class ErrorResponseError {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ErrorResponseError.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ErrorResponseError` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ErrorResponseError.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -318,6 +356,23 @@ public class ErrorResponseError {
            @Override
            public void write(JsonWriter out, ErrorResponseError value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -325,7 +380,28 @@ public class ErrorResponseError {
            public ErrorResponseError read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ErrorResponseError instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/IndexList.java
+++ b/src/main/java/org/openapitools/client/model/IndexList.java
@@ -52,7 +52,7 @@ import org.openapitools.client.JSON;
 /**
  * The list of indexes that exist in the project.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class IndexList {
   public static final String SERIALIZED_NAME_INDEXES = "indexes";
   @SerializedName(SERIALIZED_NAME_INDEXES)
@@ -89,6 +89,50 @@ public class IndexList {
     this.indexes = indexes;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IndexList instance itself
+   */
+  public IndexList putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -100,12 +144,13 @@ public class IndexList {
       return false;
     }
     IndexList indexList = (IndexList) o;
-    return Objects.equals(this.indexes, indexList.indexes);
+    return Objects.equals(this.indexes, indexList.indexes)&&
+        Objects.equals(this.additionalProperties, indexList.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(indexes);
+    return Objects.hash(indexes, additionalProperties);
   }
 
   @Override
@@ -113,6 +158,7 @@ public class IndexList {
     StringBuilder sb = new StringBuilder();
     sb.append("class IndexList {\n");
     sb.append("    indexes: ").append(toIndentedString(indexes)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -153,14 +199,6 @@ public class IndexList {
           throw new IllegalArgumentException(String.format("The required field(s) %s in IndexList is not found in the empty JSON string", IndexList.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IndexList.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IndexList` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if (jsonObj.get("indexes") != null && !jsonObj.get("indexes").isJsonNull()) {
         JsonArray jsonArrayindexes = jsonObj.getAsJsonArray("indexes");
@@ -193,6 +231,23 @@ public class IndexList {
            @Override
            public void write(JsonWriter out, IndexList value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -200,7 +255,28 @@ public class IndexList {
            public IndexList read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IndexList instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/IndexModel.java
+++ b/src/main/java/org/openapitools/client/model/IndexModel.java
@@ -52,7 +52,7 @@ import org.openapitools.client.JSON;
 /**
  * The IndexModel describes the configuration and status of a Pinecone index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class IndexModel {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -109,7 +109,7 @@ public class IndexModel {
   }
 
    /**
-   * The dimensions of the vectors to be inserted in the index
+   * The dimensions of the vectors to be inserted in the index.
    * minimum: 1
    * maximum: 20000
    * @return dimension
@@ -156,7 +156,7 @@ public class IndexModel {
    * The URL address where the index is hosted.
    * @return host
   **/
-  @javax.annotation.Nullable
+  @javax.annotation.Nonnull
   public String getHost() {
     return host;
   }
@@ -208,6 +208,50 @@ public class IndexModel {
     this.status = status;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IndexModel instance itself
+   */
+  public IndexModel putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -224,12 +268,13 @@ public class IndexModel {
         Objects.equals(this.metric, indexModel.metric) &&
         Objects.equals(this.host, indexModel.host) &&
         Objects.equals(this.spec, indexModel.spec) &&
-        Objects.equals(this.status, indexModel.status);
+        Objects.equals(this.status, indexModel.status)&&
+        Objects.equals(this.additionalProperties, indexModel.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, dimension, metric, host, spec, status);
+    return Objects.hash(name, dimension, metric, host, spec, status, additionalProperties);
   }
 
   @Override
@@ -242,6 +287,7 @@ public class IndexModel {
     sb.append("    host: ").append(toIndentedString(host)).append("\n");
     sb.append("    spec: ").append(toIndentedString(spec)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -276,6 +322,7 @@ public class IndexModel {
     openapiRequiredFields.add("name");
     openapiRequiredFields.add("dimension");
     openapiRequiredFields.add("metric");
+    openapiRequiredFields.add("host");
     openapiRequiredFields.add("spec");
     openapiRequiredFields.add("status");
   }
@@ -293,14 +340,6 @@ public class IndexModel {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IndexModel.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IndexModel` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IndexModel.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -311,7 +350,7 @@ public class IndexModel {
       if (!jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
       }
-      if ((jsonObj.get("host") != null && !jsonObj.get("host").isJsonNull()) && !jsonObj.get("host").isJsonPrimitive()) {
+      if (!jsonObj.get("host").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `host` to be a primitive type in the JSON string but got `%s`", jsonObj.get("host").toString()));
       }
       // validate the required field `spec`
@@ -335,6 +374,23 @@ public class IndexModel {
            @Override
            public void write(JsonWriter out, IndexModel value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -342,7 +398,28 @@ public class IndexModel {
            public IndexModel read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IndexModel instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/IndexModelStatus.java
+++ b/src/main/java/org/openapitools/client/model/IndexModelStatus.java
@@ -49,7 +49,7 @@ import org.openapitools.client.JSON;
 /**
  * IndexModelStatus
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class IndexModelStatus {
   public static final String SERIALIZED_NAME_READY = "ready";
   @SerializedName(SERIALIZED_NAME_READY)
@@ -71,8 +71,6 @@ public class IndexModelStatus {
     SCALINGUPPODSIZE("ScalingUpPodSize"),
     
     SCALINGDOWNPODSIZE("ScalingDownPodSize"),
-    
-    UPGRADING("Upgrading"),
     
     TERMINATING("Terminating"),
     
@@ -164,6 +162,50 @@ public class IndexModelStatus {
     this.state = state;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IndexModelStatus instance itself
+   */
+  public IndexModelStatus putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -176,12 +218,13 @@ public class IndexModelStatus {
     }
     IndexModelStatus indexModelStatus = (IndexModelStatus) o;
     return Objects.equals(this.ready, indexModelStatus.ready) &&
-        Objects.equals(this.state, indexModelStatus.state);
+        Objects.equals(this.state, indexModelStatus.state)&&
+        Objects.equals(this.additionalProperties, indexModelStatus.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ready, state);
+    return Objects.hash(ready, state, additionalProperties);
   }
 
   @Override
@@ -190,6 +233,7 @@ public class IndexModelStatus {
     sb.append("class IndexModelStatus {\n");
     sb.append("    ready: ").append(toIndentedString(ready)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -234,14 +278,6 @@ public class IndexModelStatus {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IndexModelStatus.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IndexModelStatus` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IndexModelStatus.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -269,6 +305,23 @@ public class IndexModelStatus {
            @Override
            public void write(JsonWriter out, IndexModelStatus value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -276,7 +329,28 @@ public class IndexModelStatus {
            public IndexModelStatus read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IndexModelStatus instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/PodSpec.java
+++ b/src/main/java/org/openapitools/client/model/PodSpec.java
@@ -48,9 +48,9 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * Configuration needed to deploy a pod index
+ * Configuration needed to deploy a pod-based index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class PodSpec {
   public static final String SERIALIZED_NAME_ENVIRONMENT = "environment";
   @SerializedName(SERIALIZED_NAME_ENVIRONMENT)
@@ -176,7 +176,7 @@ public class PodSpec {
   }
 
    /**
-   * The number of pods to be used in the index. This should be equal to &#x60;shards&#x60; x &#x60;replicas&#x60;.
+   * The number of pods to be used in the index. This should be equal to &#x60;shards&#x60; x &#x60;replicas&#x60;.&#39;
    * minimum: 1
    * @return pods
   **/
@@ -232,6 +232,50 @@ public class PodSpec {
     this.sourceCollection = sourceCollection;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PodSpec instance itself
+   */
+  public PodSpec putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -249,12 +293,13 @@ public class PodSpec {
         Objects.equals(this.podType, podSpec.podType) &&
         Objects.equals(this.pods, podSpec.pods) &&
         Objects.equals(this.metadataConfig, podSpec.metadataConfig) &&
-        Objects.equals(this.sourceCollection, podSpec.sourceCollection);
+        Objects.equals(this.sourceCollection, podSpec.sourceCollection)&&
+        Objects.equals(this.additionalProperties, podSpec.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(environment, replicas, shards, podType, pods, metadataConfig, sourceCollection);
+    return Objects.hash(environment, replicas, shards, podType, pods, metadataConfig, sourceCollection, additionalProperties);
   }
 
   @Override
@@ -268,6 +313,7 @@ public class PodSpec {
     sb.append("    pods: ").append(toIndentedString(pods)).append("\n");
     sb.append("    metadataConfig: ").append(toIndentedString(metadataConfig)).append("\n");
     sb.append("    sourceCollection: ").append(toIndentedString(sourceCollection)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -320,14 +366,6 @@ public class PodSpec {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PodSpec.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PodSpec` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PodSpec.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -365,6 +403,23 @@ public class PodSpec {
            @Override
            public void write(JsonWriter out, PodSpec value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -372,7 +427,28 @@ public class PodSpec {
            public PodSpec read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PodSpec instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/PodSpecMetadataConfig.java
+++ b/src/main/java/org/openapitools/client/model/PodSpecMetadataConfig.java
@@ -49,9 +49,9 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * Configuration for the behavior of Pinecone&#39;s internal metadata index. By default, all metadata is indexed; when &#x60;metadata_config&#x60; is present, only specified metadata fields are indexed. These configurations are only valid for use with pod indexes.
+ * Configuration for the behavior of Pinecone&#39;s internal metadata index. By default, all metadata is indexed; when &#x60;metadata_config&#x60; is present, only specified metadata fields are indexed. These configurations are only valid for use with pod-based indexes.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class PodSpecMetadataConfig {
   public static final String SERIALIZED_NAME_INDEXED = "indexed";
   @SerializedName(SERIALIZED_NAME_INDEXED)
@@ -75,7 +75,7 @@ public class PodSpecMetadataConfig {
   }
 
    /**
-   * By default, all metadata is indexed; to change this behavior, use this property to specify an array of metadata fields which should be indexed.
+   * By default, all metadata is indexed; to change this behavior, use this property to specify an array of metadata fields that should be indexed.
    * @return indexed
   **/
   @javax.annotation.Nullable
@@ -88,6 +88,50 @@ public class PodSpecMetadataConfig {
     this.indexed = indexed;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PodSpecMetadataConfig instance itself
+   */
+  public PodSpecMetadataConfig putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -99,12 +143,13 @@ public class PodSpecMetadataConfig {
       return false;
     }
     PodSpecMetadataConfig podSpecMetadataConfig = (PodSpecMetadataConfig) o;
-    return Objects.equals(this.indexed, podSpecMetadataConfig.indexed);
+    return Objects.equals(this.indexed, podSpecMetadataConfig.indexed)&&
+        Objects.equals(this.additionalProperties, podSpecMetadataConfig.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(indexed);
+    return Objects.hash(indexed, additionalProperties);
   }
 
   @Override
@@ -112,6 +157,7 @@ public class PodSpecMetadataConfig {
     StringBuilder sb = new StringBuilder();
     sb.append("class PodSpecMetadataConfig {\n");
     sb.append("    indexed: ").append(toIndentedString(indexed)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -152,14 +198,6 @@ public class PodSpecMetadataConfig {
           throw new IllegalArgumentException(String.format("The required field(s) %s in PodSpecMetadataConfig is not found in the empty JSON string", PodSpecMetadataConfig.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PodSpecMetadataConfig.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PodSpecMetadataConfig` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       // ensure the optional json data is an array if present
       if (jsonObj.get("indexed") != null && !jsonObj.get("indexed").isJsonNull() && !jsonObj.get("indexed").isJsonArray()) {
@@ -182,6 +220,23 @@ public class PodSpecMetadataConfig {
            @Override
            public void write(JsonWriter out, PodSpecMetadataConfig value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -189,7 +244,28 @@ public class PodSpecMetadataConfig {
            public PodSpecMetadataConfig read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PodSpecMetadataConfig instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/main/java/org/openapitools/client/model/ServerlessSpec.java
+++ b/src/main/java/org/openapitools/client/model/ServerlessSpec.java
@@ -47,12 +47,12 @@ import java.util.Set;
 import org.openapitools.client.JSON;
 
 /**
- * Configuration needed to deploy a serverless index
+ * Configuration needed to deploy a serverless index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-02-05T14:30:53.594301-05:00[America/New_York]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-04-06T02:44:17.986783Z[Etc/UTC]")
 public class ServerlessSpec {
   /**
-   * The public cloud where you would like your index hosted
+   * The public cloud where you would like your index hosted. Serverless indexes can be hosted only in AWS at this time.
    */
   @JsonAdapter(CloudEnum.Adapter.class)
   public enum CloudEnum {
@@ -118,7 +118,7 @@ public class ServerlessSpec {
   }
 
    /**
-   * The public cloud where you would like your index hosted
+   * The public cloud where you would like your index hosted. Serverless indexes can be hosted only in AWS at this time.
    * @return cloud
   **/
   @javax.annotation.Nonnull
@@ -139,7 +139,7 @@ public class ServerlessSpec {
   }
 
    /**
-   * The region where you would like your index to be created. Different cloud providers have different regions available.  See AwsRegions and GcpRegions for a list of available options.
+   * The region where you would like your index to be created.  Serverless indexes can be created only in the us-west-2 and us-east-1 regions of AWS at this time.
    * @return region
   **/
   @javax.annotation.Nonnull
@@ -152,6 +152,50 @@ public class ServerlessSpec {
     this.region = region;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ServerlessSpec instance itself
+   */
+  public ServerlessSpec putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -164,12 +208,13 @@ public class ServerlessSpec {
     }
     ServerlessSpec serverlessSpec = (ServerlessSpec) o;
     return Objects.equals(this.cloud, serverlessSpec.cloud) &&
-        Objects.equals(this.region, serverlessSpec.region);
+        Objects.equals(this.region, serverlessSpec.region)&&
+        Objects.equals(this.additionalProperties, serverlessSpec.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(cloud, region);
+    return Objects.hash(cloud, region, additionalProperties);
   }
 
   @Override
@@ -178,6 +223,7 @@ public class ServerlessSpec {
     sb.append("class ServerlessSpec {\n");
     sb.append("    cloud: ").append(toIndentedString(cloud)).append("\n");
     sb.append("    region: ").append(toIndentedString(region)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -222,14 +268,6 @@ public class ServerlessSpec {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ServerlessSpec.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ServerlessSpec` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ServerlessSpec.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -260,6 +298,23 @@ public class ServerlessSpec {
            @Override
            public void write(JsonWriter out, ServerlessSpec value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   obj.add(entry.getKey(), gson.toJsonTree(entry.getValue()).getAsJsonObject());
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -267,7 +322,28 @@ public class ServerlessSpec {
            public ServerlessSpec read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ServerlessSpec instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
+++ b/src/test/java/io/pinecone/PineconeIndexOperationsTest.java
@@ -1,0 +1,369 @@
+package io.pinecone;
+
+import com.google.gson.Gson;
+import io.pinecone.clients.Pinecone;
+import io.pinecone.exceptions.PineconeValidationException;
+import okhttp3.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openapitools.client.model.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class PineconeIndexOperationsTest {
+    private static final Gson gson = new Gson();
+
+    @Test
+    public void testDeleteIndex() throws IOException {
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create("Response body", MediaType.parse("text/plain")))
+                .build());
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        client.deleteIndex("testIndex");
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        verify(mockClient, times(1)).newCall(requestCaptor.capture());
+        verify(mockCall, times(1)).execute();
+        assertEquals(requestCaptor.getValue().method(), "DELETE");
+        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes/testIndex");
+    }
+
+    @Test
+    public void testCreateServerlessIndex() throws IOException {
+        String filePath = "src/test/resources/serverlessIndexJsonString.json";
+        String indexJsonStringServerless = new String(Files.readAllBytes(Paths.get(filePath)));
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(201)
+                .message("OK")
+                .body(ResponseBody.create(indexJsonStringServerless, MediaType.parse("application/json")))
+                .build());
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+
+        client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", "us-west-2");
+        verify(mockCall, times(1)).execute();
+
+        PineconeValidationException thrownEmptyIndexName = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("", "cosine", 3, "aws", "us-west-2"));
+        assertEquals("Index name cannot be null or empty", thrownEmptyIndexName.getMessage());
+
+        PineconeValidationException thrownNullIndexName = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex(null, "cosine", 3, "aws", "us-west-2"));
+        assertEquals("Index name cannot be null or empty", thrownNullIndexName.getMessage());
+
+        PineconeValidationException thrownEmptyMetric = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "", 3, "aws", "us-west-2"));
+        assertEquals("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()), thrownEmptyMetric.getMessage());
+
+        PineconeValidationException thrownInvalidMetric = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "blah", 3, "aws", "us-west-2"));
+        assertEquals(String.format("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values())), thrownInvalidMetric.getMessage());
+
+        PineconeValidationException thrownNullMetric = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", null, 3, "aws", "us-west-2"));
+        assertEquals("Metric cannot be null or empty. Must be one of " + Arrays.toString(IndexMetric.values()),
+            thrownNullMetric.getMessage());
+
+        PineconeValidationException thrownNegativeDimension = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", -3, "aws", "us-west-2"));
+        assertEquals("Dimension must be greater than 0. See limits for more info: https://docs.pinecone.io/reference/limits", thrownNegativeDimension.getMessage());
+
+        PineconeValidationException thrownEmptyCloud = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "", "us-west-2"));
+        assertEquals("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()),
+                thrownEmptyCloud.getMessage());
+
+        PineconeValidationException thrownNullCloud = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, null, "us-west-2"));
+        assertEquals("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()),
+                thrownNullCloud.getMessage());
+
+        PineconeValidationException thrownInvalidCloud = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "wooooo", "us-west-2"));
+        assertEquals("Cloud cannot be null or empty. Must be one of " + Arrays.toString(ServerlessSpec.CloudEnum.values()),
+                thrownInvalidCloud.getMessage());
+
+        PineconeValidationException thrownEmptyRegion = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", ""));
+        assertEquals("Region cannot be null or empty", thrownEmptyRegion.getMessage());
+
+        PineconeValidationException thrownNullRegion = assertThrows(PineconeValidationException.class,
+                () -> client.createServerlessIndex("testServerlessIndex", "cosine", 3, "aws", null));
+        assertEquals("Region cannot be null or empty", thrownNullRegion.getMessage());
+    }
+
+
+    @Test
+    public void testCreatePodIndex() throws IOException {
+        String filePath = "src/test/resources/podIndexJsonString.json";
+        String indexJsonStringPod = new String(Files.readAllBytes(Paths.get(filePath)));
+
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("test_name").dimension(3).metric(IndexMetric.COSINE);
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(201)
+                .message("OK")
+                .body(ResponseBody.create(indexJsonStringPod, MediaType.parse("application/json")))
+                .build());
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        client.createIndex(createIndexRequest);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        verify(mockClient, times(1)).newCall(requestCaptor.capture());
+        verify(mockCall, times(1)).execute();
+        assertEquals(requestCaptor.getValue().method(), "POST");
+        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes");
+    }
+
+    @Test
+    @Disabled("Re-enable when control plane validations added")
+    public void testCreateIndexWithNullIndex() {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest().dimension(3);
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        client.createIndex(createIndexRequest);
+        assertThrows(PineconeValidationException.class, () -> client.createIndex(createIndexRequest));
+    }
+
+    @Test
+    @Disabled("Re-enable when control plane validations added")
+    public void testCreateIndexWithNullDimensions() {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest().name("testIndex");
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        client.createIndex(createIndexRequest);
+        assertThrows(PineconeValidationException.class, () -> client.createIndex(createIndexRequest));
+    }
+
+    @Test
+    public void testCreateIndexWithAllFields() throws IOException {
+        String filePath = "src/test/resources/podIndexJsonString.json";
+        String indexJsonStringPod = new String(Files.readAllBytes(Paths.get(filePath)));
+        IndexModel expectedIndex = gson.fromJson(indexJsonStringPod, IndexModel.class);
+
+        CreateIndexRequestSpecPodMetadataConfig createIndexRequestSpecPodMetadataConfig = new CreateIndexRequestSpecPodMetadataConfig();
+        List<String> indexedItems = Arrays.asList("A", "B", "C", "D");
+        createIndexRequestSpecPodMetadataConfig.setIndexed(indexedItems);
+
+        CreateIndexRequestSpecPod requestSpecPod = new CreateIndexRequestSpecPod().pods(2).podType("p1.x2").replicas(2).metadataConfig(createIndexRequestSpecPodMetadataConfig).sourceCollection("step");
+        CreateIndexRequestSpec requestSpec = new CreateIndexRequestSpec().pod(requestSpecPod);
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest()
+                .name("test_name")
+                .dimension(3)
+                .metric(IndexMetric.EUCLIDEAN)
+                .spec(requestSpec);
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(201)
+                .message("OK")
+                .body(ResponseBody.create(indexJsonStringPod, MediaType.parse("application/json")))
+                .build());
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        IndexModel createdIndex = client.createIndex(createIndexRequest);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        verify(mockClient, times(1)).newCall(requestCaptor.capture());
+        verify(mockCall, times(1)).execute();
+        assertEquals(createdIndex, expectedIndex);
+        assertEquals(requestCaptor.getValue().method(), "POST");
+        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes");
+
+        // Test for null CreateIndexRequest object
+        PineconeValidationException thrown = assertThrows(PineconeValidationException.class,
+                () -> client.createIndex(null));
+        assertEquals("CreateIndexRequest object cannot be null", thrown.getMessage());
+    }
+
+    @Test
+    public void testDescribeIndex() throws IOException {
+        String filePath = "src/test/resources/serverlessIndexJsonString.json";
+        String indexJsonStringServerless = new String(Files.readAllBytes(Paths.get(filePath)));
+        IndexModel expectedIndex = gson.fromJson(indexJsonStringServerless, IndexModel.class);
+
+        Call mockCall = mock(Call.class);
+        Response mockResponse = new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create(indexJsonStringServerless, MediaType.parse("application/json")))
+                .build();
+
+        when(mockCall.execute()).thenReturn(mockResponse);
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        when(mockCall.execute()).thenReturn(mockResponse);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        IndexModel index = client.describeIndex("testIndex");
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        verify(mockClient, times(1)).newCall(requestCaptor.capture());
+        verify(mockCall, times(1)).execute();
+        assertEquals(expectedIndex, index);
+        assertEquals(requestCaptor.getValue().method(), "GET");
+        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes/testIndex");
+    }
+
+    @Test
+    public void testListIndexes() throws IOException {
+        String filePath = "src/test/resources/indexListJsonString.json";
+        String indexListJsonString = new String(Files.readAllBytes(Paths.get(filePath)));
+        IndexList expectedIndexList = gson.fromJson(indexListJsonString, IndexList.class);
+
+        Call mockCall = mock(Call.class);
+
+        Response mockResponse = new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create(indexListJsonString, MediaType.parse("application/json")))
+                .build();
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        when(mockCall.execute()).thenReturn(mockResponse);
+
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        IndexList indexList = client.listIndexes();
+
+        verify(mockClient, times(1)).newCall(requestCaptor.capture());
+        verify(mockCall, times(1)).execute();
+        assertEquals(indexList, expectedIndexList);
+        assertEquals(requestCaptor.getValue().method(), "GET");
+        assertEquals(requestCaptor.getValue().url().toString(), "https://api.pinecone.io/indexes");
+    }
+
+    @Test
+    public void testConfigureIndex() throws IOException {
+        String filePath = "src/test/resources/podIndexJsonString.json";
+        String podIndexJsonString = new String(Files.readAllBytes(Paths.get(filePath)));
+        IndexModel expectedConfiguredIndex = gson.fromJson(podIndexJsonString, IndexModel.class);
+
+        Call mockCall = mock(Call.class);
+        when(mockCall.execute()).thenReturn(new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(202)
+                .message("The index has been successfully updated.")
+                .body(ResponseBody.create(podIndexJsonString, MediaType.parse("application/json")))
+                .build());
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        IndexModel configuredIndex = client.configureIndex("testPodIndex", 3);
+
+        verify(mockCall, times(1)).execute();
+        assertEquals(expectedConfiguredIndex, configuredIndex);
+
+        // Test for empty string for index name
+        PineconeValidationException thrownEmptyIndexName = assertThrows(PineconeValidationException.class,
+                () -> client.configureIndex("",
+                        3));
+        assertEquals("indexName cannot be null or empty", thrownEmptyIndexName.getMessage());
+
+        // Test for null as index name
+        PineconeValidationException thrownNullIndexName = assertThrows(PineconeValidationException.class, () -> client.configureIndex(null,
+                3));
+        assertEquals("indexName cannot be null or empty", thrownNullIndexName.getMessage());
+
+        // Test for invalid number of replicas
+        PineconeValidationException thrownZeroReplicas = assertThrows(PineconeValidationException.class,
+                () -> client.configureIndex("testPodIndex", 0));
+        assertEquals("Number of replicas must be >= 1", thrownZeroReplicas.getMessage());
+    }
+
+    @Test
+    public void testCreateCollection() throws IOException {
+        String filePath = "src/test/resources/collectionCreation.json";
+        String JsonStringCollection = new String(Files.readAllBytes(Paths.get(filePath)));
+        CollectionModel expectedCollection = gson.fromJson(JsonStringCollection, CollectionModel.class);
+
+        Call mockCall = mock(Call.class);
+        Response mockResponse = new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create(JsonStringCollection, MediaType.parse("application/json")))
+                .build();
+
+        when(mockCall.execute()).thenReturn(mockResponse);
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        when(mockCall.execute()).thenReturn(mockResponse);
+
+        Pinecone client = new Pinecone.Builder("testAPiKey").withOkHttpClient(mockClient).build();
+        CollectionModel collection = client.createCollection(expectedCollection.getName(), "someSourceIndex");
+
+        // Test for successful creation of Collection
+        verify(mockCall, times(1)).execute();
+        assertEquals(expectedCollection, collection);
+
+        // Test for null and empty as collectionName
+        PineconeValidationException thrownNullCollectionName = assertThrows(PineconeValidationException.class,
+                () -> client.createCollection(null, "someSourceIndex"));
+        assertEquals("collectionName cannot be null or empty", thrownNullCollectionName.getMessage());
+        PineconeValidationException thrownEmptyCollectionName = assertThrows(PineconeValidationException.class,
+                () -> client.createCollection("", "someSourceIndex"));
+        assertEquals("collectionName cannot be null or empty", thrownEmptyCollectionName.getMessage());
+
+        // Test for null and empty as sourceIndex
+        PineconeValidationException thrownNullSourceIndex = assertThrows(PineconeValidationException.class,
+                () -> client.createCollection(expectedCollection.getName(), null));
+        assertEquals("sourceIndex cannot be null or empty", thrownNullSourceIndex.getMessage());
+        PineconeValidationException thrownEmptySourceIndex = assertThrows(PineconeValidationException.class,
+                () -> client.createCollection(expectedCollection.getName(), ""));
+        assertEquals("sourceIndex cannot be null or empty", thrownEmptySourceIndex.getMessage());
+    }
+}

--- a/src/test/java/org/openapitools/client/JsonParsingTest.java
+++ b/src/test/java/org/openapitools/client/JsonParsingTest.java
@@ -1,0 +1,116 @@
+package org.openapitools.client;
+
+import okhttp3.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openapitools.client.api.ManageIndexesApi;
+import org.openapitools.client.model.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class JsonParsingTest {
+    private OkHttpClient okHttpClient;
+    private ManageIndexesApi api;
+
+    @BeforeEach
+    public void setup() {
+        okHttpClient = mock(OkHttpClient.class);
+        ApiClient apiClient = new ApiClient(okHttpClient);
+        api = new ManageIndexesApi(apiClient);
+    }
+
+    private void setupMockResponse(String jsonResponse) throws Exception {
+        Call call = mock(Call.class);
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("http://example.com").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("")
+                .body(ResponseBody.create(
+                        jsonResponse, // JSON response
+                        MediaType.get("application/json; charset=utf-8")
+                ))
+                .build();
+
+        when(call.execute()).thenReturn(response);
+        when(okHttpClient.newCall(any(Request.class))).thenReturn(call);
+    }
+
+    private String readJsonFromFile(String path) throws IOException {
+        // Ensure the path is correctly referenced from your resources directory
+        return new String(Files.readAllBytes(Paths.get(path)));
+    }
+
+    @Test
+    public void test_describeIndex_happyPath() throws Exception {
+        String jsonResponse = readJsonFromFile("src/test/resources/describeIndexResponse.valid.json");
+        setupMockResponse(jsonResponse);
+
+        IndexModel indexModel = api.describeIndex("test-index");
+
+        // Don't need a ton of assertions here. The point is the code didn't blow up
+        // due to parsing the JSON response.
+        assertEquals("test-index", indexModel.getName());
+        assertEquals("Ready", indexModel.getStatus().getState().getValue());
+    }
+
+    @Test
+    public void test_describeIndex_extraProperties() throws Exception {
+        String jsonResponse = readJsonFromFile("src/test/resources/describeIndexResponse.withUnknownProperties.json");
+        setupMockResponse(jsonResponse);
+
+        IndexModel indexModel = api.describeIndex("test-index");
+
+        assertEquals("test-index", indexModel.getName());
+        assertEquals("Ready", indexModel.getStatus().getState().getValue());
+    }
+
+    @Test
+    public void test_createIndex_happyPath() throws Exception {
+        String jsonResponse = readJsonFromFile("src/test/resources/createIndexResponse.valid.json");
+        setupMockResponse(jsonResponse);
+
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest();
+        createIndexRequest.setName("test-index");
+        createIndexRequest.setDimension(1536);
+        createIndexRequest.setMetric(IndexMetric.COSINE);
+        createIndexRequest.setSpec(new CreateIndexRequestSpec());
+        IndexModel indexModel = api.createIndex(createIndexRequest);
+
+        assertEquals("serverless-index", indexModel.getName());
+        assertEquals("Ready", indexModel.getStatus().getState().getValue());
+    }
+
+    @Test
+    public void test_createIndex_extraProperties() throws Exception {
+        String jsonResponse = readJsonFromFile("src/test/resources/createIndexResponse.withUnknownProperties.json");
+        setupMockResponse(jsonResponse);
+
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest();
+        createIndexRequest.setName("test-index");
+        createIndexRequest.setDimension(1536);
+        createIndexRequest.setMetric(IndexMetric.COSINE);
+        createIndexRequest.setSpec(new CreateIndexRequestSpec());
+        IndexModel indexModel = api.createIndex(createIndexRequest);
+
+        assertEquals("serverless-index", indexModel.getName());
+        assertEquals("Ready", indexModel.getStatus().getState().getValue());
+    }
+
+    @Test
+    public void test_describeCollection_happyPath() throws Exception {
+        String jsonResponse = readJsonFromFile("src/test/resources/describeCollection.valid.json");
+        setupMockResponse(jsonResponse);
+
+        CollectionModel collectionModel = api.describeCollection("tiny-collection");
+
+        assertEquals("tiny-collection", collectionModel.getName());
+        assertEquals("Ready", collectionModel.getStatus().getValue());
+    }
+}

--- a/src/test/resources/createIndexResponse.valid.json
+++ b/src/test/resources/createIndexResponse.valid.json
@@ -1,0 +1,16 @@
+{
+  "name": "serverless-index",
+  "metric": "cosine",
+  "dimension": 1536,
+  "status": {
+    "ready": true,
+    "state": "Ready"
+  },
+  "host": "serverless-index-4zo0ijk.svc.dev-us-west2-aws.pinecone.io",
+  "spec": {
+    "serverless": {
+      "region": "us-west-2",
+      "cloud": "aws"
+    }
+  }
+}

--- a/src/test/resources/createIndexResponse.withUnknownProperties.json
+++ b/src/test/resources/createIndexResponse.withUnknownProperties.json
@@ -1,0 +1,19 @@
+{
+  "name": "serverless-index",
+  "metric": "cosine",
+  "dimension": 1536,
+  "ux_feedback": "much wow",
+  "status": {
+    "ready": true,
+    "state": "Ready",
+    "reticulating_splines": true
+  },
+  "host": "serverless-index-4zo0ijk.svc.dev-us-west2-aws.pinecone.io",
+  "spec": {
+    "serverless": {
+      "region": "us-west-2",
+      "cloud": "aws",
+      "weather_forecast": "partly sunny"
+    }
+  }
+}

--- a/src/test/resources/describeCollection.valid.json
+++ b/src/test/resources/describeCollection.valid.json
@@ -1,0 +1,8 @@
+{
+  "dimension": 3,
+  "environment": "us-east1-gcp",
+  "name": "tiny-collection",
+  "size": 3126700,
+  "status": "Ready",
+  "vector_count": 99
+}

--- a/src/test/resources/describeCollection.witihUnknownProperties.json
+++ b/src/test/resources/describeCollection.witihUnknownProperties.json
@@ -1,0 +1,10 @@
+{
+  "dimension": 3,
+  "environment": "us-east1-gcp",
+  "name": "tiny-collection",
+  "size": 3126700,
+  "status": "Ready",
+  "vector_count": 99,
+  "extra": true,
+  "even_more": null
+}

--- a/src/test/resources/describeIndexResponse.valid.json
+++ b/src/test/resources/describeIndexResponse.valid.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-index",
+  "dimension": 1536,
+  "metric": "cosine",
+  "status": {
+    "ready": true,
+    "state": "Ready"
+  },
+  "host": "https://index-host.com",
+  "spec": {
+    "serverless": {
+      "cloud": "aws",
+      "region": "us-east2-gcp"
+    }
+  }
+}

--- a/src/test/resources/describeIndexResponse.withUnknownProperties.json
+++ b/src/test/resources/describeIndexResponse.withUnknownProperties.json
@@ -1,0 +1,24 @@
+{
+  "catchphrase": "just do it",
+  "name": "test-index",
+  "dimension": 1536,
+  "metric": "cosine",
+  "status": {
+    "ready": true,
+    "state": "Ready",
+    "bottlesOfBeerOnTheWall": 99
+  },
+  "host": "https://index-host.com",
+  "spec": {
+    "future_pod_type": {
+      "who_knows": true,
+      "what_props": false,
+      "may": "exist"
+    },
+    "serverless": {
+      "cloud": "aws",
+      "region": "us-east2-gcp",
+      "hotness": "extra-spicy"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When new properties are added to API responses, this causes the Java client to error. This prevents us from making additive API changes that would otherwise be non-breaking to the end user.

## Solution

- Add tests that exercise the JSON parsing behavior in `src/test/java/org/openapitools/client/JsonParsingTest.java` and ensure the presence of additional properties will not cause the SDK to error. These tests use JSON fixtures added in `src/test/resources`.
- Regenerate the control plane rest client using the OpenAPI [java client generator](https://openapi-generator.tech/docs/generators/java/). This time, configuring the generator with
`disallowAdditionalPropertiesIfNotPresent=false` should activate the correct JSON parsing behavior in the generated code.

The code generation step was performed with this command:

```bash
mkdir codegen
mkdir codegen/gen
cd codegen

docker run --rm -v $(pwd):/workspace openapitools/openapi-generator-cli:v7.0.1 generate \
    --input-spec $SPEC_FILE \
    --additional-properties=dateLibrary='java8',disallowAdditionalPropertiesIfNotPresent=false \
    --generator-name java \
    --output /workspace/gen/java

rm -rf ../src/main/java/org/openapitools/client

cp -r gen/java/src/main/java/org/openapitools/client ../src/main/java/org/openapitools/client
```

It took some trial and error to discover an openapi generator version and spec version that produced similar results to the ones Rohan created previously using steps and commands that were not captured anywhere. These steps will be scripted and automated in a future PR to remove this element of guesswork.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Since the new tests exercise all the generated code up to the boundary where a response is returned from the okhttp library used for making requests, that gives a high confidence this will work if unexpected fields appear in future API responses.