### PR TITLE
Add javadoc docstrings to `IndexInterface`, `Index`, `AsyncIndex` classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,6 @@ javadoc {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-// Javadoc task
 task generateJavadoc(type: Javadoc) {
     source = sourceSets.main.allJava
     options.memberLevel = JavadocMemberLevel.PUBLIC

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * A client for interacting with a Pinecone index via GRPC asynchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
- * <p/>
+ * <p>
  * Example:
  * <pre>{@code
  *     import io.pinecone.clients.Pinecone;
@@ -39,7 +39,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * Constructs an {@link AsyncIndex} instance for interacting with a Pinecone index.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.clients.Pinecone;
@@ -65,7 +65,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -140,7 +140,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -160,7 +160,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -181,7 +181,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -222,7 +222,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -263,7 +263,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -292,7 +292,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -320,7 +320,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -347,7 +347,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -368,7 +368,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -390,7 +390,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -410,7 +410,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -442,7 +442,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -470,7 +470,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -497,7 +497,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -518,7 +518,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -540,7 +540,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -560,7 +560,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
@@ -579,7 +579,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
@@ -601,7 +601,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
@@ -621,7 +621,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
@@ -642,7 +642,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
@@ -680,7 +680,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -700,7 +700,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -720,7 +720,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -742,7 +742,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -763,7 +763,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -781,7 +781,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -805,7 +805,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
@@ -825,7 +825,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -16,7 +16,8 @@ import java.util.List;
 /**
  * A client for interacting with a Pinecone index via GRPC asynchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
- *
+ * <p/>
+ * Example:
  * <pre>{@code
  *     import io.pinecone.clients.Pinecone;
  *     import io.pinecone.clients.AsyncIndex;
@@ -38,7 +39,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * Constructs an {@link AsyncIndex} instance for interacting with a Pinecone index.
-     *
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.clients.Pinecone;
      *     import io.pinecone.clients.AsyncIndex;
@@ -63,6 +65,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
@@ -97,25 +101,31 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     // metadata
      *     Struct metadataStruct1 = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
-     *             .build();
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *         .build();
      *
      *     Struct metadataStruct2 = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("thriller").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2020).build())
-     *             .build();
+     *         .putFields("genre", Value.newBuilder().setStringValue("thriller").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2020).build())
+     *         .build();
      *
      *     Struct metadataStruct3 = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("comedy").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2021).build())
-     *             .build();
-     *     List<Struct> metadataStructList = Arrays.asList(metadataStruct1, metadataStruct2, metadataStruct3);
+     *         .putFields("genre", Value.newBuilder().setStringValue("comedy").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2021).build())
+     *         .build();
+     *     List<Struct> metadataStructList =
+     *     Arrays.asList(metadataStruct1, metadataStruct2, metadataStruct3);
      *
      *     List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
      *
      *     for (int i=0; i<upsertIds.size(); i++) {
-     *         vectors.add(buildUpsertVectorWithUnsignedIndices(upsertIds.get(i), values.get(i), sparseIndices.get(i), sparseValues.get(i), metadataStructList.get(i)));
+     *         vectors.add(
+     *             buildUpsertVectorWithUnsignedIndices(upsertIds.get(i),
+     *                 values.get(i),
+     *                 sparseIndices.get(i),
+     *                 sparseValues.get(i),
+     *                 metadataStructList.get(i)));
      *     }
      *
      *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert(vectors, "example-namespace");
@@ -130,13 +140,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     ListenableFuture<UpsertResponse> listenableFuture =
+     *     asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
      */
     @Override
@@ -147,13 +160,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     *     ListenableFuture<UpsertResponse> listenableFuture =
+     *     asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
      * }</pre>
      */
     @Override
@@ -165,6 +181,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
@@ -176,16 +194,17 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     // metadata
      *     Struct metadataStruct = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
-     *             .build();
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *         .build();
      *
-     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id",
-     *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                           Arrays.asList(1L, 2L, 3L),
-     *                                                                           Arrays.asList(1000f, 2000f, 3000f),
-     *                                                                           metadataStruct,
-     *                                                                           "example-namespace");
+     *     ListenableFuture<UpsertResponse> listenableFuture =
+     *     asyncIndex.upsert("my-vector-id",
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         Arrays.asList(1L, 2L, 3L),
+     *         Arrays.asList(1000f, 2000f, 3000f),
+     *         metadataStruct,
+     *         "example-namespace");
      * }</pre>
      */
     @Override
@@ -203,21 +222,24 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.query(10,
-     *                                                                                            Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                                            Arrays.asList(1L, 2L, 3L),
-     *                                                                                            Arrays.asList(1000f, 2000f, 3000f),
-     *                                                                                            null,
-     *                                                                                            "example-namespace",
-     *                                                                                            null,
-     *                                                                                            true,
-     *                                                                                            true);
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.query(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         Arrays.asList(1L, 2L, 3L),
+     *         Arrays.asList(1000f, 2000f, 3000f),
+     *         null,
+     *         "example-namespace",
+     *         null,
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -241,18 +263,21 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
-     *                                                                                                      "my-vector-id",
-     *                                                                                                      "example-namespace",
-     *                                                                                                      null,
-     *                                                                                                      true,
-     *                                                                                                      true);
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVectorId(10,
+     *         "my-vector-id",
+     *         "example-namespace",
+     *         null,
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -267,6 +292,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
@@ -274,11 +301,13 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
-     *                                                                                                      "my-vector-id",
-     *                                                                                                      "example-namespace",
-     *                                                                                                      filter);
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVectorId(10,
+     *         "my-vector-id",
+     *         "example-namespace",
+     *         filter);
      * }</pre>
      */
     @Override
@@ -291,17 +320,20 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
-     *                                                                                                      "my-vector-id",
-     *                                                                                                      "example-namespace",
-     *                                                                                                      true,
-     *                                                                                                      true);
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVectorId(10,
+     *         "my-vector-id",
+     *         "example-namespace",
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -315,13 +347,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id", "example-namespace");
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVectorId(10, "my-vector-id", "example-namespace");
      * }</pre>
      */
     @Override
@@ -333,13 +368,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id", true, true);
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVectorId(10, "my-vector-id", true, true);
      * }</pre>
      */
     @Override
@@ -352,13 +390,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id");
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVectorId(10, "my-vector-id");
      * }</pre>
      */
     @Override
@@ -369,6 +410,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
@@ -376,13 +419,15 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10,
-     *                                                                                                    Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                                                    "example-namespace",
-     *                                                                                                    filter,
-     *                                                                                                    true,
-     *                                                                                                    true);
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace",
+     *         filter,
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -397,6 +442,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
@@ -404,11 +451,13 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10,
-     *                                                                                                    Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                                                    "example-namespace",
-     *                                                                                                    filter);
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace",
+     *         filter);
      * }</pre>
      */
     @Override
@@ -421,17 +470,20 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = index.queryByVector(10,
-     *                                                                                               Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                                               "example-namespace",
-     *                                                                                               true,
-     *                                                                                               true);
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     index.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace",
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -445,13 +497,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
      * }</pre>
      */
     @Override
@@ -463,13 +518,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
      * }</pre>
      */
     @Override
@@ -482,13 +540,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture =
+     *     asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
      */
     @Override
@@ -499,13 +560,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<FetchResponse> listenableFuture = asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"));
+     *     ListenableFuture<FetchResponse> listenableFuture =
+     *     asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"));
      * }</pre>
      */
     @Override
@@ -515,13 +579,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<FetchResponse> listenableFuture = asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     *     ListenableFuture<FetchResponse> listenableFuture =
+     *     asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
      */
     @Override
@@ -534,13 +601,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     ListenableFuture<UpdateResponse> listenableFuture =
+     *     asyncIndex.update("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
      */
     @Override
@@ -551,15 +621,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id",
-     *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                           "example-namespace");
+     *     ListenableFuture<UpdateResponse> listenableFuture =
+     *     asyncIndex.update("my-vector-id",Arrays.asList(1.0f, 2.0f, 3.0f),"example-namespace");
      * }</pre>
      */
     @Override
@@ -571,6 +642,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.protobuf.Struct;
@@ -579,16 +652,17 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *     ...
      *
      *     Struct metadata = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
-     *             .build();
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *         .build();
      *
-     *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id",
-     *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                           metadata,
-     *                                                                           "example-namespace",
-     *                                                                           Arrays.asList(1L, 2L, 3L),
-     *                                                                           Arrays.asList(1000f, 2000f, 3000f));
+     *     ListenableFuture<UpdateResponse> listenableFuture =
+     *     asyncIndex.update("my-vector-id",
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         metadata,
+     *         "example-namespace",
+     *         Arrays.asList(1L, 2L, 3L),
+     *         Arrays.asList(1000f, 2000f, 3000f));
      * }</pre>
      */
     @Override
@@ -606,6 +680,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
@@ -613,7 +689,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     *     ListenableFuture<DeleteResponse> listenableFuture =
+     *     asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
      */
     @Override
@@ -623,6 +700,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
@@ -630,7 +709,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"));
+     *     ListenableFuture<DeleteResponse> listenableFuture =
+     *     asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"));
      * }</pre>
      */
     @Override
@@ -640,6 +720,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
@@ -647,8 +729,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByFilter(filter, "example-namespace");
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<DeleteResponse> listenableFuture =
+     *     asyncIndex.deleteByFilter(filter, "example-namespace");
      * }</pre>
      */
     @Override
