### PR TITLE
Add new `queryByVectorId` and `queryByVector` functions to `IndexInterface`

### DIFF
--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -135,41 +135,50 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
 
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
-                                                                            String namespace, Struct filter,
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
+                                                                            List<Float> vector,
+                                                                            String namespace,
+                                                                            Struct filter,
                                                                             boolean includeValues,
                                                                             boolean includeMetadata) {
         return query(topK, vector, null, null, null, namespace, filter, includeValues, includeMetadata);
     }
 
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
-                                                                            String namespace, Struct filter) {
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
+                                                                            List<Float> vector,
+                                                                            String namespace,
+                                                                            Struct filter) {
         return query(topK, vector, null, null, null, namespace, filter, false, false);
     }
 
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
-                                                                            String namespace, boolean includeValues,
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
+                                                                            List<Float> vector,
+                                                                            String namespace,
+                                                                            boolean includeValues,
                                                                             boolean includeMetadata) {
         return query(topK, vector, null, null, null, namespace, null, includeValues, includeMetadata);
     }
 
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
+                                                                            List<Float> vector,
                                                                             String namespace) {
         return query(topK, vector, null, null, null, namespace, null, false, false);
     }
 
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
+                                                                            List<Float> vector,
                                                                             boolean includeValues,
                                                                             boolean includeMetadata) {
         return query(topK, vector, null, null, null, null, null, includeValues, includeMetadata);
     }
 
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector) {
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
+                                                                            List<Float> vector) {
         return query(topK, vector, null, null, null, null, null, false, false);
     }
 

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -107,14 +107,70 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id,
+                                                                              String namespace,
+                                                                              boolean includeValues,
+                                                                              boolean includeMetadata) {
+        return query(topK, null, null, null, id, namespace, null, includeValues, includeMetadata);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
+                                                                              String id,
                                                                               String namespace) {
         return query(topK, null, null, null, id, namespace, null, false, false);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK, String id,
+                                                                              boolean includeValues,
+                                                                              boolean includeMetadata) {
+        return query(topK, null, null, null, id, null, null, includeValues, includeMetadata);
     }
 
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id) {
         return query(topK, null, null, null, id, null, null, false, false);
+    }
+
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+                                                                            String namespace, Struct filter,
+                                                                            boolean includeValues,
+                                                                            boolean includeMetadata) {
+        return query(topK, vector, null, null, null, namespace, filter, includeValues, includeMetadata);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+                                                                            String namespace, Struct filter) {
+        return query(topK, vector, null, null, null, namespace, filter, false, false);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+                                                                            String namespace, boolean includeValues,
+                                                                            boolean includeMetadata) {
+        return query(topK, vector, null, null, null, namespace, null, includeValues, includeMetadata);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+                                                                            String namespace) {
+        return query(topK, vector, null, null, null, namespace, null, false, false);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector,
+                                                                            boolean includeValues,
+                                                                            boolean includeMetadata) {
+        return query(topK, vector, null, null, null, null, null, includeValues, includeMetadata);
+    }
+
+    @Override
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK, List<Float> vector) {
+        return query(topK, vector, null, null, null, null, null, false, false);
     }
 
     @Override

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -101,14 +101,58 @@ public class Index implements IndexInterface<UpsertResponse,
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id,
+                                                            String namespace,
+                                                            boolean includeValues,
+                                                            boolean includeMetadata) {
+        return query(topK, null, null, null, id, namespace, null, includeValues, includeMetadata);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
+                                                            String id,
                                                             String namespace) {
         return query(topK, null, null, null, id, namespace, null, false, false);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVectorId(int topK, String id, boolean includeValues, boolean includeMetadata) {
+        return query(topK, null, null, null, id, null, null, includeValues, includeMetadata);
     }
 
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id) {
         return query(topK, null, null, null, id, null, null, false, false);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace, Struct filter, boolean includeValues, boolean includeMetadata) {
+        return query(topK, vector, null, null, null, namespace, filter, includeValues, includeMetadata);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace, Struct filter) {
+        return query(topK, vector, null, null, null, namespace, filter, false, false);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace, boolean includeValues, boolean includeMetadata) {
+        return query(topK, vector, null, null, null, namespace, null, includeValues, includeMetadata);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace) {
+        return query(topK, vector, null, null, null, namespace, null, false, false);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, boolean includeValues, boolean includeMetadata) {
+        return query(topK, vector, null, null, null, null, null, includeValues, includeMetadata);
+    }
+
+    @Override
+    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector) {
+        return query(topK, vector, null, null, null, null, null, false, false);
     }
 
     @Override

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -115,7 +115,10 @@ public class Index implements IndexInterface<UpsertResponse,
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVectorId(int topK, String id, boolean includeValues, boolean includeMetadata) {
+    public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
+                                                            String id,
+                                                            boolean includeValues,
+                                                            boolean includeMetadata) {
         return query(topK, null, null, null, id, null, null, includeValues, includeMetadata);
     }
 
