### PR TITLE
Add doc-strings for unsigned indices model classes

### DIFF
--- a/src/main/java/io/pinecone/unsigned_indices_model/QueryResponseWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/QueryResponseWithUnsignedIndices.java
@@ -8,13 +8,43 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * This class represents the response to a query, where the `ScoredVector` objects in the `matches` list
+ * contain `SparseValuesWithUnsignedIndices` instead of the standard `SparseValues`.
+ * <p>
+ * The `QueryResponseWithUnsignedIndices` class contains the following fields:
+ * - `matches`: a list of `ScoredVectorWithUnsignedIndices` objects, representing the matching vectors
+ * - `namespace`: the namespace of the query
+ * - `usage`: the usage information for the query
+ * <p>
+ * The class provides a constructor that takes a `QueryResponse` object and converts it to a
+ * `QueryResponseWithUnsignedIndices` object, as well as getter and setter methods for each of the fields.
+ * It also includes a method to convert a list of `ScoredVector` objects to a list of
+ * `ScoredVectorWithUnsignedIndices` objects.
+ */
 public class QueryResponseWithUnsignedIndices {
 
+    /**
+     * The list of matching vectors, where each vector contains sparse values with unsigned 32-bit integer indices.
+     */
     private List<ScoredVectorWithUnsignedIndices> matches;
+
+    /**
+     * The namespace of the query.
+     */
     private String namespace;
+
+    /**
+     * The usage information for the query.
+     */
     private Usage usage;
 
-
+    /**
+     * Constructs a `QueryResponseWithUnsignedIndices` object from a `QueryResponse` object, converting the
+     * `ScoredVector` objects to `ScoredVectorWithUnsignedIndices` objects.
+     *
+     * @param queryResponse the `QueryResponse` object to convert
+     */
     public QueryResponseWithUnsignedIndices(QueryResponse queryResponse) {
         if (queryResponse == null) {
             this.matches = Collections.emptyList();
@@ -27,14 +57,32 @@ public class QueryResponseWithUnsignedIndices {
         }
     }
 
+    /**
+     * Returns the list of matching vectors, where each vector contains sparse values with unsigned 32-bit integer indices.
+     *
+     * @return the list of `ScoredVectorWithUnsignedIndices` objects
+     */
     public List<ScoredVectorWithUnsignedIndices> getMatchesList() {
         return matches;
     }
 
+    /**
+     * Returns the `ScoredVectorWithUnsignedIndices` object at the specified index in the `matches` list.
+     *
+     * @param index the index of the `ScoredVectorWithUnsignedIndices` object to return
+     * @return the `ScoredVectorWithUnsignedIndices` object at the specified index
+     */
     public ScoredVectorWithUnsignedIndices getMatches(int index) {
         return matches.get(index);
     }
 
+    /**
+     * Converts a list of `ScoredVector` objects to a list of `ScoredVectorWithUnsignedIndices` objects.
+     *
+     * @param matches the list of `ScoredVector` objects to convert
+     * @return the list of `ScoredVectorWithUnsignedIndices` objects
+     * @throws IllegalArgumentException if the `matches` list is null
+     */
     public List<ScoredVectorWithUnsignedIndices> convertToScoredVectorWithUnsignedIndices(List<ScoredVector> matches) {
         if (matches == null) {
             throw new IllegalArgumentException("Matches list cannot be null.");
@@ -46,25 +94,56 @@ public class QueryResponseWithUnsignedIndices {
         return scoredVectorList;
     }
 
+    /**
+     * Sets the list of matching vectors, where each vector contains sparse values with unsigned 32-bit integer indices.
+     *
+     * @param matches the new list of `ScoredVectorWithUnsignedIndices` objects
+     */
     public void setMatches(List<ScoredVectorWithUnsignedIndices> matches) {
         this.matches = matches;
     }
 
+    /**
+     * Returns the namespace of the query.
+     *
+     * @return the namespace
+     */
     public String getNamespace() {
         return namespace;
     }
 
+    /**
+     * Sets the namespace of the query.
+     *
+     * @param namespace the new namespace
+     */
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
 
-    public Usage getUsage() { return usage; }
-
-    public void setUsage(Usage usage) { this.usage = usage; }
+    /**
+     * Returns the usage information for the query.
+     *
+     * @return the usage
+     */
+    public Usage getUsage() {
+        return usage;
+    }
 
     /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
+     * Sets the usage information for the query.
+     *
+     * @param usage the new usage
+     */
+    public void setUsage(Usage usage) {
+        this.usage = usage;
+    }
+
+    /**
+     * Converts the given object to a string with each line indented by 4 spaces (except the first line).
+     *
+     * @param o the object to convert to a string
+     * @return the indented string representation of the object
      */
     private String toIndentedString(Object o) {
         if (o == null) {

--- a/src/main/java/io/pinecone/unsigned_indices_model/QueryResponseWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/QueryResponseWithUnsignedIndices.java
@@ -9,18 +9,18 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * This class represents the response to a query, where the `ScoredVector` objects in the `matches` list
- * contain `SparseValuesWithUnsignedIndices` instead of the standard `SparseValues`.
+ * This class represents the response to a query, where the {@link ScoredVector} objects in the `matches` list
+ * contain {@link SparseValuesWithUnsignedIndices} instead of the standard SparseValues.
  * <p>
- * The `QueryResponseWithUnsignedIndices` class contains the following fields:
- * - `matches`: a list of `ScoredVectorWithUnsignedIndices` objects, representing the matching vectors
- * - `namespace`: the namespace of the query
- * - `usage`: the usage information for the query
+ * The {@link QueryResponseWithUnsignedIndices} class contains the following fields:
+ * - matches: a list of {@link ScoredVectorWithUnsignedIndices} objects, representing the matching vectors
+ * - namespace: the namespace of the index to retrieve search results from
+ * - usage: the usage information for the queryS
  * <p>
- * The class provides a constructor that takes a `QueryResponse` object and converts it to a
- * `QueryResponseWithUnsignedIndices` object, as well as getter and setter methods for each of the fields.
+ * The class provides a constructor that takes a {@link QueryResponse} object and converts it to a
+ * {@link QueryResponseWithUnsignedIndices} object, as well as getter and setter methods for each of the fields.
  * It also includes a method to convert a list of `ScoredVector` objects to a list of
- * `ScoredVectorWithUnsignedIndices` objects.
+ * {@link ScoredVectorWithUnsignedIndices} objects.
  */
 public class QueryResponseWithUnsignedIndices {
 
@@ -40,10 +40,10 @@ public class QueryResponseWithUnsignedIndices {
     private Usage usage;
 
     /**
-     * Constructs a `QueryResponseWithUnsignedIndices` object from a `QueryResponse` object, converting the
-     * `ScoredVector` objects to `ScoredVectorWithUnsignedIndices` objects.
+     * Constructs a {@link QueryResponseWithUnsignedIndices} object from a {@link QueryResponse} object, converting the
+     * `ScoredVector` objects to {@link ScoredVectorWithUnsignedIndices} objects.
      *
-     * @param queryResponse the `QueryResponse` object to convert
+     * @param queryResponse The {@link QueryResponse} object to convert
      */
     public QueryResponseWithUnsignedIndices(QueryResponse queryResponse) {
         if (queryResponse == null) {
@@ -60,28 +60,28 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Returns the list of matching vectors, where each vector contains sparse values with unsigned 32-bit integer indices.
      *
-     * @return the list of `ScoredVectorWithUnsignedIndices` objects
+     * @return The list of {@link ScoredVectorWithUnsignedIndices} objects
      */
     public List<ScoredVectorWithUnsignedIndices> getMatchesList() {
         return matches;
     }
 
     /**
-     * Returns the `ScoredVectorWithUnsignedIndices` object at the specified index in the `matches` list.
+     * Returns the {@link ScoredVectorWithUnsignedIndices} object at the specified index in the `matches` list.
      *
-     * @param index the index of the `ScoredVectorWithUnsignedIndices` object to return
-     * @return the `ScoredVectorWithUnsignedIndices` object at the specified index
+     * @param index The index of the {@link ScoredVectorWithUnsignedIndices} object to return
+     * @return The {@link ScoredVectorWithUnsignedIndices} object at the specified index
      */
     public ScoredVectorWithUnsignedIndices getMatches(int index) {
         return matches.get(index);
     }
 
     /**
-     * Converts a list of `ScoredVector` objects to a list of `ScoredVectorWithUnsignedIndices` objects.
+     * Converts a list of {@link ScoredVector} objects to a list of {@link ScoredVectorWithUnsignedIndices} objects.
      *
-     * @param matches the list of `ScoredVector` objects to convert
-     * @return the list of `ScoredVectorWithUnsignedIndices` objects
-     * @throws IllegalArgumentException if the `matches` list is null
+     * @param matches The list of {@link ScoredVector} objects to convert
+     * @return The list of {@link ScoredVectorWithUnsignedIndices} objects
+     * @throws IllegalArgumentException If the matches list is null
      */
     public List<ScoredVectorWithUnsignedIndices> convertToScoredVectorWithUnsignedIndices(List<ScoredVector> matches) {
         if (matches == null) {
@@ -97,7 +97,7 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Sets the list of matching vectors, where each vector contains sparse values with unsigned 32-bit integer indices.
      *
-     * @param matches the new list of `ScoredVectorWithUnsignedIndices` objects
+     * @param matches The new list of {@link ScoredVectorWithUnsignedIndices} objects
      */
     public void setMatches(List<ScoredVectorWithUnsignedIndices> matches) {
         this.matches = matches;
@@ -106,7 +106,7 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Returns the namespace of the query.
      *
-     * @return the namespace
+     * @return The namespace
      */
     public String getNamespace() {
         return namespace;
@@ -115,7 +115,7 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Sets the namespace of the query.
      *
-     * @param namespace the new namespace
+     * @param namespace The new namespace
      */
     public void setNamespace(String namespace) {
         this.namespace = namespace;
@@ -124,7 +124,7 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Returns the usage information for the query.
      *
-     * @return the usage
+     * @return The usage
      */
     public Usage getUsage() {
         return usage;
@@ -133,7 +133,7 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Sets the usage information for the query.
      *
-     * @param usage the new usage
+     * @param usage The new usage
      */
     public void setUsage(Usage usage) {
         this.usage = usage;
@@ -142,8 +142,8 @@ public class QueryResponseWithUnsignedIndices {
     /**
      * Converts the given object to a string with each line indented by 4 spaces (except the first line).
      *
-     * @param o the object to convert to a string
-     * @return the indented string representation of the object
+     * @param o The object to convert to a string
+     * @return The indented string representation of the object
      */
     private String toIndentedString(Object o) {
         if (o == null) {

--- a/src/main/java/io/pinecone/unsigned_indices_model/ScoredVectorWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/ScoredVectorWithUnsignedIndices.java
@@ -6,14 +6,55 @@ import io.pinecone.proto.ScoredVector;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * This class represents a scored vector with unsigned 32-bit integer indices for the sparse values.
+ * Unlike the `ScoredVector` class, which uses the `SparseValues` class to represent the sparse values,
+ * this class uses the `SparseValuesWithUnsignedIndices` class, which allows for the use of unsigned 32-bit
+ * integers as indices.
+ * <p>
+ * The `ScoredVectorWithUnsignedIndices` class contains the following fields:
+ * - `score`: the score associated with the vector
+ * - `id`: the identifier of the vector
+ * - `values`: the dense vector values
+ * - `metadata`: the metadata associated with the vector
+ * - `sparseValuesWithUnsignedIndices`: the sparse values associated with the vector, using unsigned 32-bit integer indices
+ * <p>
+ * The class provides a constructor that takes a `ScoredVector` object and converts it to a
+ * `ScoredVectorWithUnsignedIndices` object, as well as getter and setter methods for each of the fields.
+ */
 public class ScoredVectorWithUnsignedIndices {
 
+    /**
+     * The score associated with the vector.
+     */
     private float score;
+
+    /**
+     * The identifier of the vector.
+     */
     private String id;
+
+    /**
+     * The dense vector values.
+     */
     private List<Float> values;
+
+    /**
+     * The metadata associated with the vector.
+     */
     private Struct metadata;
+
+    /**
+     * The sparse values associated with the vector, using unsigned 32-bit integer indices.
+     */
     private SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices;
 
+    /**
+     * Constructs a `ScoredVectorWithUnsignedIndices` object from a `ScoredVector` object, converting the
+     * `SparseValues` to `SparseValuesWithUnsignedIndices`.
+     *
+     * @param scoredVector the `ScoredVector` object to convert
+     */
     public ScoredVectorWithUnsignedIndices(ScoredVector scoredVector) {
         if (scoredVector == null) {
             this.score = 0F;
@@ -30,49 +71,101 @@ public class ScoredVectorWithUnsignedIndices {
         }
     }
 
+    /**
+     * Returns the score associated with the vector.
+     *
+     * @return the score
+     */
     public float getScore() {
         return score;
     }
 
+    /**
+     * Sets the score associated with the vector.
+     *
+     * @param score the new score
+     */
     public void setScore(float score) {
         this.score = score;
     }
 
+    /**
+     * Returns the identifier of the vector.
+     *
+     * @return the id
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Sets the identifier of the vector.
+     *
+     * @param id the new id
+     */
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Returns the dense vector values.
+     *
+     * @return the list of values
+     */
     public List<Float> getValuesList() {
         return values;
     }
 
+    /**
+     * Sets the dense vector values.
+     *
+     * @param values the new list of values
+     */
     public void setValues(List<Float> values) {
         this.values = values;
     }
 
+    /**
+     * Returns the metadata associated with the vector.
+     *
+     * @return the metadata
+     */
     public Struct getMetadata() {
         return metadata;
     }
 
+    /**
+     * Sets the metadata associated with the vector.
+     *
+     * @param metadata the new metadata
+     */
     public void setMetadata(Struct metadata) {
         this.metadata = metadata;
     }
 
+    /**
+     * Returns the sparse values associated with the vector, using unsigned 32-bit integer indices.
+     *
+     * @return the `SparseValuesWithUnsignedIndices` object
+     */
     public SparseValuesWithUnsignedIndices getSparseValuesWithUnsignedIndices() {
         return sparseValuesWithUnsignedIndices;
     }
 
+    /**
+     * Sets the sparse values associated with the vector, using unsigned 32-bit integer indices.
+     *
+     * @param sparseValuesWithUnsignedIndices the new `SparseValuesWithUnsignedIndices` object
+     */
     public void setSparseValuesWithUnsignedIndices(SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.sparseValuesWithUnsignedIndices = sparseValuesWithUnsignedIndices;
     }
 
     /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
+     * Converts the given object to a string with each line indented by 4 spaces (except the first line).
+     *
+     * @param o the object to convert to a string
+     * @return the indented string representation of the object
      */
     private String toIndentedString(Object o) {
         if (o == null) {

--- a/src/main/java/io/pinecone/unsigned_indices_model/ScoredVectorWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/ScoredVectorWithUnsignedIndices.java
@@ -8,19 +8,19 @@ import java.util.List;
 
 /**
  * This class represents a scored vector with unsigned 32-bit integer indices for the sparse values.
- * Unlike the `ScoredVector` class, which uses the `SparseValues` class to represent the sparse values,
- * this class uses the `SparseValuesWithUnsignedIndices` class, which allows for the use of unsigned 32-bit
+ * Unlike the {@link ScoredVector} class, which uses the SparseValues class to represent the sparse values,
+ * this class uses the {@link SparseValuesWithUnsignedIndices} class, which allows for the use of unsigned 32-bit
  * integers as indices.
  * <p>
- * The `ScoredVectorWithUnsignedIndices` class contains the following fields:
- * - `score`: the score associated with the vector
- * - `id`: the identifier of the vector
- * - `values`: the dense vector values
- * - `metadata`: the metadata associated with the vector
- * - `sparseValuesWithUnsignedIndices`: the sparse values associated with the vector, using unsigned 32-bit integer indices
+ * The {@link ScoredVectorWithUnsignedIndices} class contains the following fields:
+ * - score: the score associated with the vector
+ * - id: the identifier of the vector
+ * - values: the dense vector values
+ * - metadata: the metadata associated with the vector
+ * - sparseValuesWithUnsignedIndices: the sparse values associated with the vector, using unsigned 32-bit integer indices
  * <p>
- * The class provides a constructor that takes a `ScoredVector` object and converts it to a
- * `ScoredVectorWithUnsignedIndices` object, as well as getter and setter methods for each of the fields.
+ * The class provides a constructor that takes a {@link ScoredVector} object and converts it to a
+ * {@link ScoredVectorWithUnsignedIndices} object, as well as getter and setter methods for each of the fields.
  */
 public class ScoredVectorWithUnsignedIndices {
 
@@ -50,10 +50,10 @@ public class ScoredVectorWithUnsignedIndices {
     private SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices;
 
     /**
-     * Constructs a `ScoredVectorWithUnsignedIndices` object from a `ScoredVector` object, converting the
-     * `SparseValues` to `SparseValuesWithUnsignedIndices`.
+     * Constructs a {@link ScoredVectorWithUnsignedIndices} object from a {@link ScoredVector} object, converting the
+     * SparseValues to {@link SparseValuesWithUnsignedIndices}.
      *
-     * @param scoredVector the `ScoredVector` object to convert
+     * @param scoredVector the {@link ScoredVector} object to convert
      */
     public ScoredVectorWithUnsignedIndices(ScoredVector scoredVector) {
         if (scoredVector == null) {
@@ -74,7 +74,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Returns the score associated with the vector.
      *
-     * @return the score
+     * @return The score
      */
     public float getScore() {
         return score;
@@ -83,7 +83,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Sets the score associated with the vector.
      *
-     * @param score the new score
+     * @param score The new score
      */
     public void setScore(float score) {
         this.score = score;
@@ -92,7 +92,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Returns the identifier of the vector.
      *
-     * @return the id
+     * @return The id
      */
     public String getId() {
         return id;
@@ -101,7 +101,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Sets the identifier of the vector.
      *
-     * @param id the new id
+     * @param id The new id
      */
     public void setId(String id) {
         this.id = id;
@@ -110,7 +110,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Returns the dense vector values.
      *
-     * @return the list of values
+     * @return The list of values
      */
     public List<Float> getValuesList() {
         return values;
@@ -119,7 +119,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Sets the dense vector values.
      *
-     * @param values the new list of values
+     * @param values The new list of values
      */
     public void setValues(List<Float> values) {
         this.values = values;
@@ -128,7 +128,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Returns the metadata associated with the vector.
      *
-     * @return the metadata
+     * @return The metadata
      */
     public Struct getMetadata() {
         return metadata;
@@ -137,7 +137,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Sets the metadata associated with the vector.
      *
-     * @param metadata the new metadata
+     * @param metadata The new metadata
      */
     public void setMetadata(Struct metadata) {
         this.metadata = metadata;
@@ -146,7 +146,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Returns the sparse values associated with the vector, using unsigned 32-bit integer indices.
      *
-     * @return the `SparseValuesWithUnsignedIndices` object
+     * @return The {@link SparseValuesWithUnsignedIndices} object
      */
     public SparseValuesWithUnsignedIndices getSparseValuesWithUnsignedIndices() {
         return sparseValuesWithUnsignedIndices;
@@ -155,7 +155,7 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Sets the sparse values associated with the vector, using unsigned 32-bit integer indices.
      *
-     * @param sparseValuesWithUnsignedIndices the new `SparseValuesWithUnsignedIndices` object
+     * @param sparseValuesWithUnsignedIndices The new {@link SparseValuesWithUnsignedIndices} object
      */
     public void setSparseValuesWithUnsignedIndices(SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.sparseValuesWithUnsignedIndices = sparseValuesWithUnsignedIndices;
@@ -164,8 +164,8 @@ public class ScoredVectorWithUnsignedIndices {
     /**
      * Converts the given object to a string with each line indented by 4 spaces (except the first line).
      *
-     * @param o the object to convert to a string
-     * @return the indented string representation of the object
+     * @param o The object to convert to a string
+     * @return The indented string representation of the object
      */
     private String toIndentedString(Object o) {
         if (o == null) {

--- a/src/main/java/io/pinecone/unsigned_indices_model/SparseValuesWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/SparseValuesWithUnsignedIndices.java
@@ -6,22 +6,55 @@ import java.util.Collections;
 import java.util.List;
 
 import static io.pinecone.utils.SparseIndicesConverter.convertSigned32IntToUnsigned32Int;
-
+/**
+ * This class represents a set of sparse values, where the indices are represented as unsigned 32-bit integers.
+ * Unlike the `SparseValues` class, which uses signed 32-bit integers for the indices, this class uses `Long` to
+ * represent the indices, allowing for the full range of unsigned 32-bit integers (0 to 4,294,967,295).
+ * <p>
+ * The `indicesWithUnsigned32Int` list contains the indices, while the `values` list contains the corresponding
+ * values. The two lists are parallel, meaning that the value at index `i` in the `values` list corresponds to
+ * the index at index `i` in the `indicesWithUnsigned32Int` list.
+ * <p>
+ * This class provides a constructor that takes a `SparseValues` object and converts the signed 32-bit integer
+ * indices to unsigned 32-bit integers, as well as methods to get and set the indices and values.
+ */
 public class SparseValuesWithUnsignedIndices {
 
+    /**
+     * The list of indices, represented as unsigned 32-bit integers.
+     */
     private List<Long> indicesWithUnsigned32Int;
+
+    /**
+     * The list of values corresponding to the indices in `indicesWithUnsigned32Int`.
+     */
     private List<Float> values;
 
+    /**
+     * Constructs an empty `SparseValuesWithUnsignedIndices` object with empty lists for indices and values.
+     */
     public SparseValuesWithUnsignedIndices() {
         this.indicesWithUnsigned32Int = Collections.emptyList();
         this.values = Collections.emptyList();
     }
 
+    /**
+     * Constructs a `SparseValuesWithUnsignedIndices` object with the given lists of indices and values.
+     *
+     * @param indicesWithUnsigned32Int the list of indices, represented as unsigned 32-bit integers
+     * @param values the list of values corresponding to the indices
+     */
     public SparseValuesWithUnsignedIndices(List<Long> indicesWithUnsigned32Int, List<Float> values) {
         this.indicesWithUnsigned32Int = indicesWithUnsigned32Int;
         this.values = values;
     }
 
+    /**
+     * Constructs a `SparseValuesWithUnsignedIndices` object from a `SparseValues` object, converting the
+     * signed 32-bit integer indices to unsigned 32-bit integers.
+     *
+     * @param sparseValues the `SparseValues` object to convert
+     */
     public SparseValuesWithUnsignedIndices(SparseValues sparseValues) {
         if (sparseValues == null) {
             this.indicesWithUnsigned32Int = Collections.emptyList();
@@ -32,25 +65,47 @@ public class SparseValuesWithUnsignedIndices {
         }
     }
 
+    /**
+     * Returns the list of indices, represented as unsigned 32-bit integers.
+     *
+     * @return the list of indices
+     */
     public List<Long> getIndicesWithUnsigned32IntList() {
         return indicesWithUnsigned32Int;
     }
 
+    /**
+     * Sets the list of indices, represented as unsigned 32-bit integers.
+     *
+     * @param indicesWithUnsigned32Int the new list of indices
+     */
     public void setIndicesWithUnsigned32Int(List<Long> indicesWithUnsigned32Int) {
         this.indicesWithUnsigned32Int = indicesWithUnsigned32Int;
     }
 
+    /**
+     * Returns the list of values corresponding to the indices.
+     *
+     * @return the list of values
+     */
     public List<Float> getValuesList() {
         return values;
     }
 
+    /**
+     * Sets the list of values corresponding to the indices.
+     *
+     * @param values the new list of values
+     */
     public void setValues(List<Float> values) {
         this.values = values;
     }
 
     /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
+     * Converts the given object to a string with each line indented by 4 spaces (except the first line).
+     *
+     * @param o the object to convert to a string
+     * @return the indented string representation of the object
      */
     private String toIndentedString(Object o) {
         if (o == null) {

--- a/src/main/java/io/pinecone/unsigned_indices_model/SparseValuesWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/SparseValuesWithUnsignedIndices.java
@@ -8,14 +8,14 @@ import java.util.List;
 import static io.pinecone.utils.SparseIndicesConverter.convertSigned32IntToUnsigned32Int;
 /**
  * This class represents a set of sparse values, where the indices are represented as unsigned 32-bit integers.
- * Unlike the `SparseValues` class, which uses signed 32-bit integers for the indices, this class uses `Long` to
- * represent the indices, allowing for the full range of unsigned 32-bit integers (0 to 4,294,967,295).
+ * Unlike the {@link SparseValues} class, which uses signed 32-bit integers for the indices, this class uses {@link Long}
+ * to represent the indices, allowing for the full range of unsigned 32-bit integers (0 to 4,294,967,295).
  * <p>
- * The `indicesWithUnsigned32Int` list contains the indices, while the `values` list contains the corresponding
- * values. The two lists are parallel, meaning that the value at index `i` in the `values` list corresponds to
- * the index at index `i` in the `indicesWithUnsigned32Int` list.
+ * The indicesWithUnsigned32Int list contains the indices, while the values list contains the corresponding
+ * values. The two lists are parallel, meaning that the value at index i in the values list corresponds to
+ * the index at index i in the indicesWithUnsigned32Int list.
  * <p>
- * This class provides a constructor that takes a `SparseValues` object and converts the signed 32-bit integer
+ * This class provides a constructor that takes a {@link SparseValues} object and converts the signed 32-bit integer
  * indices to unsigned 32-bit integers, as well as methods to get and set the indices and values.
  */
 public class SparseValuesWithUnsignedIndices {
@@ -26,12 +26,12 @@ public class SparseValuesWithUnsignedIndices {
     private List<Long> indicesWithUnsigned32Int;
 
     /**
-     * The list of values corresponding to the indices in `indicesWithUnsigned32Int`.
+     * The list of values corresponding to the indices in indicesWithUnsigned32Int.
      */
     private List<Float> values;
 
     /**
-     * Constructs an empty `SparseValuesWithUnsignedIndices` object with empty lists for indices and values.
+     * Constructs an empty {@link SparseValuesWithUnsignedIndices} object with empty lists for indices and values.
      */
     public SparseValuesWithUnsignedIndices() {
         this.indicesWithUnsigned32Int = Collections.emptyList();
@@ -39,10 +39,10 @@ public class SparseValuesWithUnsignedIndices {
     }
 
     /**
-     * Constructs a `SparseValuesWithUnsignedIndices` object with the given lists of indices and values.
+     * Constructs a {@link SparseValuesWithUnsignedIndices} object with the given lists of indices and values.
      *
-     * @param indicesWithUnsigned32Int the list of indices, represented as unsigned 32-bit integers
-     * @param values the list of values corresponding to the indices
+     * @param indicesWithUnsigned32Int The list of indices, represented as unsigned 32-bit integers
+     * @param values The list of values corresponding to the indices
      */
     public SparseValuesWithUnsignedIndices(List<Long> indicesWithUnsigned32Int, List<Float> values) {
         this.indicesWithUnsigned32Int = indicesWithUnsigned32Int;
@@ -50,10 +50,10 @@ public class SparseValuesWithUnsignedIndices {
     }
 
     /**
-     * Constructs a `SparseValuesWithUnsignedIndices` object from a `SparseValues` object, converting the
+     * Constructs a {@link SparseValuesWithUnsignedIndices} object from a {@link SparseValues} object, converting the
      * signed 32-bit integer indices to unsigned 32-bit integers.
      *
-     * @param sparseValues the `SparseValues` object to convert
+     * @param sparseValues The {@link SparseValues} object to convert
      */
     public SparseValuesWithUnsignedIndices(SparseValues sparseValues) {
         if (sparseValues == null) {
@@ -68,7 +68,7 @@ public class SparseValuesWithUnsignedIndices {
     /**
      * Returns the list of indices, represented as unsigned 32-bit integers.
      *
-     * @return the list of indices
+     * @return The list of indices
      */
     public List<Long> getIndicesWithUnsigned32IntList() {
         return indicesWithUnsigned32Int;
@@ -77,7 +77,7 @@ public class SparseValuesWithUnsignedIndices {
     /**
      * Sets the list of indices, represented as unsigned 32-bit integers.
      *
-     * @param indicesWithUnsigned32Int the new list of indices
+     * @param indicesWithUnsigned32Int The new list of indices
      */
     public void setIndicesWithUnsigned32Int(List<Long> indicesWithUnsigned32Int) {
         this.indicesWithUnsigned32Int = indicesWithUnsigned32Int;
@@ -86,7 +86,7 @@ public class SparseValuesWithUnsignedIndices {
     /**
      * Returns the list of values corresponding to the indices.
      *
-     * @return the list of values
+     * @return The list of values
      */
     public List<Float> getValuesList() {
         return values;
@@ -95,7 +95,7 @@ public class SparseValuesWithUnsignedIndices {
     /**
      * Sets the list of values corresponding to the indices.
      *
-     * @param values the new list of values
+     * @param values The new list of values
      */
     public void setValues(List<Float> values) {
         this.values = values;
@@ -104,8 +104,8 @@ public class SparseValuesWithUnsignedIndices {
     /**
      * Converts the given object to a string with each line indented by 4 spaces (except the first line).
      *
-     * @param o the object to convert to a string
-     * @return the indented string representation of the object
+     * @param o The object to convert to a string
+     * @return The indented string representation of the object
      */
     private String toIndentedString(Object o) {
         if (o == null) {

--- a/src/main/java/io/pinecone/unsigned_indices_model/VectorWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/VectorWithUnsignedIndices.java
@@ -4,20 +4,66 @@ import com.google.protobuf.Struct;
 
 import java.util.List;
 
+/**
+ * This class represents a vector with sparse values, where the indices of the sparse values are represented
+ * as unsigned 32-bit integers.
+ * <p>
+ * The `VectorWithUnsignedIndices` class contains the following fields:
+ * - `id`: the identifier of the vector
+ * - `values`: the dense vector values
+ * - `metadata`: the metadata associated with the vector
+ * - `sparseValuesWithUnsignedIndices`: the sparse values associated with the vector, using unsigned 32-bit integer indices
+ * <p>
+ * The class provides constructors to create `VectorWithUnsignedIndices` objects, as well as getter and setter
+ * methods for each of the fields.
+ */
 public class VectorWithUnsignedIndices {
 
+    /**
+     * The identifier of the vector.
+     */
     private String id;
+
+    /**
+     * The dense vector values.
+     */
     private List<Float> values;
+
+    /**
+     * The metadata associated with the vector.
+     */
     private Struct metadata;
+
+    /**
+     * The sparse values associated with the vector, using unsigned 32-bit integer indices.
+     */
     private SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices;
 
+    /**
+     * Constructs an empty `VectorWithUnsignedIndices` object.
+     */
     public VectorWithUnsignedIndices() {}
 
+    /**
+     * Constructs a `VectorWithUnsignedIndices` object with the given identifier and dense vector values.
+     *
+     * @param id     the identifier of the vector
+     * @param values the dense vector values
+     */
     public VectorWithUnsignedIndices(String id, List<Float> values) {
         this.id = id;
         this.values = values;
     }
 
+    /**
+     * Constructs a `VectorWithUnsignedIndices` object with the given identifier, dense vector values, metadata,
+     * and sparse values with unsigned 32-bit integer indices.
+     *
+     * @param id                              the identifier of the vector
+     * @param values                         the dense vector values
+     * @param metadata                       the metadata associated with the vector
+     * @param sparseValuesWithUnsignedIndices the sparse values associated with the vector, using unsigned 32-bit integer indices
+     */
     public VectorWithUnsignedIndices(String id, List<Float> values, Struct metadata, SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.id = id;
         this.values = values;
@@ -25,35 +71,74 @@ public class VectorWithUnsignedIndices {
         this.sparseValuesWithUnsignedIndices = sparseValuesWithUnsignedIndices;
     }
 
-
+    /**
+     * Returns the identifier of the vector.
+     *
+     * @return the identifier
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Sets the identifier of the vector.
+     *
+     * @param id the new identifier
+     */
     public void setId(String id) {
         this.id = id;
     }
 
+    /**
+     * Returns the dense vector values.
+     *
+     * @return the list of values
+     */
     public List<Float> getValuesList() {
         return values;
     }
 
+    /**
+     * Sets the dense vector values.
+     *
+     * @param values the new list of values
+     */
     public void setValues(List<Float> values) {
         this.values = values;
     }
 
+    /**
+     * Returns the metadata associated with the vector.
+     *
+     * @return the metadata
+     */
     public Struct getMetadata() {
         return metadata;
     }
 
+    /**
+     * Sets the metadata associated with the vector.
+     *
+     * @param metadata the new metadata
+     */
     public void setMetadata(Struct metadata) {
         this.metadata = metadata;
     }
 
+    /**
+     * Returns the sparse values associated with the vector, using unsigned 32-bit integer indices.
+     *
+     * @return the `SparseValuesWithUnsignedIndices` object
+     */
     public SparseValuesWithUnsignedIndices getSparseValuesWithUnsignedIndices() {
         return sparseValuesWithUnsignedIndices;
     }
 
+    /**
+     * Sets the sparse values associated with the vector, using unsigned 32-bit integer indices.
+     *
+     * @param sparseValuesWithUnsignedIndices the new `SparseValuesWithUnsignedIndices` object
+     */
     public void setSparseValuesWithUnsignedIndices(SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.sparseValuesWithUnsignedIndices = sparseValuesWithUnsignedIndices;
     }

--- a/src/main/java/io/pinecone/unsigned_indices_model/VectorWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/VectorWithUnsignedIndices.java
@@ -8,13 +8,13 @@ import java.util.List;
  * This class represents a vector with sparse values, where the indices of the sparse values are represented
  * as unsigned 32-bit integers.
  * <p>
- * The `VectorWithUnsignedIndices` class contains the following fields:
- * - `id`: the identifier of the vector
- * - `values`: the dense vector values
- * - `metadata`: the metadata associated with the vector
- * - `sparseValuesWithUnsignedIndices`: the sparse values associated with the vector, using unsigned 32-bit integer indices
+ * The {@link VectorWithUnsignedIndices} class contains the following fields:
+ * - id: the identifier of the vector
+ * - values: the dense vector values
+ * - metadata: the metadata associated with the vector
+ * - sparseValuesWithUnsignedIndices: the sparse values associated with the vector, using unsigned 32-bit integer indices
  * <p>
- * The class provides constructors to create `VectorWithUnsignedIndices` objects, as well as getter and setter
+ * The class provides constructors to create {@link VectorWithUnsignedIndices} objects, as well as getter and setter
  * methods for each of the fields.
  */
 public class VectorWithUnsignedIndices {
@@ -40,15 +40,15 @@ public class VectorWithUnsignedIndices {
     private SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices;
 
     /**
-     * Constructs an empty `VectorWithUnsignedIndices` object.
+     * Constructs an empty {@link VectorWithUnsignedIndices} object.
      */
     public VectorWithUnsignedIndices() {}
 
     /**
-     * Constructs a `VectorWithUnsignedIndices` object with the given identifier and dense vector values.
+     * Constructs a {@link VectorWithUnsignedIndices} object with the given identifier and dense vector values.
      *
-     * @param id     the identifier of the vector
-     * @param values the dense vector values
+     * @param id     The identifier of the vector
+     * @param values The dense vector values
      */
     public VectorWithUnsignedIndices(String id, List<Float> values) {
         this.id = id;
@@ -56,13 +56,13 @@ public class VectorWithUnsignedIndices {
     }
 
     /**
-     * Constructs a `VectorWithUnsignedIndices` object with the given identifier, dense vector values, metadata,
+     * Constructs a {@link VectorWithUnsignedIndices} object with the given identifier, dense vector values, metadata,
      * and sparse values with unsigned 32-bit integer indices.
      *
-     * @param id                              the identifier of the vector
-     * @param values                         the dense vector values
-     * @param metadata                       the metadata associated with the vector
-     * @param sparseValuesWithUnsignedIndices the sparse values associated with the vector, using unsigned 32-bit integer indices
+     * @param id                              The identifier of the vector
+     * @param values                         The dense vector values
+     * @param metadata                       The metadata associated with the vector
+     * @param sparseValuesWithUnsignedIndices The sparse values associated with the vector, using unsigned 32-bit integer indices
      */
     public VectorWithUnsignedIndices(String id, List<Float> values, Struct metadata, SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.id = id;
@@ -74,7 +74,7 @@ public class VectorWithUnsignedIndices {
     /**
      * Returns the identifier of the vector.
      *
-     * @return the identifier
+     * @return The identifier
      */
     public String getId() {
         return id;
@@ -83,16 +83,16 @@ public class VectorWithUnsignedIndices {
     /**
      * Sets the identifier of the vector.
      *
-     * @param id the new identifier
+     * @param id The new identifier
      */
     public void setId(String id) {
         this.id = id;
     }
 
     /**
-     * Returns the dense vector values.
+     * Returns The dense vector values.
      *
-     * @return the list of values
+     * @return The list of values
      */
     public List<Float> getValuesList() {
         return values;
@@ -101,7 +101,7 @@ public class VectorWithUnsignedIndices {
     /**
      * Sets the dense vector values.
      *
-     * @param values the new list of values
+     * @param values The new list of values
      */
     public void setValues(List<Float> values) {
         this.values = values;
@@ -110,7 +110,7 @@ public class VectorWithUnsignedIndices {
     /**
      * Returns the metadata associated with the vector.
      *
-     * @return the metadata
+     * @return The metadata
      */
     public Struct getMetadata() {
         return metadata;
@@ -119,7 +119,7 @@ public class VectorWithUnsignedIndices {
     /**
      * Sets the metadata associated with the vector.
      *
-     * @param metadata the new metadata
+     * @param metadata The new metadata
      */
     public void setMetadata(Struct metadata) {
         this.metadata = metadata;
@@ -128,7 +128,7 @@ public class VectorWithUnsignedIndices {
     /**
      * Returns the sparse values associated with the vector, using unsigned 32-bit integer indices.
      *
-     * @return the `SparseValuesWithUnsignedIndices` object
+     * @return the {@link SparseValuesWithUnsignedIndices} object
      */
     public SparseValuesWithUnsignedIndices getSparseValuesWithUnsignedIndices() {
         return sparseValuesWithUnsignedIndices;
@@ -137,7 +137,7 @@ public class VectorWithUnsignedIndices {
     /**
      * Sets the sparse values associated with the vector, using unsigned 32-bit integer indices.
      *
-     * @param sparseValuesWithUnsignedIndices the new `SparseValuesWithUnsignedIndices` object
+     * @param sparseValuesWithUnsignedIndices the new {@link SparseValuesWithUnsignedIndices} object
      */
     public void setSparseValuesWithUnsignedIndices(SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.sparseValuesWithUnsignedIndices = sparseValuesWithUnsignedIndices;


### PR DESCRIPTION
## Problem

The java sdk contains custom model classes created to support the conversion of unsigned 32 bit integers to signed 32 bit integers and vice-versa, which are currently missing the doc-strings.

## Solution

Add doc strings to the following model classes:
1. QueryResponseWithUnsignedIndices
2. ScoredVectorWithUnsignedIndices
3. SparseValuesWithUnsignedIndices
4. VectorWithUnsignedIndices

## Type of Change

- [X] Non-code change (docs, etc)

## Test Plan

CI tests