@@ -658,6 +742,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
@@ -665,7 +751,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByFilter(filter);
      * }</pre>
      */
@@ -676,6 +763,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
@@ -692,16 +781,16 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
      *     ...
      *
-     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.delete(Arrays.asList("v1", "v2", "v3"),
-     *                                                                           false,
-     *                                                                           "example-namespace",
-     *                                                                           null);
+     *     ListenableFuture<DeleteResponse> listenableFuture =
+     *     asyncIndex.delete(Arrays.asList("v1", "v2", "v3"),false,"example-namespace",null);
      * }</pre>
      */
     @Override
@@ -716,6 +805,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
@@ -734,6 +825,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *     import com.google.protobuf.Struct;
@@ -741,7 +834,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<DescribeIndexStatsResponse> listenableFuture = asyncIndex.describeIndexStats();
      * }</pre>
      */

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -64,16 +64,13 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
      *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     // Vector ids to be upserted
      *     List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
@@ -134,13 +131,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpsertResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
@@ -154,13 +148,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpsertResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
      * }</pre>
@@ -175,16 +166,13 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
      *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     // metadata
      *     Struct metadataStruct = Struct.newBuilder()
@@ -216,13 +204,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.query(10,
      *                                                                                            Arrays.asList(1.0f, 2.0f, 3.0f),
@@ -257,13 +242,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
      *                                                                                                      "my-vector-id",
@@ -286,14 +268,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
@@ -313,13 +292,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
      *                                                                                                      "my-vector-id",
@@ -340,13 +316,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id", "example-namespace");
      * }</pre>
@@ -361,13 +334,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id", true, true);
      * }</pre>
@@ -383,13 +353,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id");
      * }</pre>
@@ -403,14 +370,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10,
@@ -434,14 +398,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10,
@@ -461,13 +422,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = index.queryByVector(10,
      *                                                                                               Arrays.asList(1.0f, 2.0f, 3.0f),
@@ -488,13 +446,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
      * }</pre>
@@ -509,13 +464,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
      * }</pre>
@@ -531,13 +483,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
@@ -551,13 +500,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.FetchResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<FetchResponse> listenableFuture = asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"));
      * }</pre>
@@ -570,13 +516,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.FetchResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<FetchResponse> listenableFuture = asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
@@ -592,13 +535,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
@@ -612,13 +552,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id",
      *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
@@ -635,14 +572,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct metadata = Struct.newBuilder()
      *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
@@ -673,14 +607,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
@@ -693,14 +624,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"));
      * }</pre>
@@ -713,14 +641,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByFilter(filter, "example-namespace");
@@ -734,14 +659,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByFilter(filter);
@@ -755,13 +677,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteAll("example-namespace");
      * }</pre>
@@ -774,13 +693,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.delete(Arrays.asList("v1", "v2", "v3"),
      *                                                                           false,
@@ -801,13 +717,10 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.AsyncIndex;
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     ListenableFuture<DescribeIndexStatsResponse> listenableFuture = asyncIndex.describeIndexStats();
      * }</pre>
@@ -822,14 +735,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *     import com.google.protobuf.Struct;
      *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     ListenableFuture<DescribeIndexStatsResponse> listenableFuture = asyncIndex.describeIndexStats();

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -16,6 +16,14 @@ import java.util.List;
 /**
  * A client for interacting with a Pinecone index via GRPC asynchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
+ *
+ * <pre>{@code
+ *     import io.pinecone.clients.Pinecone;
+ *     import io.pinecone.clients.AsyncIndex;
+ *
+ *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+ *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+ * }</pre>
  */
 public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertResponse>,
         ListenableFuture<QueryResponseWithUnsignedIndices>,
@@ -31,9 +39,17 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * Constructs an {@link AsyncIndex} instance for interacting with a Pinecone index.
      *
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     * }</pre>
+     *
      * @param connection The {@link PineconeConnection} configuration to be used for this index.
      * @param indexName The name of the index to interact with. The index host will be automatically resolved.
