### PR TITLE
Add docstrings for configs

### DIFF
--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -2,10 +2,43 @@ package io.pinecone.configs;
 
 import io.grpc.ManagedChannel;
 import io.pinecone.exceptions.PineconeConfigurationException;
+
 /**
  * The {@link PineconeConfig} class is responsible for managing the configuration settings
  * required to interact with the Pinecone API. It provides methods to set and retrieve
  * the necessary API key, host, source tag, and custom managed channel.
+ * <pre>{@code
+ *
+ *     import io.grpc.ManagedChannel;
+ *     import io.grpc.netty.GrpcSslContexts;
+ *     import io.grpc.netty.NegotiationType;
+ *     import io.grpc.netty.NettyChannelBuilder;
+ *     import io.pinecone.configs.PineconeConfig;
+ *     import io.pinecone.exceptions.PineconeException;
+ *
+ *     import javax.net.ssl.SSLException;
+ *     import java.util.concurrent.TimeUnit;
+ * ...
+ *
+ *
+ *     PineconeConfig config = new PineconeConfig("apikey");
+ *     String endpoint = "some-endpoint";
+ *     NettyChannelBuilder builder = NettyChannelBuilder.forTarget(endpoint);
+ *
+ *     // Custom channel with timeouts
+ *     try {
+ *         builder = builder.overrideAuthority(endpoint)
+ *             .negotiationType(NegotiationType.TLS)
+ *             .keepAliveTimeout(5, TimeUnit.SECONDS)
+ *             .sslContext(GrpcSslContexts.forClient().build());
+ *     } catch (SSLException e) {
+ *         throw new PineconeException("SSL error opening gRPC channel", e);
+ *     }
+ *
+ *     // Build the managed channel with the configured options
+ *     ManagedChannel channel = builder.build();
+ *     config.setCustomManagedChannel(channel);
+ * }</pre>
  */
 public class PineconeConfig {
 
@@ -29,8 +62,8 @@ public class PineconeConfig {
     /**
      * Constructs a {@link PineconeConfig} instance with the specified API key and source tag.
      *
-     * @param apiKey      The API key required to authenticate with the Pinecone API.
-     * @param sourceTag   An optional source tag to be included in the user agent.
+     * @param apiKey    The API key required to authenticate with the Pinecone API.
+     * @param sourceTag An optional source tag to be included in the user agent.
      */
     public PineconeConfig(String apiKey, String sourceTag) {
         this.apiKey = apiKey;

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -110,6 +110,10 @@ public class PineconeConfig {
         this.customManagedChannel = customManagedChannel;
     }
 
+    public interface CustomChannelBuilder {
+        ManagedChannel buildChannel();
+    }
+
     /**
      * Validates the configuration, ensuring that the API key is not null or empty.
      *

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -2,69 +2,138 @@ package io.pinecone.configs;
 
 import io.grpc.ManagedChannel;
 import io.pinecone.exceptions.PineconeConfigurationException;
-import io.pinecone.exceptions.PineconeValidationException;
-
+/**
+ * The `PineconeConfig` class is responsible for managing the configuration settings
+ * required to interact with the Pinecone API. It provides methods to set and retrieve
+ * the necessary API key, host, source tag, and custom managed channel.
+ */
 public class PineconeConfig {
 
+    // Required field
     private String apiKey;
+
+    // Optional fields
     private String host;
     private String sourceTag;
     private ManagedChannel customManagedChannel;
 
+    /**
+     * Constructs a {@link PineconeConfig} instance with the specified API key.
+     *
+     * @param apiKey The API key required to authenticate with the Pinecone API.
+     */
     public PineconeConfig(String apiKey) {
         this(apiKey, null);
     }
 
+    /**
+     * Constructs a {@link PineconeConfig} instance with the specified API key and source tag.
+     *
+     * @param apiKey      The API key required to authenticate with the Pinecone API.
+     * @param sourceTag   An optional source tag to be included in the user agent.
+     */
     public PineconeConfig(String apiKey, String sourceTag) {
         this.apiKey = apiKey;
         this.sourceTag = sourceTag;
     }
 
+    /**
+     * Returns the API key.
+     *
+     * @return The API key.
+     */
     public String getApiKey() {
         return apiKey;
     }
 
+    /**
+     * Sets the API key.
+     *
+     * @param apiKey The new API key.
+     */
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
     }
 
+    /**
+     * Returns the host.
+     *
+     * @return The host.
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Sets the host.
+     *
+     * @param host The new host.
+     */
     public void setHost(String host) {
         this.host = host;
     }
 
+    /**
+     * Returns the source tag.
+     *
+     * @return The source tag.
+     */
     public String getSourceTag() {
         return sourceTag;
     }
 
+    /**
+     * Sets the source tag. The source tag is normalized before being stored.
+     *
+     * @param sourceTag The new source tag.
+     */
     public void setSourceTag(String sourceTag) {
         this.sourceTag = normalizeSourceTag(sourceTag);
     }
 
+    /**
+     * Returns the custom gRPC managed channel.
+     *
+     * @return The custom gRPC managed channel.
+     */
     public ManagedChannel getCustomManagedChannel() {
         return this.customManagedChannel;
     }
 
+    /**
+     * Sets the custom gRPC managed channel if the user is not interested in using default gRPC channel initialized
+     * and set in the Pinecone Builder class.
+     *
+     * @param customManagedChannel The new custom gRPC managed channel.
+     */
     public void setCustomManagedChannel(ManagedChannel customManagedChannel) {
         this.customManagedChannel = customManagedChannel;
     }
 
-    public interface CustomChannelBuilder {
-        ManagedChannel buildChannel();
-    }
-
+    /**
+     * Validates the configuration, ensuring that the API key is not null or empty.
+     *
+     * @throws PineconeConfigurationException if the API key is null or empty.
+     */
     public void validate() {
         if (apiKey == null || apiKey.isEmpty())
             throw new PineconeConfigurationException("The API key is required and must not be empty or null");
     }
 
+    /**
+     * Builds the user agent string for the Pinecone client.
+     *
+     * @return The user agent string.
+     */
     public String getUserAgent() {
         return buildUserAgent("pineconeClientVersion");
     }
 
+    /**
+     * Builds the user agent string for the Pinecone client's gRPC requests.
+     *
+     * @return The user agent string for gRPC requests.
+     */
     public String getUserAgentGrpc() {
         return buildUserAgent("pineconeClientVersion[grpc]");
     }

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -3,7 +3,7 @@ package io.pinecone.configs;
 import io.grpc.ManagedChannel;
 import io.pinecone.exceptions.PineconeConfigurationException;
 /**
- * The `PineconeConfig` class is responsible for managing the configuration settings
+ * The {@link PineconeConfig} class is responsible for managing the configuration settings
  * required to interact with the Pinecone API. It provides methods to set and retrieve
  * the necessary API key, host, source tag, and custom managed channel.
  */

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -18,6 +18,25 @@ import java.util.concurrent.TimeUnit;
 /**
  * The {@link PineconeConnection} class handles communication with a Pinecone service or router. One PineconeConnection
  * can be shared and used concurrently by multiple threads.
+ *  <pre>{@code
+ *
+ *  import io.pinecone.clients.AsyncIndex;
+ *  import io.pinecone.clients.Index;
+ *  import io.pinecone.configs.PineconeConnection;
+ *  ...
+ *
+ *  // Construct the connection object
+ *  PineconeConnection connection = new PineconeConnection(config);
+ *
+ *  // Construct the index object for synchronous data plane operations
+ *  Index index = new Index(connection, "example-index");
+ *  index.describeIndexStats();
+ *
+ *  // Construct the async index object for asynchronous data plane operations
+ *  AsyncIndex asyncIndex = new AsyncIndex(connection, "example-index");
+ *  asyncIndex.describeIndexStats();
+ *
+ *  }</pre>
  */
 public class PineconeConnection implements AutoCloseable {
 

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -16,7 +16,7 @@ import javax.net.ssl.SSLException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * The PineconeConnection class handles communication with a Pinecone service or router. One PineconeConnection
+ * The {@link PineconeConnection} class handles communication with a Pinecone service or router. One PineconeConnection
  * can be shared and used concurrently by multiple threads.
  */
 public class PineconeConnection implements AutoCloseable {

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -107,6 +107,7 @@ public class PineconeConnection implements AutoCloseable {
 
     /**
      * Return the gRPC stub used for sending requests to Pinecone.
+     * @return The blocking stub
      */
     public VectorServiceGrpc.VectorServiceBlockingStub getBlockingStub() {
         return blockingStub;
@@ -114,6 +115,7 @@ public class PineconeConnection implements AutoCloseable {
 
     /**
      * Return the gRPC async stub to allow clients to do ListenableFuture-style rpc calls to Pinecone.
+     * @return The async stub
      */
     public VectorServiceGrpc.VectorServiceFutureStub getAsyncStub() {
         return asyncStub;

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -106,14 +106,14 @@ public class PineconeConnection implements AutoCloseable {
     }
 
     /**
-     * Returns the gRPC stub used for sending requests to Pinecone.
+     * Return the gRPC stub used for sending requests to Pinecone.
      */
     public VectorServiceGrpc.VectorServiceBlockingStub getBlockingStub() {
         return blockingStub;
     }
 
     /**
-     * Get the gRPC async stub to allow clients to do ListenableFuture-style rpc calls to Pinecone.
+     * Return the gRPC async stub to allow clients to do ListenableFuture-style rpc calls to Pinecone.
      */
     public VectorServiceGrpc.VectorServiceFutureStub getAsyncStub() {
         return asyncStub;

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -16,8 +16,8 @@ import javax.net.ssl.SSLException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Handles communication with a Pinecone service or router. One PineconeConnection can be shared
- * and used concurrently by multiple threads.
+ * The PineconeConnection class handles communication with a Pinecone service or router. One PineconeConnection
+ * can be shared and used concurrently by multiple threads.
  */
 public class PineconeConnection implements AutoCloseable {
 
@@ -28,13 +28,24 @@ public class PineconeConnection implements AutoCloseable {
     final ManagedChannel channel;
 
     /**
-     * The gRPC stub used for sending requests to Pinecone. Blocks until response. Access to this
-     * field is not thread-safe; modifications should be synchronized by callers.
+     * The gRPC stub used for sending requests to Pinecone. Blocks until response.
      */
     private VectorServiceGrpc.VectorServiceBlockingStub blockingStub;
 
+    /**
+     * The gRPC async stub to allow clients to do ListenableFuture-style rpc calls to Pinecone.
+     */
     private VectorServiceGrpc.VectorServiceFutureStub asyncStub;
 
+    /**
+     * Constructs a {@link PineconeConnection} instance with the specified {@link PineconeConfig}.
+     * If a custom gRPC ManagedChannel is provided in the {@link PineconeConfig}, it will be used.
+     * Otherwise, a new gRPC ManagedChannel will be built using the host specified in the {@link PineconeConfig}.
+     * <p>
+     *
+     * @param config The {@link PineconeConfig} containing configuration settings for the PineconeConnection.
+     * @throws PineconeValidationException If index name or host is not provided for data plane operations.
+     */
     public PineconeConnection(PineconeConfig config) {
         this.config = config;
         if (config.getCustomManagedChannel() != null) {
@@ -87,14 +98,23 @@ public class PineconeConnection implements AutoCloseable {
         }
     }
 
+    /**
+     * Returns the gRPC channel.
+     */
     public ManagedChannel getChannel() {
         return channel;
     }
 
+    /**
+     * Returns the gRPC stub used for sending requests to Pinecone.
+     */
     public VectorServiceGrpc.VectorServiceBlockingStub getBlockingStub() {
         return blockingStub;
     }
 
+    /**
+     * Get the gRPC async stub to allow clients to do ListenableFuture-style rpc calls to Pinecone.
+     */
     public VectorServiceGrpc.VectorServiceFutureStub getAsyncStub() {
         return asyncStub;
     }


### PR DESCRIPTION
## Problem

Docstrings for configs are missing.

## Solution

Added docstrings for PineconeConnection and PineconeConfig classes. PineconeConnection is mainly expected to be used by users if they are trying to set the custom gRPC channels.

## Type of Change

- [X] Non-code change (docs, etc)

## Test Plan
NA