@@ -126,32 +129,50 @@ public class Index implements IndexInterface<UpsertResponse,
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace, Struct filter, boolean includeValues, boolean includeMetadata) {
+    public QueryResponseWithUnsignedIndices queryByVector(int topK,
+                                                          List<Float> vector,
+                                                          String namespace,
+                                                          Struct filter,
+                                                          boolean includeValues,
+                                                          boolean includeMetadata) {
         return query(topK, vector, null, null, null, namespace, filter, includeValues, includeMetadata);
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace, Struct filter) {
+    public QueryResponseWithUnsignedIndices queryByVector(int topK,
+                                                          List<Float> vector,
+                                                          String namespace,
+                                                          Struct filter) {
         return query(topK, vector, null, null, null, namespace, filter, false, false);
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace, boolean includeValues, boolean includeMetadata) {
+    public QueryResponseWithUnsignedIndices queryByVector(int topK,
+                                                          List<Float> vector,
+                                                          String namespace,
+                                                          boolean includeValues,
+                                                          boolean includeMetadata) {
         return query(topK, vector, null, null, null, namespace, null, includeValues, includeMetadata);
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, String namespace) {
+    public QueryResponseWithUnsignedIndices queryByVector(int topK,
+                                                          List<Float> vector,
+                                                          String namespace) {
         return query(topK, vector, null, null, null, namespace, null, false, false);
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector, boolean includeValues, boolean includeMetadata) {
+    public QueryResponseWithUnsignedIndices queryByVector(int topK,
+                                                          List<Float> vector,
+                                                          boolean includeValues,
+                                                          boolean includeMetadata) {
         return query(topK, vector, null, null, null, null, null, includeValues, includeMetadata);
     }
 
     @Override
-    public QueryResponseWithUnsignedIndices queryByVector(int topK, List<Float> vector) {
+    public QueryResponseWithUnsignedIndices queryByVector(int topK,
+                                                          List<Float> vector) {
         return query(topK, vector, null, null, null, null, null, false, false);
     }
 

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -277,12 +277,28 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
 
     U queryByVectorId(int topK, String id);
 
+    U queryByVectorId(int topK, String id, boolean includeValues, boolean includeMetadata);
+
     U queryByVectorId(int topK, String id, String namespace);
+
+    U queryByVectorId(int topK, String id, String namespace, boolean includeValues, boolean includeMetadata);
 
     U queryByVectorId(int topK, String id, String namespace, Struct filter);
 
     U queryByVectorId(int topK, String id, String namespace, Struct filter, boolean includeValues,
                       boolean includeMetadata);
+
+    U queryByVector(int topK, List<Float> vector);
+
+    U queryByVector(int topK, List<Float> vector, boolean includeValues, boolean includeMetadata);
+
+    U queryByVector(int topK, List<Float> vector, String namespace);
+
+    U queryByVector(int topK, List<Float> vector, String namespace, boolean includeValues, boolean includeMetadata);
+
+    U queryByVector(int topK, List<Float> vector, String namespace, Struct filter);
+
+    U queryByVector(int topK, List<Float> vector, String namespace, Struct filter, boolean includeValues, boolean includeMetadata);
 
     U query(int topK, List<Float> vector, List<Long> sparseIndices, List<Float> sparseValues, String id,
             String namespace, Struct filter, boolean includeValues, boolean includeMetadata);


### PR DESCRIPTION
## Problem
Because of the lack of optional arguments, we have a lot of overloaded functions in `IndexInterface` which are meant to make working with the data plane easier for users.

Currently, we're missing some variations of `queryByVectorId` which need to be added. We're also missing any functionality for `queryByVector` behavior which is a commonly used operations by users.

## Solution
- Add new function overloads to `IndexInterface` to support `queryByVectorId` minimal requests with namespace and/or `includeValues` and `includeMetadata`.
- Duplicate our `queryByVectorId` functions into new `queryByVector` functions.

All of these functions are going through the existing validation logic, so it should be safe to add these in calling the base `query` function. Unfortunately, there's not any unit tests for `Index` or `AsyncIndex` and those will need to be added in a follow up.

This is also a lot of overloads, I'm sure there is a better pattern for handling this from a UX perspective.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI tests, or running an example app locally.