-     * @throws PineconeValidationException if the connection object is null or the indexName is null or empty.
+     * @throws PineconeValidationException if the connection object is null.
      */
     public AsyncIndex(PineconeConnection connection, String indexName) {
         if (connection == null) {

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -13,6 +13,10 @@ import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 
 import java.util.List;
 
+/**
+ * A client for interacting with a Pinecone index via GRPC asynchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
+ * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
+ */
 public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertResponse>,
         ListenableFuture<QueryResponseWithUnsignedIndices>,
         ListenableFuture<FetchResponse>,
@@ -24,6 +28,13 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     private final VectorServiceGrpc.VectorServiceFutureStub asyncStub;
     private final String indexName;
 
+    /**
+     * Constructs an {@link AsyncIndex} instance for interacting with a Pinecone index.
+     *
+     * @param connection The {@link PineconeConnection} configuration to be used for this index.
+     * @param indexName The name of the index to interact with. The index host will be automatically resolved.
+     * @throws PineconeValidationException if the connection object is null or the indexName is null or empty.
+     */
     public AsyncIndex(PineconeConnection connection, String indexName) {
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
@@ -34,6 +45,69 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         this.asyncStub = connection.getAsyncStub();
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpsertResponse;
+     *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+     *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     // Vector ids to be upserted
+     *     List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
+     *
+     *     // List of values to be upserted
+     *     List<List<Float>> values = new ArrayList<>();
+     *     values.add(Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     values.add(Arrays.asList(4.0f, 5.0f, 6.0f));
+     *     values.add(Arrays.asList(7.0f, 8.0f, 9.0f));
+     *
+     *     // List of sparse indices to be upserted
+     *     List<List<Long>> sparseIndices = new ArrayList<>();
+     *     sparseIndices.add(Arrays.asList(1L, 2L, 3L));
+     *     sparseIndices.add(Arrays.asList(4L, 5L, 6L));
+     *     sparseIndices.add(Arrays.asList(7L, 8L, 9L));
+     *
+     *     // List of sparse values to be upserted
+     *     List<List<Float>> sparseValues = new ArrayList<>();
+     *     sparseValues.add(Arrays.asList(1000f, 2000f, 3000f));
+     *     sparseValues.add(Arrays.asList(4000f, 5000f, 6000f));
+     *     sparseValues.add(Arrays.asList(7000f, 8000f, 9000f));
+     *
+     *     List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
+     *
+     *     // metadata
+     *     Struct metadataStruct1 = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *             .build();
+     *
+     *     Struct metadataStruct2 = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("thriller").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2020).build())
+     *             .build();
+     *
+     *     Struct metadataStruct3 = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("comedy").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2021).build())
+     *             .build();
+     *     List<Struct> metadataStructList = Arrays.asList(metadataStruct1, metadataStruct2, metadataStruct3);
+     *
+     *     List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
+     *
+     *     for (int i=0; i<upsertIds.size(); i++) {
+     *         vectors.add(buildUpsertVectorWithUnsignedIndices(upsertIds.get(i), values.get(i), sparseIndices.get(i), sparseValues.get(i), metadataStructList.get(i)));
+     *     }
+     *
+     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert(vectors, "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpsertResponse> upsert(List<VectorWithUnsignedIndices> vectorList,
                                                    String namespace) {
@@ -41,12 +115,40 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.upsert(upsertRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpsertResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpsertResponse> upsert(String id,
                                                    List<Float> values) {
         return upsert(id, values, null, null, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpsertResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpsertResponse> upsert(String id,
                                                    List<Float> values,
@@ -54,6 +156,34 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return upsert(id, values, null, null, null, namespace);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpsertResponse;
+     *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+     *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     // metadata
+     *     Struct metadataStruct = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *             .build();
+     *
+     *     ListenableFuture<UpsertResponse> listenableFuture = asyncIndex.upsert("my-vector-id",
+     *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                           Arrays.asList(1L, 2L, 3L),
+     *                                                                           Arrays.asList(1000f, 2000f, 3000f),
+     *                                                                           metadataStruct,
+     *                                                                           "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpsertResponse> upsert(String id,
                                                    List<Float> values,
@@ -67,6 +197,28 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.upsert(upsertRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.query(10,
+     *                                                                                            Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                                            Arrays.asList(1L, 2L, 3L),
+     *                                                                                            Arrays.asList(1000f, 2000f, 3000f),
+     *                                                                                            null,
+     *                                                                                            "example-namespace",
+     *                                                                                            null,
+     *                                                                                            true,
+     *                                                                                            true);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> query(int topK,
                                                                     List<Float> vector,
@@ -86,6 +238,25 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
                 QueryResponseWithUnsignedIndices::new, MoreExecutors.directExecutor());
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
+     *                                                                                                      "my-vector-id",
+     *                                                                                                      "example-namespace",
+     *                                                                                                      null,
+     *                                                                                                      true,
+     *                                                                                                      true);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id,
@@ -96,6 +267,25 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, null, null, null, id, namespace, filter, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
+     *                                                                                                      "my-vector-id",
+     *                                                                                                      "example-namespace",
+     *                                                                                                      filter);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id,
@@ -104,6 +294,24 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, null, null, null, id, namespace, filter, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10,
+     *                                                                                                      "my-vector-id",
+     *                                                                                                      "example-namespace",
+     *                                                                                                      true,
+     *                                                                                                      true);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id,
@@ -113,6 +321,20 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, null, null, null, id, namespace, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id", "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id,
@@ -120,20 +342,69 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, null, null, null, id, namespace, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id", true, true);
+     * }</pre>
+     */
     @Override
-    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK, String id,
+    public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
+                                                                              String id,
                                                                               boolean includeValues,
                                                                               boolean includeMetadata) {
         return query(topK, null, null, null, id, null, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVectorId(10, "my-vector-id");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVectorId(int topK,
                                                                               String id) {
         return query(topK, null, null, null, id, null, null, false, false);
     }
 
-
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10,
+     *                                                                                                    Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                                                    "example-namespace",
+     *                                                                                                    filter,
+     *                                                                                                    true,
+     *                                                                                                    true);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
                                                                             List<Float> vector,
@@ -144,6 +415,25 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, vector, null, null, null, namespace, filter, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10,
+     *                                                                                                    Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                                                    "example-namespace",
+     *                                                                                                    filter);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
                                                                             List<Float> vector,
@@ -152,6 +442,24 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, vector, null, null, null, namespace, filter, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = index.queryByVector(10,
+     *                                                                                               Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                                               "example-namespace",
+     *                                                                                               true,
+     *                                                                                               true);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
                                                                             List<Float> vector,
@@ -161,6 +469,20 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, vector, null, null, null, namespace, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
                                                                             List<Float> vector,
@@ -168,6 +490,20 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, vector, null, null, null, namespace, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
                                                                             List<Float> vector,
@@ -176,17 +512,59 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return query(topK, vector, null, null, null, null, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<QueryResponseWithUnsignedIndices> listenableFuture = asyncIndex.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
+     * }</pre>
+     */
     @Override
     public ListenableFuture<QueryResponseWithUnsignedIndices> queryByVector(int topK,
                                                                             List<Float> vector) {
         return query(topK, vector, null, null, null, null, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.FetchResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<FetchResponse> listenableFuture = asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"));
+     * }</pre>
+     */
     @Override
     public ListenableFuture<FetchResponse> fetch(List<String> ids) {
         return fetch(ids, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.FetchResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<FetchResponse> listenableFuture = asyncIndex.fetch(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<FetchResponse> fetch(List<String> ids,
                                                  String namespace) {
@@ -195,12 +573,42 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.fetch(fetchRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpdateResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpdateResponse> update(String id,
                                                    List<Float> values) {
         return update(id, values, null, null, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpdateResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id",
+     *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                           "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpdateResponse> update(String id,
                                                    List<Float> values,
@@ -208,6 +616,31 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return update(id, values, null, namespace, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.UpdateResponse;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct metadata = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *             .build();
+     *
+     *     ListenableFuture<UpdateResponse> listenableFuture = asyncIndex.update("my-vector-id",
+     *                                                                           Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                           metadata,
+     *                                                                           "example-namespace",
+     *                                                                           Arrays.asList(1L, 2L, 3L),
+     *                                                                           Arrays.asList(1000f, 2000f, 3000f));
+     * }</pre>
+     */
     @Override
     public ListenableFuture<UpdateResponse> update(String id,
                                                    List<Float> values,
@@ -221,31 +654,124 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.update(updateRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DeleteResponse> deleteByIds(List<String> ids, String namespace) {
         return delete(ids, false, namespace, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByIds(Arrays.asList("v1", "v2", "v3"));
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DeleteResponse> deleteByIds(List<String> ids) {
         return delete(ids, false, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByFilter(filter, "example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DeleteResponse> deleteByFilter(Struct filter, String namespace) {
         return delete(null, false, namespace, filter);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteByFilter(filter);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DeleteResponse> deleteByFilter(Struct filter) {
         return delete(null, false, null, filter);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.deleteAll("example-namespace");
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DeleteResponse> deleteAll(String namespace) {
         return delete(null, true, namespace, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<DeleteResponse> listenableFuture = asyncIndex.delete(Arrays.asList("v1", "v2", "v3"),
+     *                                                                           false,
+     *                                                                           "example-namespace",
+     *                                                                           null);
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DeleteResponse> delete(List<String> ids,
                                                    boolean deleteAll,
@@ -256,6 +782,20 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.delete(deleteRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.AsyncIndex;
+     *     import io.pinecone.proto.DescribeIndexStatsResponse;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     ListenableFuture<DescribeIndexStatsResponse> listenableFuture = asyncIndex.describeIndexStats();
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DescribeIndexStatsResponse> describeIndexStats() {
         DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(null);
@@ -263,6 +803,22 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.describeIndexStats(describeIndexStatsRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DescribeIndexStatsResponse;
+     *     import com.google.protobuf.Struct;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     AsyncIndex asyncIndex = client.getAsyncIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     ListenableFuture<DescribeIndexStatsResponse> listenableFuture = asyncIndex.describeIndexStats();
+     * }</pre>
+     */
     @Override
     public ListenableFuture<DescribeIndexStatsResponse> describeIndexStats(Struct filter) {
         DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(filter);
@@ -271,9 +827,11 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     }
 
     /**
-     * Close the connection and release all resources. A PineconeConnection's underlying gRPC components use resources
-     * like threads and TCP connections. To prevent leaking these resources the connection should be closed when it
-     * will no longer be used. If it may be used again leave it running.
+     * {@inheritDoc}
+     * Closes the current index connection gracefully, releasing any resources associated with it. This method should
+     * be called when the index instance is no longer needed, to ensure proper cleanup of network connections and other
+     * resources. It closes both the connection to the Pinecone service identified by {@code indexName} and any internal
+     * resources held by the {@link PineconeConnection} object.
      */
     @Override
     public void close() {

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -61,14 +61,11 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
      *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     // Vector ids to be upserted
      *     List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
@@ -98,12 +95,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpsertResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     UpsertResponse upsertResponse = index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
@@ -117,12 +111,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpsertResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     UpsertResponse upsertResponse = index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
      * }</pre>
@@ -137,15 +128,12 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
      *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     // metadata
      *     Struct metadataStruct = Struct.newBuilder()
@@ -177,12 +165,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.query(10,
      *                                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
@@ -214,12 +199,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10,
      *                                                                            "my-vector-id",
@@ -242,13 +224,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10,
@@ -268,12 +247,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", "example-namespace", true, true);
      * }</pre>
@@ -290,12 +266,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", "example-namespace");
      * }</pre>
@@ -310,12 +283,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", true, true);
      * }</pre>
@@ -331,12 +301,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id");
      * }</pre>
@@ -350,13 +317,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
@@ -380,13 +344,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
@@ -406,12 +367,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
      *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
@@ -432,12 +390,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
      * }</pre>
@@ -452,12 +407,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
      * }</pre>
@@ -473,12 +425,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
@@ -492,12 +441,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.FetchResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     FetchResponse fetchResponse = index.fetch(Arrays.asList("v1", "v2", "v3"));
      * }</pre>
@@ -510,12 +456,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.FetchResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     FetchResponse fetchResponse = index.fetch(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
@@ -531,12 +474,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpdateResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     UpdateResponse updateResponse = index.update("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
@@ -550,12 +490,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpdateResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     UpdateResponse updateResponse = index.update("my-vector-id",
      *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
@@ -572,13 +509,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct metadata = Struct.newBuilder()
      *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
@@ -609,13 +543,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     DeleteResponse deleteResponse = index.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
@@ -628,13 +559,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     DeleteResponse deleteResponse = index.deleteByIds(Arrays.asList("v1", "v2", "v3"));
      * }</pre>
@@ -647,13 +575,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     DeleteResponse deleteResponse = index.deleteByFilter(filter, "example-namespace");
@@ -667,13 +592,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     DeleteResponse deleteResponse = index.deleteByFilter(filter);
@@ -687,12 +609,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     DeleteResponse deleteResponse = index.deleteAll("example-namespace");
      * }</pre>
@@ -705,12 +624,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DeleteResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     DeleteResponse deleteResponse = index.delete(Arrays.asList("v1", "v2", "v3"),
      *                                                  false,
@@ -731,12 +647,9 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
      * }</pre>
@@ -751,13 +664,10 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * {@inheritDoc}
      * <pre>{@code
-     *     import io.pinecone.clients.Pinecone;
-     *     import io.pinecone.clients.Index;
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *     import com.google.protobuf.Struct;
      *
-     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *     Index index = client.getIndexConnection("my-index");
+     *     ...
      *
      *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * A client for interacting with a Pinecone index via GRPC synchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
- * <p/>
+ * <p>
  * Example:
  * <pre>{@code
  *     import io.pinecone.clients.Pinecone;
@@ -36,7 +36,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * Constructs an {@link Index} instance for interacting with a Pinecone index.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.clients.Pinecone;
@@ -62,7 +62,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -100,7 +100,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
@@ -114,7 +114,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -136,7 +136,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
@@ -176,7 +176,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -213,7 +213,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -241,7 +241,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -268,7 +268,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -294,7 +294,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -316,7 +316,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -340,7 +340,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -360,7 +360,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -391,7 +391,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -418,7 +418,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -444,7 +444,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -466,7 +466,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -490,7 +490,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
@@ -509,7 +509,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
@@ -526,7 +526,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
@@ -546,7 +546,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
@@ -564,7 +564,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
@@ -586,7 +586,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
@@ -623,7 +623,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -642,7 +642,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -660,7 +660,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -680,7 +680,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -700,7 +700,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -717,7 +717,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
@@ -740,7 +740,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
@@ -759,7 +759,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -13,6 +13,14 @@ import java.util.List;
 /**
  * A client for interacting with a Pinecone index via GRPC synchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
+ *
+ * <pre>{@code
+ *     import io.pinecone.clients.Pinecone;
+ *     import io.pinecone.clients.Index;
+ *
+ *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+ *     Index index = client.getIndexConnection("my-index");
+ * }</pre>
  */
 public class Index implements IndexInterface<UpsertResponse,
         QueryResponseWithUnsignedIndices,
@@ -28,9 +36,17 @@ public class Index implements IndexInterface<UpsertResponse,
     /**
      * Constructs an {@link Index} instance for interacting with a Pinecone index.
      *
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     * }</pre>
+     *
      * @param connection The {@link PineconeConnection} configuration to be used for this index.
      * @param indexName The name of the index to interact with. The index host will be automatically resolved.
-     * @throws PineconeValidationException if the connection object is null or the indexName is null or empty.
+     * @throws PineconeValidationException if the connection object is null.
      */
     public Index(PineconeConnection connection, String indexName) {
         if (connection == null) {

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -13,7 +13,8 @@ import java.util.List;
 /**
  * A client for interacting with a Pinecone index via GRPC synchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
- *
+ * <p/>
+ * Example:
  * <pre>{@code
  *     import io.pinecone.clients.Pinecone;
  *     import io.pinecone.clients.Index;
@@ -35,7 +36,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * Constructs an {@link Index} instance for interacting with a Pinecone index.
-     *
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.clients.Pinecone;
      *     import io.pinecone.clients.Index;
@@ -60,6 +62,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
@@ -79,7 +83,9 @@ public class Index implements IndexInterface<UpsertResponse,
      *     List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
      *
      *     for (int i=0; i<upsertIds.size(); i++) {
-     *         vectors.add(buildUpsertVectorWithUnsignedIndices(upsertIds.get(i), values.get(i), null, null, null));
+     *         vectors.add(
+     *             buildUpsertVectorWithUnsignedIndices(upsertIds.get(i),
+     *                 values.get(i), null, null, null));
      *     }
      *
      *     UpsertResponse upsertResponse = index.upsert(vectors, "example-namespace");
@@ -94,12 +100,10 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
-     *     import io.pinecone.proto.UpsertResponse;
-     *
-     *     ...
-     *
-     *     UpsertResponse upsertResponse = index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
      */
     @Override
@@ -110,12 +114,17 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *
      *     ...
      *
-     *     UpsertResponse upsertResponse = index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     *     UpsertResponse upsertResponse =
+     *     index.upsert("my-vector-id",
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace");
      * }</pre>
      */
     @Override
@@ -127,6 +136,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpsertResponse;
      *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
@@ -137,16 +148,17 @@ public class Index implements IndexInterface<UpsertResponse,
      *
      *     // metadata
      *     Struct metadataStruct = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
-     *             .build();
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *         .build();
      *
-     *     UpsertResponse upsertResponse = index.upsert("my-vector-id",
-     *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                  Arrays.asList(1L, 2L, 3L),
-     *                                                  Arrays.asList(1000f, 2000f, 3000f),
-     *                                                  metadataStruct,
-     *                                                  "example-namespace");
+     *     UpsertResponse upsertResponse =
+     *     index.upsert("my-vector-id",
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         Arrays.asList(1L, 2L, 3L),
+     *         Arrays.asList(1000f, 2000f, 3000f),
+     *         metadataStruct,
+     *         "example-namespace");
      * }</pre>
      */
     @Override
@@ -164,20 +176,23 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.query(10,
-     *                                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                  Arrays.asList(1L, 2L, 3L),
-     *                                                                  Arrays.asList(1000f, 2000f, 3000f),
-     *                                                                  null,
-     *                                                                  "example-namespace",
-     *                                                                  null,
-     *                                                                  true,
-     *                                                                  true);
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *         index.query(10,
+     *             Arrays.asList(1.0f, 2.0f, 3.0f),
+     *             Arrays.asList(1L, 2L, 3L),
+     *             Arrays.asList(1000f, 2000f, 3000f),
+     *             null,
+     *             "example-namespace",
+     *             null,
+     *             true,
+     *             true);
      * }</pre>
      */
     @Override
@@ -198,17 +213,20 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10,
-     *                                                                            "my-vector-id",
-     *                                                                            "example-namespace",
-     *                                                                            null,
-     *                                                                            true,
-     *                                                                            true);
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *         index.queryByVectorId(10,
+     *             "my-vector-id",
+     *             "example-namespace",
+     *             null,
+     *             true,
+     *             true);
      * }</pre>
      */
     @Override
@@ -223,17 +241,21 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10,
-     *                                                                            "my-vector-id",
-     *                                                                            "example-namespace",
-     *                                                                            filter);
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *         index.queryByVectorId(10,
+     *             "my-vector-id",
+     *             "example-namespace",
+     *             filter);
      * }</pre>
      */
     @Override
@@ -246,12 +268,19 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", "example-namespace", true, true);
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVectorId(10,
+     *         "my-vector-id",
+     *         "example-namespace",
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -265,12 +294,17 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", "example-namespace");
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVectorId(10,
+     *         "my-vector-id",
+     *         "example-namespace");
      * }</pre>
      */
     @Override
@@ -282,12 +316,18 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", true, true);
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVectorId(10,
+     *         "my-vector-id",
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -300,12 +340,16 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id");
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVectorId(10,
+     *         "my-vector-id");
      * }</pre>
      */
     @Override
@@ -316,19 +360,23 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
-     *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                          "example-namespace",
-     *                                                                          filter,
-     *                                                                          true,
-     *                                                                          true);
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace",
+     *         filter,
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -343,17 +391,21 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
-     *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                          "example-namespace",
-     *                                                                          filter);
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace",
+     *         filter);
      * }</pre>
      */
     @Override
@@ -366,16 +418,19 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
-     *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                                          "example-namespace",
-     *                                                                          true,
-     *                                                                          true);
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace",
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -389,12 +444,17 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace");
      * }</pre>
      */
     @Override
@@ -406,12 +466,18 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVector(10,
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         true,
+     *         true);
      * }</pre>
      */
     @Override
@@ -424,12 +490,15 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
      *
      *     ...
      *
-     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     QueryResponseWithUnsignedIndices queryResponse =
+     *     index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
      * }</pre>
      */
     @Override
@@ -440,6 +509,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
      *
@@ -455,6 +526,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.FetchResponse;
      *
@@ -473,6 +546,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
      *
@@ -489,14 +564,17 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
      *
      *     ...
      *
-     *     UpdateResponse updateResponse = index.update("my-vector-id",
-     *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                  "example-namespace");
+     *     UpdateResponse updateResponse =
+     *     index.update("my-vector-id",
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         "example-namespace");
      * }</pre>
      */
     @Override
@@ -508,6 +586,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.UpdateResponse;
      *     import com.google.protobuf.Struct;
@@ -515,16 +595,17 @@ public class Index implements IndexInterface<UpsertResponse,
      *     ...
      *
      *     Struct metadata = Struct.newBuilder()
-     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
-     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
-     *             .build();
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *         .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *         .build();
      *
-     *     UpdateResponse updateResponse = index.update("my-vector-id",
-     *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
-     *                                                  metadata,
-     *                                                  "example-namespace",
-     *                                                  Arrays.asList(1L, 2L, 3L),
-     *                                                  Arrays.asList(1000f, 2000f, 3000f));
+     *     UpdateResponse updateResponse =
+     *     index.update("my-vector-id",
+     *         Arrays.asList(1.0f, 2.0f, 3.0f),
+     *         metadata,
+     *         "example-namespace",
+     *         Arrays.asList(1L, 2L, 3L),
+     *         Arrays.asList(1000f, 2000f, 3000f));
      * }</pre>
      */
     @Override
@@ -542,13 +623,16 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     DeleteResponse deleteResponse = index.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     *     DeleteResponse deleteResponse =
+     *     index.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
      * }</pre>
      */
     @Override
@@ -558,6 +642,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
@@ -574,13 +660,16 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     DeleteResponse deleteResponse = index.deleteByFilter(filter, "example-namespace");
      * }</pre>
      */
@@ -591,13 +680,16 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     DeleteResponse deleteResponse = index.deleteByFilter(filter);
      * }</pre>
      */
@@ -608,6 +700,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *
@@ -623,15 +717,15 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DeleteResponse;
      *
      *     ...
      *
-     *     DeleteResponse deleteResponse = index.delete(Arrays.asList("v1", "v2", "v3"),
-     *                                                  false,
-     *                                                  "example-namespace",
-     *                                                  null);
+     *     DeleteResponse deleteResponse =
+     *     index.delete(Arrays.asList("v1", "v2", "v3"),false,"example-namespace",null);
      * }</pre>
      */
     @Override
@@ -646,6 +740,8 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *
@@ -663,13 +759,16 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * Example:
      * <pre>{@code
      *     import io.pinecone.proto.DescribeIndexStatsResponse;
      *     import com.google.protobuf.Struct;
      *
      *     ...
      *
-     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     Struct filter = Struct.newBuilder()
+     *         .putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
      *     DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
      * }</pre>
      */

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -10,6 +10,10 @@ import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 
 import java.util.List;
 
+/**
+ * A client for interacting with a Pinecone index via GRPC synchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
+ * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
+ */
 public class Index implements IndexInterface<UpsertResponse,
         QueryResponseWithUnsignedIndices,
         FetchResponse,
@@ -21,6 +25,13 @@ public class Index implements IndexInterface<UpsertResponse,
     private final String indexName;
     private final VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
 
+    /**
+     * Constructs an {@link Index} instance for interacting with a Pinecone index.
+     *
+     * @param connection The {@link PineconeConnection} configuration to be used for this index.
+     * @param indexName The name of the index to interact with. The index host will be automatically resolved.
+     * @throws PineconeValidationException if the connection object is null or the indexName is null or empty.
+     */
     public Index(PineconeConnection connection, String indexName) {
         if (connection == null) {
             throw new PineconeValidationException("Pinecone connection object cannot be null.");
@@ -31,6 +42,36 @@ public class Index implements IndexInterface<UpsertResponse,
         this.blockingStub = connection.getBlockingStub();
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpsertResponse;
+     *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+     *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     // Vector ids to be upserted
+     *     List<String> upsertIds = Arrays.asList("v1", "v2", "v3");
+     *
+     *     // List of values to be upserted
+     *     List<List<Float>> values = new ArrayList<>();
+     *     values.add(Arrays.asList(1.0f, 2.0f, 3.0f));
+     *     values.add(Arrays.asList(4.0f, 5.0f, 6.0f));
+     *     values.add(Arrays.asList(7.0f, 8.0f, 9.0f));
+     *
+     *     List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
+     *
+     *     for (int i=0; i<upsertIds.size(); i++) {
+     *         vectors.add(buildUpsertVectorWithUnsignedIndices(upsertIds.get(i), values.get(i), null, null, null));
+     *     }
+     *
+     *     UpsertResponse upsertResponse = index.upsert(vectors, "example-namespace");
+     * }</pre>
+     */
     @Override
     public UpsertResponse upsert(List<VectorWithUnsignedIndices> vectorList,
                                  String namespace) {
@@ -38,12 +79,38 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.upsert(upsertRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpsertResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     UpsertResponse upsertResponse = index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     * }</pre>
+     */
     @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values) {
         return upsert(id, values, null, null, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpsertResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     UpsertResponse upsertResponse = index.upsert("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     * }</pre>
+     */
     @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values,
@@ -51,6 +118,33 @@ public class Index implements IndexInterface<UpsertResponse,
         return upsert(id, values, null, null, null, namespace);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpsertResponse;
+     *     import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+     *     import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     // metadata
+     *     Struct metadataStruct = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *             .build();
+     *
+     *     UpsertResponse upsertResponse = index.upsert("my-vector-id",
+     *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                  Arrays.asList(1L, 2L, 3L),
+     *                                                  Arrays.asList(1000f, 2000f, 3000f),
+     *                                                  metadataStruct,
+     *                                                  "example-namespace");
+     * }</pre>
+     */
     @Override
     public UpsertResponse upsert(String id,
                                  List<Float> values,
@@ -64,6 +158,27 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.upsert(upsertRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.query(10,
+     *                                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                  Arrays.asList(1L, 2L, 3L),
+     *                                                                  Arrays.asList(1000f, 2000f, 3000f),
+     *                                                                  null,
+     *                                                                  "example-namespace",
+     *                                                                  null,
+     *                                                                  true,
+     *                                                                  true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices query(int topK,
                                                   List<Float> vector,
@@ -80,6 +195,24 @@ public class Index implements IndexInterface<UpsertResponse,
         return new QueryResponseWithUnsignedIndices(blockingStub.query(queryRequest));
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10,
+     *                                                                            "my-vector-id",
+     *                                                                            "example-namespace",
+     *                                                                            null,
+     *                                                                            true,
+     *                                                                            true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id,
@@ -90,6 +223,24 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, null, null, null, id, namespace, filter, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10,
+     *                                                                            "my-vector-id",
+     *                                                                            "example-namespace",
+     *                                                                            filter);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id,
@@ -98,6 +249,19 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, null, null, null, id, namespace, filter, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", "example-namespace", true, true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id,
@@ -107,6 +271,19 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, null, null, null, id, namespace, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", "example-namespace");
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id,
@@ -114,6 +291,19 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, null, null, null, id, namespace, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id", true, true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id,
@@ -122,12 +312,45 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, null, null, null, id, null, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVectorId(10, "my-vector-id");
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVectorId(int topK,
                                                             String id) {
         return query(topK, null, null, null, id, null, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
+     *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                          "example-namespace",
+     *                                                                          filter,
+     *                                                                          true,
+     *                                                                          true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVector(int topK,
                                                           List<Float> vector,
@@ -138,6 +361,24 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, vector, null, null, null, namespace, filter, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
+     *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                          "example-namespace",
+     *                                                                          filter);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVector(int topK,
                                                           List<Float> vector,
@@ -146,6 +387,23 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, vector, null, null, null, namespace, filter, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10,
+     *                                                                          Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                                          "example-namespace",
+     *                                                                          true,
+     *                                                                          true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVector(int topK,
                                                           List<Float> vector,
@@ -155,6 +413,19 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, vector, null, null, null, namespace, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), "example-namespace");
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVector(int topK,
                                                           List<Float> vector,
@@ -162,6 +433,19 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, vector, null, null, null, namespace, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f), true, true);
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVector(int topK,
                                                           List<Float> vector,
@@ -170,17 +454,56 @@ public class Index implements IndexInterface<UpsertResponse,
         return query(topK, vector, null, null, null, null, null, includeValues, includeMetadata);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     QueryResponseWithUnsignedIndices queryResponse = index.queryByVector(10, Arrays.asList(1.0f, 2.0f, 3.0f));
+     * }</pre>
+     */
     @Override
     public QueryResponseWithUnsignedIndices queryByVector(int topK,
                                                           List<Float> vector) {
         return query(topK, vector, null, null, null, null, null, false, false);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.FetchResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     FetchResponse fetchResponse = index.fetch(Arrays.asList("v1", "v2", "v3"));
+     * }</pre>
+     */
     @Override
     public FetchResponse fetch(List<String> ids) {
         return fetch(ids, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.FetchResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     FetchResponse fetchResponse = index.fetch(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     * }</pre>
+     */
     @Override
     public FetchResponse fetch(List<String> ids,
                                String namespace) {
@@ -189,12 +512,40 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.fetch(fetchRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpdateResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     UpdateResponse updateResponse = index.update("my-vector-id", Arrays.asList(1.0f, 2.0f, 3.0f));
+     * }</pre>
+     */
     @Override
     public UpdateResponse update(String id,
                                  List<Float> values) {
         return update(id, values, null, null, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpdateResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     UpdateResponse updateResponse = index.update("my-vector-id",
+     *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                  "example-namespace");
+     * }</pre>
+     */
     @Override
     public UpdateResponse update(String id,
                                  List<Float> values,
@@ -202,6 +553,30 @@ public class Index implements IndexInterface<UpsertResponse,
         return update(id, values, null, namespace, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.UpdateResponse;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct metadata = Struct.newBuilder()
+     *             .putFields("genre", Value.newBuilder().setStringValue("action").build())
+     *             .putFields("year", Value.newBuilder().setNumberValue(2019).build())
+     *             .build();
+     *
+     *     UpdateResponse updateResponse = index.update("my-vector-id",
+     *                                                  Arrays.asList(1.0f, 2.0f, 3.0f),
+     *                                                  metadata,
+     *                                                  "example-namespace",
+     *                                                  Arrays.asList(1L, 2L, 3L),
+     *                                                  Arrays.asList(1000f, 2000f, 3000f));
+     * }</pre>
+     */
     @Override
     public UpdateResponse update(String id,
                                  List<Float> values,
@@ -215,30 +590,118 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.update(updateRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     DeleteResponse deleteResponse = index.deleteByIds(Arrays.asList("v1", "v2", "v3"), "example-namespace");
+     * }</pre>
+     */
     @Override
     public DeleteResponse deleteByIds(List<String> ids, String namespace) {
         return delete(ids, false, namespace, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     DeleteResponse deleteResponse = index.deleteByIds(Arrays.asList("v1", "v2", "v3"));
+     * }</pre>
+     */
     @Override
     public DeleteResponse deleteByIds(List<String> ids) {
         return delete(ids, false, null, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     DeleteResponse deleteResponse = index.deleteByFilter(filter, "example-namespace");
+     * }</pre>
+     */
+    @Override
     public DeleteResponse deleteByFilter(Struct filter, String namespace) {
         return delete(null, false, namespace, filter);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     DeleteResponse deleteResponse = index.deleteByFilter(filter);
+     * }</pre>
+     */
     @Override
     public DeleteResponse deleteByFilter(Struct filter) {
         return delete(null, false, null, filter);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     DeleteResponse deleteResponse = index.deleteAll("example-namespace");
+     * }</pre>
+     */
     @Override
     public DeleteResponse deleteAll(String namespace) {
         return delete(null, true, namespace, null);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DeleteResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     DeleteResponse deleteResponse = index.delete(Arrays.asList("v1", "v2", "v3"),
+     *                                                  false,
+     *                                                  "example-namespace",
+     *                                                  null);
+     * }</pre>
+     */
     @Override
     public DeleteResponse delete(List<String> ids,
                                  boolean deleteAll,
@@ -249,6 +712,19 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.delete(deleteRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DescribeIndexStatsResponse;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
+     * }</pre>
+     */
     @Override
     public DescribeIndexStatsResponse describeIndexStats() {
         DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(null);
@@ -256,6 +732,21 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.describeIndexStats(describeIndexStatsRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <pre>{@code
+     *     import io.pinecone.clients.Pinecone;
+     *     import io.pinecone.clients.Index;
+     *     import io.pinecone.proto.DescribeIndexStatsResponse;
+     *     import com.google.protobuf.Struct;
+     *
+     *     Pinecone client = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *     Index index = client.getIndexConnection("my-index");
+     *
+     *     Struct filter = Struct.newBuilder().putFields("genre", Value.newBuilder().setStringValue("action").build()).build();
+     *     DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
+     * }</pre>
+     */
     @Override
     public DescribeIndexStatsResponse describeIndexStats(Struct filter) {
         DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(filter);
@@ -263,6 +754,13 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.describeIndexStats(describeIndexStatsRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * Closes the current index connection gracefully, releasing any resources associated with it. This method should
+     * be called when the index instance is no longer needed, to ensure proper cleanup of network connections and other
+     * resources. It closes both the connection to the Pinecone service identified by {@code indexName} and any internal
+     * resources held by the {@link PineconeConnection} object.
+     */
     @Override
     public void close() {
         Pinecone.closeConnection(indexName);

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -48,7 +48,7 @@ public class Pinecone {
 
     /**
      * Creates a new serverless index with the specified parameters.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     client.createServerlessIndex("YOUR-INDEX", "cosine", 1536, "aws", "us-west-2");
@@ -119,7 +119,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment and podType, the minimum required parameters.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     client.createPodsIndex("YOUR-INDEX", 1536, "us-east4-gcp", "p1.x2");
@@ -138,7 +138,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, and metric.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     client.createPodsIndex("YOUR-INDEX", 1536, "us-east4-gcp", "p1.x2", "cosine");
@@ -159,7 +159,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, metric, and metadataConfig.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.CreateIndexRequestSpecPodMetadataConfig;
@@ -190,7 +190,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, metric, and sourceCollection.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     client.createPodsIndex("YOUR-INDEX", 1536, "us-east4-gcp", "p1.x2", "cosine", "my-collection");
@@ -213,7 +213,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, and pods.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     client.createPodsIndex("YOUR-INDEX", 1536, "us-east4-gcp", "p1.x2", "cosine", 6);
@@ -234,7 +234,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, pods, and metadataConfig.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.CreateIndexRequestSpecPodMetadataConfig;
@@ -263,7 +263,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, replicas, and shards.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code
      *     client.createPodsIndex("YOUR-INDEX", 1536, "us-east4-gcp", "p1.x2", "cosine", 2, 2);
@@ -286,7 +286,7 @@ public class Pinecone {
 
     /**
      * Overload for creating a new pods index with environment, podType, replicas, shards, and metadataConfig.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.CreateIndexRequestSpecPodMetadataConfig;
@@ -317,7 +317,7 @@ public class Pinecone {
 
     /**
      * Creates a new pods index with the specified parameters.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.CreateIndexRequestSpecPodMetadataConfig;
@@ -420,7 +420,7 @@ public class Pinecone {
 
     /**
      * Retrieves information about an existing index.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.IndexModel;
@@ -445,7 +445,7 @@ public class Pinecone {
 
     /**
      * Configures an existing pod-based index with new settings.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.IndexModel;
@@ -500,7 +500,7 @@ public class Pinecone {
 
     /**
      * Overload for configureIndex to only change the number of replicas for an index.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.IndexModel;
@@ -520,7 +520,7 @@ public class Pinecone {
 
     /**
      * Overload for configureIndex to only change the podType of an index.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.IndexModel;
@@ -540,7 +540,7 @@ public class Pinecone {
 
     /**
      * Lists all indexes in your project, including the index name, dimension, metric, status, and spec.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.IndexList;
@@ -573,7 +573,7 @@ public class Pinecone {
      * You can check the status of the index by calling the describeIndex command.
      * With repeated polling of the describeIndex command, you will see the index transition to a
      * Terminating state before eventually resulting in a 404 after it has been removed.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.IndexModel;
@@ -600,7 +600,7 @@ public class Pinecone {
 
     /**
      * Creates a new collection from a source index.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.CollectionModel;
@@ -637,7 +637,7 @@ public class Pinecone {
 
     /**
      * Describes an existing collection.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import io.pinecone.clients.Pinecone;
@@ -663,7 +663,7 @@ public class Pinecone {
 
     /**
      * Lists all collections in the project.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import org.openapitools.client.model.CollectionList;
@@ -691,7 +691,7 @@ public class Pinecone {
      * Deleting a collection is an irreversible operation. All data in the collection will be lost.
      * This method tells Pinecone you would like to delete a collection, but it takes a few moments to complete the operation.
      * Use the describeCollection() method to confirm that the collection has been deleted.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     client.deleteCollection('my-collection');
@@ -715,7 +715,7 @@ public class Pinecone {
      * Retrieves a connection to a specific index for synchronous operations. This method initializes
      * and returns an {@link Index} object that represents a connection to an index and allowing for
      * synchronous operations against it.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import io.pinecone.clients.Index;
@@ -745,7 +745,7 @@ public class Pinecone {
      * Retrieves a connection to a specific index for asynchronous operations. This method initializes
      * and returns an {@link AsyncIndex} object that represents a connection to an index and allowing for
      * synchronous operations against it.
-     * <p/>
+     * <p>
      * Example:
      * <pre>{@code 
      *     import io.pinecone.clients.AsyncIndex;
@@ -824,7 +824,7 @@ public class Pinecone {
 
         /**
          * Sets the source tag to include with all requests made by the Pinecone client.
-         * <p/>
+         * <p>
          * Source tag is an optional string identifier used to help Pinecone attribute API activity to our partners.
          * For more info, see
          * <a href="https://docs.pinecone.io/integrations/build-integration/attribute-api-activity">

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -692,6 +692,7 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
 
     /**
      * Retrieves statistics about the index's contents for vectors that satisfy the applied metadata filter.
+     * 
      * @param filter A metadata filter used to select vectors that satisfy the filter criteria.
      * @return A generic type {@code Y} that contains the stats about the index.
      */

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -11,8 +11,34 @@ import java.util.List;
 
 import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSigned32Int;
 
+/**
+ * The {@code IndexInterface} provides a set of methods for performing operations
+ * such as upserting, querying, fetching, updating, and deleting vectors in an index.
+ * It supports operations with various types of data including dense vectors, sparse vectors,
+ * and metadata associated with the vectors. This interface is designed to be generic to support
+ * different implementations for handling vector storage and retrieval.
+ *
+ * @param <T> The return type for upsert operations.
+ * @param <U> The return type for query operations.
+ * @param <V> The return type for fetch operations.
+ * @param <W> The return type for update operations.
+ * @param <X> The return type for delete operations.
+ * @param <Y> The return type for describing index stats.
+ */
 public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
 
+    /**
+     * Validates and builds an upsert request with a single vector and optional namespace.
+     *
+     * @param id The unique identifier of the vector
+     * @param values The values of the dense vector
+     * @param sparseIndices The indices for the sparse vector representation
+     * @param sparseValues The values corresponding to the indices in the sparse vector representation
+     * @param metadata The metadata associated with the vector
+     * @param namespace The namespace of the vector (optional)
+     * @return An {@link UpsertRequest} built from the provided arguments
+     * @throws PineconeValidationException if there are invalid arguments
+     */
     default UpsertRequest validateUpsertRequest(String id,
                                                 List<Float> values,
                                                 List<Long> sparseIndices,
@@ -31,6 +57,15 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return upsertRequest.build();
     }
 
+    /**
+     * Validates and builds an upsert request with a list of vectors and optional namespace. This method
+     * is useful for batch upsert operations.
+     *
+     * @param vectorWithUnsignedIndicesList A list of {@link VectorWithUnsignedIndices} objects representing the vectors to upsert.
+     * @param namespace The namespace within which these vectors should be upserted. This parameter is optional.
+     * @return An {@link UpsertRequest} object constructed based on the provided vectors and namespace.
+     * @throws PineconeValidationException if any of the vectors contain invalid arguments.
+     */
     default UpsertRequest validateUpsertRequest(List<VectorWithUnsignedIndices> vectorWithUnsignedIndicesList,
                                                 String namespace) {
         List<Vector> vectors = new ArrayList<>(vectorWithUnsignedIndicesList.size());
@@ -50,6 +85,18 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return UpsertRequest.newBuilder().addAllVectors(vectors).setNamespace(namespace).build();
     }
 
+    /**
+     * Constructs a {@link Vector} object while validating the provided arguments. This helper method is used in a
+     * variety of upsert operations.
+     *
+     * @param id The unique identifier for the vector.
+     * @param values The dense vector values.
+     * @param sparseIndices Indices for sparse vector representation.
+     * @param sparseValues Values for the sparse indices.
+     * @param metadata Metadata associated with the vector.
+     * @return A {@link Vector} object constructed from the provided arguments.
+     * @throws PineconeValidationException if there are invalid arguments.
+     */
     default Vector buildUpsertVector(String id,
                                      List<Float> values,
                                      List<Long> sparseIndices,
@@ -89,6 +136,18 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return vectorBuilder.build();
     }
 
+    /**
+     * Constructs a {@link VectorWithUnsignedIndices} object while validating the provided arguments. This helper method
+     * is used in a variety of upsert operations.
+     *
+     * @param id The unique identifier for the vector.
+     * @param values The dense vector values.
+     * @param sparseIndices Indices for sparse vector representation, using unsigned integers.
+     * @param sparseValues Values for the sparse indices.
+     * @param metadata Metadata associated with the vector.
+     * @return A {@link VectorWithUnsignedIndices} object constructed from the provided arguments.
+     * @throws PineconeValidationException if there are invalid arguments.
+     */
     static VectorWithUnsignedIndices buildUpsertVectorWithUnsignedIndices(String id,
                                                                           List<Float> values,
                                                                           List<Long> sparseIndices,
@@ -125,6 +184,21 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return vectorWithUnsignedIndices;
     }
 
+    /**
+     * Validates and constructs a {@link QueryRequest} object.
+     *
+     * @param topK The number of top matching vectors to retrieve.
+     * @param vector The query vector for similarity search. If querying with vector, id must be null.
+     * @param sparseIndices Indices for sparse query vector.
+     * @param sparseValues Values for the sparse query vector.
+     * @param id The unique identifier of the vector to query. If querying with id, vector must be null.
+     * @param namespace The namespace from which to query vectors.
+     * @param filter The filter to apply. You can use vector metadata to limit your search.
+     * @param includeValues Flag indicating whether to include vector values in the response.
+     * @param includeMetadata Flag indicating whether to include metadata in the response.
+     * @return A {@link QueryRequest} object constructed from the provided arguments.
+     * @throws PineconeValidationException if there are invalid request arguments.
+     */
     default QueryRequest validateQueryRequest(int topK,
                                               List<Float> vector,
                                               List<Long> sparseIndices,
@@ -179,6 +253,14 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return queryRequest.build();
     }
 
+    /**
+     * Validates and constructs a fetch request for retrieving vectors by their ids from a namespace.
+     *
+     * @param ids The list of vector IDs to fetch.
+     * @param namespace The namespace to fetch vectors from. If not specified, the default namespace is used.
+     * @return A {@link FetchRequest} object constructed from the provided IDs and namespace.
+     * @throws PineconeValidationException if the vector IDs are not provided.
+     */
     default FetchRequest validateFetchRequest(List<String> ids, String namespace) {
         FetchRequest.Builder fetchRequest = FetchRequest.newBuilder();
 
@@ -194,6 +276,18 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return fetchRequest.build();
     }
 
+    /**
+     * Validates and constructs an update request for modifying an existing vector.
+     *
+     * @param id The unique ID of the vector to update.
+     * @param values The new values for the vector. If provided, these values replace the existing ones.
+     * @param metadata The new metadata for the vector. If provided, it replaces the existing metadata.
+     * @param namespace The namespace of the vector to be updated. If not specified, the default namespace is used.
+     * @param sparseIndices Indices for updating a sparse vector representation.
+     * @param sparseValues Values corresponding to the sparse indices.
+     * @return An {@link UpdateRequest} object constructed from the provided parameters.
+     * @throws PineconeValidationException if there are invalid arguments.
+     */
     default UpdateRequest validateUpdateRequest(String id,
                                                 List<Float> values,
                                                 Struct metadata,
@@ -237,6 +331,17 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return updateRequest.build();
     }
 
+    /**
+     * Validates and constructs a delete request for removing vectors by their IDs or based on a filter.
+     * Can also handle requests for deleting all vectors within a namespace.
+     *
+     * @param ids The list of vector IDs to delete.
+     * @param deleteAll Flag indicating whether to delete all vectors in the namespace.
+     * @param namespace The namespace from which to delete the vectors. This parameter is optional if deleteAll is true.
+     * @param filter A metadata filter used to select the vectors to delete. Mutually exclusive with ids and deleteAll.
+     * @return A {@link DeleteRequest} object constructed from the provided parameters.
+     * @throws PineconeValidationException if the request parameters are invalid.
+     */
     default DeleteRequest validateDeleteRequest(List<String> ids,
                                                 boolean deleteAll,
                                                 String namespace,
@@ -257,6 +362,12 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return deleteRequest.build();
     }
 
+    /**
+     * Validates and constructs a request to describe the statistics of the index.
+     *
+     * @param filter If a filter is provided, the operation returns statistics for vectors that match the filter.
+     * @return A {@link DescribeIndexStatsRequest} object constructed from the provided filter.
+     */
     default DescribeIndexStatsRequest validateDescribeIndexStatsRequest(Struct filter) {
         DescribeIndexStatsRequest.Builder describeIndexStatsRequest = DescribeIndexStatsRequest.newBuilder();
 
@@ -266,67 +377,323 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
         return describeIndexStatsRequest.build();
     }
 
+    /**
+     * Performs an upsert operation for a list of vectors within a namespace. If namespace is empty a default namespace is used.
+     *
+     * @param vectorList A list of vectors with unsigned indices to upsert.
+     * @param namespace The namespace where the vectors should be upserted. This is optional.
+     * @return A generic type {@code T} indicating the result of the upsert operation.
+     */
     T upsert(List<VectorWithUnsignedIndices> vectorList, String namespace);
 
+    /**
+     * Performs an upsert operation for a single vector in the default namespace.
+     *
+     * @param id The unique identifier of the vector.
+     * @param values The list of floating-point values that represent the vector.
+     * @return A generic type {@code T} indicating the result of the upsert operation.
+     */
     T upsert(String id, List<Float> values);
 
+    /**
+     * Performs an upsert operation for a single vector in the specified namespace.
+     *
+     * @param id The unique identifier of the vector.
+     * @param values The list of floating-point values that represent the vector.
+     * @param namespace The namespace where the vector should be upserted. This is optional.
+     * @return A generic type {@code T} indicating the result of the upsert operation.
+     */
     T upsert(String id, List<Float> values, String namespace);
 
+    /**
+     * Upserts a vector with both dense and sparse components, and optional metadata, into a specified namespace.
+     *
+     * @param id The unique identifier for the vector.
+     * @param values The dense vector values.
+     * @param sparseIndices Indices for sparse vector representation.
+     * @param sparseValues Values for the sparse indices.
+     * @param metadata Metadata associated with the vector.
+     * @param namespace The namespace to upsert the vector into. This is optional.
+     * @return A generic type {@code T} indicating the result of the upsert operation.
+     */
     T upsert(String id, List<Float> values, List<Long> sparseIndices, List<Float> sparseValues, Struct metadata,
              String namespace);
 
+    /**
+     * Queries a namespace using a query vector. Retrieves the ids of the most similar items, along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param id The unique id of a vector to be used as a query vector.
+     * @return A generic type {@code U} representing the query results.
+     */
     U queryByVectorId(int topK, String id);
 
+    /**
+     * Queries a namespace using a query vector identified by an ID, with options to include values and metadata in the results.
+     * Retrieves the IDs of the most similar items, along with their similarity scores, and optionally, their values and metadata.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param id The unique ID of a vector to be used as a query vector.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results, including optional values and metadata based on parameters.
+     */
     U queryByVectorId(int topK, String id, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Queries a specified namespace using a vector ID. Retrieves the IDs of the most similar items, along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param id The unique ID of a vector to be used as a query vector.
+     * @param namespace The namespace within which the query is performed.
+     * @return A generic type {@code U} representing the query results.
+     */
     U queryByVectorId(int topK, String id, String namespace);
 
+    /**
+     * Queries a specified namespace using a vector ID, with options to include values and metadata in the results.
+     * Retrieves the IDs of the most similar items, along with their similarity scores, and optionally, their values and metadata.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param id The unique ID of a vector to be used as a query vector.
+     * @param namespace The namespace within which the query is performed.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results, including optional values and metadata based on parameters.
+     */
     U queryByVectorId(int topK, String id, String namespace, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Queries a specified namespace using a vector ID and a custom filter. Retrieves the IDs of the most similar items, along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param id The unique ID of a vector to be used as a query vector.
+     * @param namespace The namespace within which the query is performed.
+     * @param filter A Struct defining additional filtering criteria for the query.
+     * @return A generic type {@code U} representing the query results, filtered according to the provided criteria.
+     */
     U queryByVectorId(int topK, String id, String namespace, Struct filter);
 
-    U queryByVectorId(int topK, String id, String namespace, Struct filter, boolean includeValues,
-                      boolean includeMetadata);
+    /**
+     * Queries a specified namespace using a vector ID, a custom filter, and options to include values and metadata in the results.
+     * Retrieves the IDs of the most similar items, along with their similarity scores, and optionally, their values and metadata, all while applying a filter.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param id The unique ID of a vector to be used as a query vector.
+     * @param namespace The namespace within which the query is performed.
+     * @param filter A Struct defining additional filtering criteria for the query.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results, including optional values and metadata based on parameters and filtered according to the provided criteria.
+     */
+    U queryByVectorId(int topK, String id, String namespace, Struct filter, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Queries the default namespace using a provided query vector. Retrieves the IDs of the most similar items,
+     * along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The query vector as a list of floating-point values.
+     * @return A generic type {@code U} representing the query results.
+     */
     U queryByVector(int topK, List<Float> vector);
 
+    /**
+     * Queries the default namespace using a provided query vector, with options to include values and metadata in the results.
+     * Retrieves the IDs of the most similar items, along with their similarity scores, and optionally, their values and metadata.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The query vector as a list of floating-point values.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results, including optional values and metadata based on parameters.
+     */
     U queryByVector(int topK, List<Float> vector, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Queries a specified namespace using a provided query vector. Retrieves the IDs of the most similar items,
+     * along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The query vector as a list of floating-point values.
+     * @param namespace The namespace within which the query is performed.
+     * @return A generic type {@code U} representing the query results.
+     */
     U queryByVector(int topK, List<Float> vector, String namespace);
 
+    /**
+     * Queries a specified namespace using a provided query vector, with options to include values and metadata in the results.
+     * Retrieves the IDs of the most similar items, along with their similarity scores, and optionally, their values and metadata.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The query vector as a list of floating-point values.
+     * @param namespace The namespace within which the query is performed.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results, including optional values and metadata based on parameters.
+     */
     U queryByVector(int topK, List<Float> vector, String namespace, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Queries a specified namespace using a provided query vector and a custom filter. Retrieves the IDs of the most similar items,
+     * along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The query vector as a list of floating-point values.
+     * @param namespace The namespace within which the query is performed.
+     * @param filter A Struct defining additional filtering criteria for the query.
+     * @return A generic type {@code U} representing the query results, filtered according to the provided criteria.
+     */
     U queryByVector(int topK, List<Float> vector, String namespace, Struct filter);
 
+    /**
+     * Queries a specified namespace using a provided query vector, a custom filter, and options to include values and metadata in the results.
+     * Retrieves the IDs of the most similar topK items, along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The query vector as a list of floating-point values.
+     * @param namespace The namespace within which the query is performed.
+     * @param filter A Struct defining additional filtering criteria for the query.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results, including optional values and metadata based on parameters and filtered according to the provided criteria.
+     */
     U queryByVector(int topK, List<Float> vector, String namespace, Struct filter, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Queries a namespace using a provided query vector. Retrieves the IDs of the most similar items, along with their similarity scores.
+     *
+     * @param topK The number of top similar vectors to retrieve.
+     * @param vector The dense query vector as a list of floating-point values. Each query can contain only one of the parameters: vector or id.
+     * @param sparseIndices The indices of the sparse vector representation, if applicable.
+     * @param sparseValues The values at the specified indices of the sparse vector representation.
+     * @param id The unique ID of a vector to be used as a query vector. Each query can contain only one of the parameters: vector or id.
+     * @param namespace The namespace within which the query is performed.
+     * @param filter A Struct defining additional filtering criteria for the query.
+     * @param includeValues Flag indicating whether to include the vector values in the query results.
+     * @param includeMetadata Flag indicating whether to include the vector metadata in the query results.
+     * @return A generic type {@code U} representing the query results containing a list of the closest vectors and a namespace name.
+     *
+     */
     U query(int topK, List<Float> vector, List<Long> sparseIndices, List<Float> sparseValues, String id,
             String namespace, Struct filter, boolean includeValues, boolean includeMetadata);
 
+    /**
+     * Looks up vectors by ID from the default namespace.
+     *
+     * @param ids A list of unique identifiers for the vectors to fetch.
+     * @return A generic type {@code V} representing the fetched vectors and the namespace.
+     */
     V fetch(List<String> ids);
 
+    /**
+     * Looks up vectors by ID from a specified namespace.
+     *
+     * @param ids A list of unique identifiers for the vectors to fetch.
+     * @param namespace The namespace to fetch vectors from.
+     * @return A generic type {@code V} representing the fetched vectors and the namespace.
+     */
     V fetch(List<String> ids, String namespace);
 
+    /**
+     * Updates an existing vector by ID with new values in the default namespace.
+     *
+     * @param id The unique identifier of the vector to update.
+     * @param values The new list of vector values to assign to set.
+     * @return A generic type {@code W} representing the result of the update operation.
+     */
     W update(String id, List<Float> values);
 
+    /**
+     * Updates an existing vector by ID with new values in a specified namespace.
+     *
+     * @param id The unique identifier of the vector to update.
+     * @param values The new list of vector values to assign to set.
+     * @param namespace The namespace in which to update the vector.
+     * @return A generic type {@code W} representing the result of the update operation.
+     */
     W update(String id, List<Float> values, String namespace);
 
+    /**
+     * Updates an existing vector by ID in a specified namespace. Allows updating the vector's values, metadata,
+     * and sparse representation.
+     *
+     * @param id The unique identifier of the vector to be updated.
+     * @param values The new list of floating-point values for the vector's dense representation. Previous values are overwritten.
+     * @param metadata Optional new metadata to associate with the vector. If provided, it replaces the existing metadata.
+     * @param namespace The namespace in which the vector resides and will be updated.
+     * @param sparseIndices Indices for the sparse vector representation, if applicable.
+     * @param sparseValues Values for the sparse vector representation. Must correspond to the provided indices.
+     * @return A generic type {@code W} representing the result of the update operation.
+     */
     W update(String id, List<Float> values, Struct metadata, String namespace, List<Long> sparseIndices,
              List<Float> sparseValues);
 
+    /**
+     * Deletes a list of vectors by ID from the default namespace.
+     *
+     * @param ids A list of unique vector IDs to be deleted.
+     * @return A generic type {@code X} indicating the result of the delete operation.
+     */
     X deleteByIds(List<String> ids);
 
+    /**
+     * Deletes vectors identified by a list of unique IDs from a specified namespace.
+     *
+     * @param ids A list of unique vector IDs to be deleted.
+     * @param namespace The namespace from which the vectors will be deleted.
+     * @return A generic type {@code X} indicating the result of the delete operation.
+     */
     X deleteByIds(List<String> ids, String namespace);
 
+    /**
+     * Deletes vectors matching a specific metadata filter criteria from the default namespace.
+     *
+     * @param filter The metadata filter used to select vectors to delete.
+     * @return A generic type {@code X} indicating the result of the delete operation.
+     */
     X deleteByFilter(Struct filter);
 
+    /**
+     * Deletes vectors matching a specific metadata filter criteria from a specified namespace.
+     *
+     * @param filter The metadata filter used to select vectors to delete.
+     * @param namespace The namespace from which the vectors matching the filter will be deleted.
+     * @return A generic type {@code X} indicating the result of the delete operation.
+     */
     X deleteByFilter(Struct filter, String namespace);
 
+    /**
+     * Deletes all vectors within a specified namespace. If {@code null} is passed, all vectors in the
+     * default namespace are deleted.
+     *
+     * @param namespace The namespace from which all vectors will be deleted. If not specified the default will be used.
+     * @return A generic type {@code X} indicating the result of the delete all operation.
+     */
     X deleteAll(String namespace);
 
+    /**
+     * A flexible delete operation allowing for the deletion of vectors by ID, by filter, or all vectors in a namespace.
+     *
+     * @param ids A list of unique identifiers for specific vectors to be deleted. Ignored if deleteAll is true.
+     * @param deleteAll A boolean flag indicating whether to delete all vectors in the specified namespace.
+     * @param namespace The namespace from which vectors will be deleted. If not specified, the default namespace is used.
+     * @param filter An optional Struct defining additional filtering criteria for vectors to be deleted. Ignored if deleteAll is true.
+     * @return A generic type {@code X} indicating the result of the delete operation.
+     */
     X delete(List<String> ids, boolean deleteAll, String namespace, Struct filter);
 
+    /**
+     * Retrieves statistics about the index's contents, such as vector count per namespace, and number of dimensions.
+     *
+     * @return A generic type {@code Y} that contains the stats about the index.
+     */
     Y describeIndexStats();
 
+    /**
+     * Retrieves statistics about the index's contents for vectors that satisfy the applied metadata filter.
+     * @param filter A metadata filter used to select vectors that satisfy the filter criteria.
+     * @return A generic type {@code Y} that contains the stats about the index.
+     */
     Y describeIndexStats(Struct filter);
 }

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -692,7 +692,7 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
 
     /**
      * Retrieves statistics about the index's contents for vectors that satisfy the applied metadata filter.
-     * 
+     *
      * @param filter A metadata filter used to select vectors that satisfy the filter criteria.
      * @return A generic type {@code Y} that contains the stats about the index.
      */


### PR DESCRIPTION
## Problem
The Java client is lacking docstrings and we're working on adding them.

`IndexInterface`, `Index`, and `AsyncIndex` all need javadoc docstrings with code examples.

## Solution
- Add docstrings to `IndexInterface` and the implementing classes: `Index` and `AsyncIndex`. The code examples are documented in the implementing classes and they inherit the root documentation from `IndexInterface`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Pull this branch down and run `gradle generateJavadoc` locally. Even with the errors and warnings you should still get the `/docs` output in the project folder. You can open this in your browser.

Make sure none of the errors or warnings have increased / we're not seeing any outside of the generated code package:
![Screenshot 2024-04-10 at 2 46 13 AM](https://github.com/pinecone-io/pinecone-java-client/assets/119623786/6a5a8c90-a133-4805-aea4-7bdba9e8116b)

