### PR TITLE
Add list endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,24 @@ List<String> ids = Arrays.asList("v1", "v2", "v3");
 FetchResponse fetchResponse = index.fetch(ids, "example-namespace");
 ```
 
+## List vector IDs by Namespace
+The following example lists up to 100 vector IDs from a particular namespace.
+
+This method accepts optional parameters for `prefix` (list IDs filtered by a prefix), `limit` (retrieve `n` vector 
+IDs), and `paginationToken` (retrieve the next set of vector IDs).
+
+```java
+import io.pinecone.clients.Index;
+import io.pinecone.clients.Pinecone;
+import io.pinecone.proto.ListResponse;
+
+Pinecone pinecone = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+String indexName = "example-index";
+Index index = pinecone.getIndexConnection(indexName);
+ListResponse listResponse = index.list("example-namespace");
+```
+
+
 ## Update vectors
 
 The following example updates vectors by ID.

--- a/README.md
+++ b/README.md
@@ -327,11 +327,13 @@ List<String> ids = Arrays.asList("v1", "v2", "v3");
 FetchResponse fetchResponse = index.fetch(ids, "example-namespace");
 ```
 
-## List vector IDs by Namespace
-The following example lists up to 100 vector IDs from a particular namespace.
+## List vector IDs
+The following example lists up to 100 vector IDs from a Pinecone index.
 
-This method accepts optional parameters for `prefix` (list IDs filtered by a prefix), `limit` (retrieve `n` vector 
-IDs), and `paginationToken` (retrieve the next set of vector IDs).
+This method accepts optional parameters for `namespace`, `prefix`, `limit`, and `paginationToken`. 
+
+The following 
+demonstrates how to use the `list` endpoint to get vector IDs from a specific `namespace`, filtered by a given `prefix`.
 
 ```java
 import io.pinecone.clients.Index;
@@ -341,7 +343,7 @@ import io.pinecone.proto.ListResponse;
 Pinecone pinecone = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
 String indexName = "example-index";
 Index index = pinecone.getIndexConnection(indexName);
-ListResponse listResponse = index.list("example-namespace");
+ListResponse listResponse = index.list("example-namespace", "prefix-");
 ```
 
 

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -81,8 +81,13 @@ public class TestIndexResourcesManager {
         return dimension;
     }
 
+
     public String getEnvironment() {
         return environment;
+    }
+
+    public String getNamespace() {
+        return this.namespace;
     }
 
     public List<String> getVectorIds() {
@@ -104,9 +109,6 @@ public class TestIndexResourcesManager {
         return collectionModel;
     }
 
-    public String getNamespace() {
-        return this.namespace;
-    }
 
     public void cleanupResources() {
         if (podIndexName != null) {

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -147,7 +147,7 @@ public class TestIndexResourcesManager {
         Thread.sleep(30000);
 
         // Seed default vector IDs into default namespace
-        seedDefaultNamespace(indexName);
+        seedIndex(vectorIdsForDefaultNamespace, indexName, defaultNamespace);
 
         this.podIndexName = indexName;
         return indexName;
@@ -169,8 +169,8 @@ public class TestIndexResourcesManager {
 
         // Seed default vector IDs into default namespace, seed custom vector IDs into custom namespace; all in
         // same index
-        seedDefaultNamespace(indexName);
-        seedCustomNamespace(indexName);
+        seedIndex(vectorIdsForDefaultNamespace, indexName, defaultNamespace);
+        seedIndex(vectorIdsForCustomNamespace, indexName, customNamespace);
 
         this.serverlessIndexName = indexName;
         return indexName;
@@ -207,37 +207,13 @@ public class TestIndexResourcesManager {
         return collectionName;
     }
 
-    private void seedDefaultNamespace(String indexName) throws InterruptedException {
+    private void seedIndex(List<String> vectorIds, String indexName, String namespace) throws InterruptedException {
         // Build upsert request
         Index indexClient = pineconeClient.getIndexConnection(indexName);
-
-        // Upsert vectors into both default namespace
-        indexClient.upsert(buildRequiredUpsertRequestByDimension(vectorIdsForDefaultNamespace, dimension), defaultNamespace);
+        indexClient.upsert(buildRequiredUpsertRequestByDimension(vectorIds, dimension), namespace);
 
         // Wait for record freshness
         DescribeIndexStatsResponse indexStats = indexClient.describeIndexStats();
-
-        int totalTimeWaitedForVectors = 0;
-        while (indexStats.getTotalVectorCount() == 0 || totalTimeWaitedForVectors <= 60000) {
-            Thread.sleep(2000);
-            totalTimeWaitedForVectors += 2000;
-            indexStats = indexClient.describeIndexStats();
-        }
-        if (indexStats.getTotalVectorCount() == 0 && totalTimeWaitedForVectors >= 60000) {
-            throw new PineconeException("Failed to seed index " + indexName + "with vectors");
-        }
-    }
-
-    private void seedCustomNamespace(String indexName) throws InterruptedException {
-        // Build upsert request
-        Index indexClient = pineconeClient.getIndexConnection(indexName);
-
-        // Upsert vectors into both custom namespace
-        indexClient.upsert(buildRequiredUpsertRequestByDimension(vectorIdsForCustomNamespace, dimension), customNamespace);
-
-        // Wait for record freshness
-        DescribeIndexStatsResponse indexStats = indexClient.describeIndexStats();
-
         int totalTimeWaitedForVectors = 0;
         while (indexStats.getTotalVectorCount() == 0 || totalTimeWaitedForVectors <= 60000) {
             Thread.sleep(2000);

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -43,7 +43,8 @@ public class TestIndexResourcesManager {
     private String collectionName;
     private CollectionModel collectionModel;
     private final List<String> vectorIds = Arrays.asList("id1", "id2", "prefix-id3");
-    private final String namespace = "example-namespace";
+    private final String customNamespace = "example-namespace";
+    private final String defaultNamespace = "";
 
 
     private TestIndexResourcesManager() {
@@ -86,8 +87,12 @@ public class TestIndexResourcesManager {
         return environment;
     }
 
-    public String getNamespace() {
-        return this.namespace;
+    public String getCustomNamespace() {
+        return this.customNamespace;
+    }
+
+    public String getDefaultNamespace() {
+        return this.defaultNamespace;
     }
 
     public List<String> getVectorIds() {
@@ -199,7 +204,12 @@ public class TestIndexResourcesManager {
     private void seedIndex(List<String> vectorIds, String indexName) throws InterruptedException {
         // Build upsert request
         Index indexClient = pineconeClient.getIndexConnection(indexName);
-        indexClient.upsert(buildRequiredUpsertRequestByDimension(vectorIds, dimension), namespace);
+
+        // Upsert vectors into both custom and default namespaces
+        List<String> namespaces = Arrays.asList(customNamespace, defaultNamespace);
+        for (String namespace : namespaces) {
+            indexClient.upsert(buildRequiredUpsertRequestByDimension(vectorIds, dimension), namespace);
+        }
 
         // Wait for record freshness
         DescribeIndexStatsResponse indexStats = indexClient.describeIndexStats();

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -20,9 +20,8 @@ public class TestIndexResourcesManager {
     private static final Logger logger = LoggerFactory.getLogger(IndexManager.class);
     private static TestIndexResourcesManager instance;
     private static final String apiKey = System.getenv("PINECONE_API_KEY");
-
     private final int dimension = System.getenv("DIMENSION") == null
-            ? 3
+            ? 4
             : Integer.parseInt(System.getenv("DIMENSION"));
     private final String environment = System.getenv("PINECONE_ENVIRONMENT") == null
             ? "us-east4-gcp"
@@ -40,16 +39,15 @@ public class TestIndexResourcesManager {
     private String podIndexName;
     private IndexModel podIndexModel;
     private IndexModel serverlessIndexModel;
-    private  String serverlessIndexName;
+    private String serverlessIndexName;
     private String collectionName;
     private CollectionModel collectionModel;
-    private final List<String> vectorIds = Arrays.asList("id1", "id2", "cidddd3");
+    private final List<String> vectorIds = Arrays.asList("id1", "id2", "prefix-id3");
     private final String namespace = "example-namespace";
 
 
     private TestIndexResourcesManager() {
         pineconeClient = new Pinecone.Builder(apiKey).build();
-
     }
 
     public static TestIndexResourcesManager getInstance() {

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -104,6 +104,10 @@ public class TestIndexResourcesManager {
         return collectionModel;
     }
 
+    public String getNamespace() {
+        return this.namespace;
+    }
+
     public void cleanupResources() {
         if (podIndexName != null) {
             pineconeClient.deleteIndex(podIndexName);

--- a/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestIndexResourcesManager.java
@@ -1,5 +1,6 @@
 package io.pinecone.helpers;
 
+import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.exceptions.PineconeException;
@@ -19,6 +20,7 @@ public class TestIndexResourcesManager {
     private static final Logger logger = LoggerFactory.getLogger(IndexManager.class);
     private static TestIndexResourcesManager instance;
     private static final String apiKey = System.getenv("PINECONE_API_KEY");
+
     private final int dimension = System.getenv("DIMENSION") == null
             ? 3
             : Integer.parseInt(System.getenv("DIMENSION"));
@@ -57,8 +59,12 @@ public class TestIndexResourcesManager {
         return instance;
     }
 
-    public  Index getIndexConnection() {
+    public  Index getServerlessIndexConnection() {
         return this.getInstance().pineconeClient.getIndexConnection(this.serverlessIndexName);
+    }
+
+    public AsyncIndex getServerlessAsyncIndexConnection() {
+        return this.getInstance().pineconeClient.getAsyncIndexConnection(this.serverlessIndexName);
     }
 
     public String getPodIndexName() throws InterruptedException, PineconeException {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -35,12 +35,14 @@ public class CollectionTest {
     private static CollectionModel collection;
     private static String indexName;
     private static String collectionName;
+    private static String namespace;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
         indexName = indexManager.getPodIndexName();
         collectionName = indexManager.getCollectionName();
         collection = indexManager.getCollectionModel();
+        namespace = indexManager.getNamespace();
     }
 
     @AfterAll
@@ -110,7 +112,7 @@ public class CollectionTest {
                 assertEquals(describeResponse.getTotalVectorCount(), 3);
 
                 // Verify the vectors from the collection -> new index can be fetched
-                FetchResponse fetchedVectors = indexClient.fetch(upsertIds, "example-namespace");
+                FetchResponse fetchedVectors = indexClient.fetch(upsertIds, namespace);
                 for (String key : upsertIds) {
                     assertTrue(fetchedVectors.containsVectors(key));
                 }

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -110,7 +110,7 @@ public class CollectionTest {
                 assertEquals(describeResponse.getTotalVectorCount(), 3);
 
                 // Verify the vectors from the collection -> new index can be fetched
-                FetchResponse fetchedVectors = indexClient.fetch(upsertIds, "");
+                FetchResponse fetchedVectors = indexClient.fetch(upsertIds, "example-namespace");
                 for (String key : upsertIds) {
                     assertTrue(fetchedVectors.containsVectors(key));
                 }

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -29,7 +29,7 @@ public class CollectionTest {
     private static final Logger logger = LoggerFactory.getLogger(CollectionTest.class);
     private static final ArrayList<String> indexesToCleanUp = new ArrayList<>();
     private static final String indexMetric = IndexMetric.COSINE.toString();
-    private static final List<String> upsertIds = indexManager.getVectorIds();
+    private static final List<String> upsertIds = indexManager.getVectorIdsFromDefaultNamespace();
     private static final String environment = indexManager.getEnvironment();
     private static final int dimension = indexManager.getDimension();
     private static CollectionModel collection;
@@ -79,7 +79,7 @@ public class CollectionTest {
 
         assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
         assertEquals(collection.getDimension(), dimension);
-        assertEquals(collection.getVectorCount(), 6);
+        assertEquals(collection.getVectorCount(), 8);
         assertNotEquals(collection.getVectorCount(), null);
         assertTrue(collection.getSize() > 0);
 
@@ -109,7 +109,7 @@ public class CollectionTest {
                 DescribeIndexStatsResponse describeResponse = indexClient.describeIndexStats();
 
                 // Verify stats reflect the vectors in the collection
-                assertEquals(describeResponse.getTotalVectorCount(), 6);
+                assertEquals(describeResponse.getTotalVectorCount(), 8);
 
                 // Verify the vectors from the collection -> new index can be fetched
                 FetchResponse fetchedVectors = indexClient.fetch(upsertIds, namespace);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -29,7 +29,7 @@ public class CollectionTest {
     private static final Logger logger = LoggerFactory.getLogger(CollectionTest.class);
     private static final ArrayList<String> indexesToCleanUp = new ArrayList<>();
     private static final String indexMetric = IndexMetric.COSINE.toString();
-    private static final List<String> upsertIds = indexManager.getPodIndexVectorIds();
+    private static final List<String> upsertIds = indexManager.getVectorIds();
     private static final String environment = indexManager.getEnvironment();
     private static final int dimension = indexManager.getDimension();
     private static CollectionModel collection;

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -42,7 +42,7 @@ public class CollectionTest {
         indexName = indexManager.getPodIndexName();
         collectionName = indexManager.getCollectionName();
         collection = indexManager.getCollectionModel();
-        namespace = indexManager.getNamespace();
+        namespace = indexManager.getCustomNamespace();
     }
 
     @AfterAll
@@ -79,7 +79,7 @@ public class CollectionTest {
 
         assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
         assertEquals(collection.getDimension(), dimension);
-        assertEquals(collection.getVectorCount(), 3);
+        assertEquals(collection.getVectorCount(), 6);
         assertNotEquals(collection.getVectorCount(), null);
         assertTrue(collection.getSize() > 0);
 
@@ -109,7 +109,7 @@ public class CollectionTest {
                 DescribeIndexStatsResponse describeResponse = indexClient.describeIndexStats();
 
                 // Verify stats reflect the vectors in the collection
-                assertEquals(describeResponse.getTotalVectorCount(), 3);
+                assertEquals(describeResponse.getTotalVectorCount(), 6);
 
                 // Verify the vectors from the collection -> new index can be fetched
                 FetchResponse fetchedVectors = indexClient.fetch(upsertIds, namespace);

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -42,7 +42,7 @@ public class CollectionTest {
         indexName = indexManager.getPodIndexName();
         collectionName = indexManager.getCollectionName();
         collection = indexManager.getCollectionModel();
-        namespace = indexManager.getCustomNamespace();
+        namespace = indexManager.getDefaultNamespace();
     }
 
     @AfterAll
@@ -79,7 +79,7 @@ public class CollectionTest {
 
         assertEquals(collection.getStatus(), CollectionModel.StatusEnum.READY);
         assertEquals(collection.getDimension(), dimension);
-        assertEquals(collection.getVectorCount(), 8);
+        assertEquals(collection.getVectorCount(), 4);
         assertNotEquals(collection.getVectorCount(), null);
         assertTrue(collection.getSize() > 0);
 
@@ -109,7 +109,7 @@ public class CollectionTest {
                 DescribeIndexStatsResponse describeResponse = indexClient.describeIndexStats();
 
                 // Verify stats reflect the vectors in the collection
-                assertEquals(describeResponse.getTotalVectorCount(), 8);
+                assertEquals(describeResponse.getTotalVectorCount(), 4);
 
                 // Verify the vectors from the collection -> new index can be fetched
                 FetchResponse fetchedVectors = indexClient.fetch(upsertIds, namespace);

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -1,9 +1,12 @@
 package io.pinecone.integration.dataPlane;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.TestIndexResourcesManager;
+import io.pinecone.proto.ListResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -14,28 +17,29 @@ public class ListEndpointTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static String indexName ;
     private static Index indexConnection;
+    private static AsyncIndex asyncIndexConnection;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
         indexName = indexManager.getServerlessIndexName();
-        indexConnection = indexManager.getIndexConnection();
-//        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
+        indexConnection = indexManager.getServerlessIndexConnection();
+        asyncIndexConnection = indexManager.getServerlessAsyncIndexConnection();
     }
 
     @AfterAll
     public static void cleanUp() {
         String apiKey = System.getenv("PINECONE_API_KEY");
         Pinecone pinecone = new Pinecone.Builder(apiKey).build();
-
         pinecone.deleteIndex(indexName);
         indexConnection.close();
-//        asyncIndex.close();
+        asyncIndexConnection.close();
     }
 
     @Test
     public void testListEndpoint() throws InterruptedException {
         Thread.sleep(10000); // wait for the index to be ready for operations
 
+        // Sync
         String listResponse = indexConnection.list("example-namespace").toString();
         assertTrue(listResponse.contains("id1"));
         assertTrue(listResponse.contains("id2"));
@@ -50,6 +54,25 @@ public class ListEndpointTest {
         assertTrue(listResponseWithLimit.contains("cidddd3")); // (IDs returned in LIFO order)
         assertFalse(listResponseWithLimit.contains("id2")); // should not be in response
         assertFalse(listResponseWithLimit.contains("id1")); // should not be in response
+
+        //Async
+        ListenableFuture<ListResponse> futureResponse = asyncIndexConnection.list("example-namespace");
+        ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+        assertTrue(asyncListResponse.toString().contains("id1"));
+        assertTrue(asyncListResponse.toString().contains("id2"));
+        assertTrue(asyncListResponse.toString().contains("cidddd3"));
+
+        ListenableFuture<ListResponse> futureResponseWithPrefix = asyncIndexConnection.list("example-namespace", "i");
+        ListResponse asyncListResponseWithPrefix = Futures.getUnchecked(futureResponseWithPrefix);
+        assertTrue(asyncListResponseWithPrefix.toString().contains("id1"));
+        assertTrue(asyncListResponseWithPrefix.toString().contains("id2"));
+        assertFalse(asyncListResponseWithPrefix.toString().contains("cidddd3"));
+
+        ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list("example-namespace", 1);
+        ListResponse asyncListResponseWithLimit = Futures.getUnchecked(futureResponseWithLimit);
+        assertTrue(asyncListResponseWithLimit.toString().contains("cidddd3"));
+        assertFalse(asyncListResponseWithLimit.toString().contains("id2"));
+        assertFalse(asyncListResponseWithLimit.toString().contains("id1"));
     }
 
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -3,65 +3,32 @@ package io.pinecone.integration.dataPlane;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.clients.Pinecone;
-import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+import io.pinecone.helpers.TestIndexResourcesManager;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openapitools.client.model.IndexModelSpec;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
-import static io.pinecone.helpers.IndexManager.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ListEndpointTest {
-    private static Index index;
-    private static AsyncIndex asyncIndex;
+    private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
+    private static String indexName ;
+    private static Index indexConnection;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        int dimension = 3;
-        String apiKey = System.getenv("PINECONE_API_KEY");
-        String indexType = IndexModelSpec.SERIALIZED_NAME_SERVERLESS;
-        Pinecone pinecone = new Pinecone.Builder(apiKey).build();
-
-        String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
-        if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
-        index = pinecone.getIndexConnection(indexName);
-        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
-
-        List<String> upsertIds = Arrays.asList("v1", "v2", "c3");
-
-        List<List<Float>> values = new ArrayList<>();
-        values.add(Arrays.asList(1.0f, 2.0f, 3.0f));
-        values.add(Arrays.asList(4.0f, 5.0f, 6.0f));
-        values.add(Arrays.asList(7.0f, 8.0f, 9.0f));
-
-        List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
-        for (int i=0; i<upsertIds.size(); i++) {
-            VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(upsertIds.get(i), values.get(i), null, null, null);
-            vectors.add(vector);
-        }
-
-        // Upsert data
-        index.upsert(vectors, "example-namespace");
-
+        indexName = indexManager.getServerlessIndexName();
+        indexConnection = indexManager.getIndexConnection();
 //        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
     }
 
     @AfterAll
     public static void cleanUp() {
         String apiKey = System.getenv("PINECONE_API_KEY");
-        String indexType = IndexModelSpec.SERIALIZED_NAME_SERVERLESS;
         Pinecone pinecone = new Pinecone.Builder(apiKey).build();
-        String indexName = findIndexWithDimensionAndType(pinecone, 3, indexType);
 
         pinecone.deleteIndex(indexName);
-
-        index.close();
+        indexConnection.close();
 //        asyncIndex.close();
     }
 
@@ -69,23 +36,20 @@ public class ListEndpointTest {
     public void testListEndpoint() throws InterruptedException {
         Thread.sleep(10000); // wait for the index to be ready for operations
 
-        String listResponse = index.list("example-namespace").toString();
-        assertTrue(listResponse.contains("v1"));
-        assertTrue(listResponse.contains("v2"));
-        assertTrue(listResponse.contains("c3"));
+        String listResponse = indexConnection.list("example-namespace").toString();
+        assertTrue(listResponse.contains("id1"));
+        assertTrue(listResponse.contains("id2"));
+        assertTrue(listResponse.contains("cidddd3"));
 
-        String listResponseWithPrefix = index.list("example-namespace", "v").toString();
-        assertTrue(listResponseWithPrefix.contains("v1"));
-        assertTrue(listResponseWithPrefix.contains("v2"));
-        assertFalse(listResponseWithPrefix.contains("c3")); // should not be in response
+        String listResponseWithPrefix = indexConnection.list("example-namespace", "i").toString();
+        assertTrue(listResponseWithPrefix.contains("id1"));
+        assertTrue(listResponseWithPrefix.contains("id2"));
+        assertFalse(listResponseWithPrefix.contains("cidddd3")); // should not be in response
 
-        String listResponseWithLimit = index.list("example-namespace", 1).toString();
-        assertTrue(listResponseWithLimit.contains("v1"));
-        assertFalse(listResponseWithLimit.contains("v2")); // should not be in response
-        assertFalse(listResponseWithLimit.contains("c3")); // should not be in response
+        String listResponseWithLimit = indexConnection.list("example-namespace", 1).toString();
+        assertTrue(listResponseWithLimit.contains("cidddd3")); // (IDs returned in LIFO order)
+        assertFalse(listResponseWithLimit.contains("id2")); // should not be in response
+        assertFalse(listResponseWithLimit.contains("id1")); // should not be in response
     }
-
-
-
 
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -1,0 +1,91 @@
+package io.pinecone.integration.dataPlane;
+
+import io.pinecone.clients.AsyncIndex;
+import io.pinecone.clients.Index;
+import io.pinecone.clients.Pinecone;
+import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openapitools.client.model.IndexModelSpec;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices;
+import static io.pinecone.helpers.IndexManager.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ListEndpointTest {
+    private static Index index;
+    private static AsyncIndex asyncIndex;
+
+    @BeforeAll
+    public static void setUp() throws InterruptedException {
+        int dimension = 3;
+        String apiKey = System.getenv("PINECONE_API_KEY");
+        String indexType = IndexModelSpec.SERIALIZED_NAME_SERVERLESS;
+        Pinecone pinecone = new Pinecone.Builder(apiKey).build();
+
+        String indexName = findIndexWithDimensionAndType(pinecone, dimension, indexType);
+        if (indexName.isEmpty()) indexName = createNewIndex(pinecone, dimension, indexType, true);
+        index = pinecone.getIndexConnection(indexName);
+        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
+
+        List<String> upsertIds = Arrays.asList("v1", "v2", "c3");
+
+        List<List<Float>> values = new ArrayList<>();
+        values.add(Arrays.asList(1.0f, 2.0f, 3.0f));
+        values.add(Arrays.asList(4.0f, 5.0f, 6.0f));
+        values.add(Arrays.asList(7.0f, 8.0f, 9.0f));
+
+        List<VectorWithUnsignedIndices> vectors = new ArrayList<>(3);
+        for (int i=0; i<upsertIds.size(); i++) {
+            VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(upsertIds.get(i), values.get(i), null, null, null);
+            vectors.add(vector);
+        }
+
+        // Upsert data
+        index.upsert(vectors, "example-namespace");
+
+//        asyncIndex = pinecone.getAsyncIndexConnection(indexName);
+    }
+
+    @AfterAll
+    public static void cleanUp() {
+        String apiKey = System.getenv("PINECONE_API_KEY");
+        String indexType = IndexModelSpec.SERIALIZED_NAME_SERVERLESS;
+        Pinecone pinecone = new Pinecone.Builder(apiKey).build();
+        String indexName = findIndexWithDimensionAndType(pinecone, 3, indexType);
+
+        pinecone.deleteIndex(indexName);
+
+        index.close();
+//        asyncIndex.close();
+    }
+
+    @Test
+    public void testListEndpoint() throws InterruptedException {
+        Thread.sleep(10000); // wait for the index to be ready for operations
+
+        String listResponse = index.list("example-namespace").toString();
+        assertTrue(listResponse.contains("v1"));
+        assertTrue(listResponse.contains("v2"));
+        assertTrue(listResponse.contains("c3"));
+
+        String listResponseWithPrefix = index.list("example-namespace", "v").toString();
+        assertTrue(listResponseWithPrefix.contains("v1"));
+        assertTrue(listResponseWithPrefix.contains("v2"));
+        assertFalse(listResponseWithPrefix.contains("c3")); // should not be in response
+
+        String listResponseWithLimit = index.list("example-namespace", 1).toString();
+        assertTrue(listResponseWithLimit.contains("v1"));
+        assertFalse(listResponseWithLimit.contains("v2")); // should not be in response
+        assertFalse(listResponseWithLimit.contains("c3")); // should not be in response
+    }
+
+
+
+
+}

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -10,19 +10,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
+
 
 public class ListEndpointTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static Index indexConnection;
     private static AsyncIndex asyncIndexConnection;
     private static String customNamespace;
-    private static List<String> defaultVectorIDs;
-    private static List<String> customVectorIDs;
-    private static List<String> allVectorIds;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
@@ -30,13 +25,6 @@ public class ListEndpointTest {
         indexConnection = indexManager.getServerlessIndexConnection();
         asyncIndexConnection = indexManager.getServerlessAsyncIndexConnection();
         customNamespace = indexManager.getCustomNamespace();
-
-        // Grab IDs for testing
-        defaultVectorIDs = indexManager.getVectorIdsFromDefaultNamespace();
-        customVectorIDs = indexManager.getVectorIdsFromCustomNamespace();
-        allVectorIds = new ArrayList<>();
-        allVectorIds.addAll(customVectorIDs);
-        allVectorIds.addAll(defaultVectorIDs);
     }
 
     @AfterAll
@@ -49,36 +37,27 @@ public class ListEndpointTest {
     public void testSyncListEndpoint() throws InterruptedException {
         // Confirm default vector IDs are returned when no namespace is specified
         ListResponse listResponseNoArgs = indexConnection.list();
-
-        assertEquals(listResponseNoArgs.getVectorsList().size(), defaultVectorIDs.size());
-
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains(defaultVectorIDs.get(0)));
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains(defaultVectorIDs.get(1)));
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains(defaultVectorIDs.get(2)));
+        assertEquals(listResponseNoArgs.getVectorsList().size(), 4);
+        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-id1"));
+        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-id2"));
+        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-prefix-id3"));
+        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-prefix-id4"));
 
         // Confirm all vector IDs from custom namespace are returned when pass customNamespace
         ListResponse listResponseCustomNamespace = indexConnection.list(customNamespace);
-
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains(customVectorIDs.get(0)));
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains(customVectorIDs.get(1)));
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains(customVectorIDs.get(2)));
+        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-id1"));
+        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-id2"));
+        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id4"));
 
         // Confirm all vector IDs from custom namespace are returned, filtered by given prefix
         ListResponse listResponseCustomNamespaceWithPrefix = indexConnection.list(customNamespace, "cus-prefix-");
-        List<String> filteredCustomVectorIDs = new ArrayList<>();
-        for (String vectorID : customVectorIDs) {
-            if (vectorID.startsWith("cus-prefix-")) {
-                filteredCustomVectorIDs.add(vectorID);
-            }
-        }
-        assertEquals(listResponseCustomNamespaceWithPrefix.getVectorsList().size(), filteredCustomVectorIDs.size());
-
-        assertTrue(listResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains(customVectorIDs.get(2)));
-        assertTrue(listResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains(customVectorIDs.get(3)));
+        assertEquals(listResponseCustomNamespaceWithPrefix.getVectorsList().size(), 2);
+        assertTrue(listResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(listResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id4"));
 
         // Confirm all vector IDs from custom namespace are returned when limit is specified
         ListResponse listResponseWithLimit = indexConnection.list(customNamespace, 1);
-
         assertEquals(1, listResponseWithLimit.getVectorsList().size());
     }
 
@@ -87,41 +66,31 @@ public class ListEndpointTest {
         // Confirm default vector IDs are returned when no namespace is specified
         ListenableFuture<ListResponse> futureResponseNoArgs = asyncIndexConnection.list();
         ListResponse asyncListResponseNoArgs = Futures.getUnchecked(futureResponseNoArgs);
-
-        assertEquals(asyncListResponseNoArgs.getVectorsList().size(), defaultVectorIDs.size());
-
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains(defaultVectorIDs.get(0)));
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains(defaultVectorIDs.get(1)));
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains(defaultVectorIDs.get(2)));
+        assertEquals(asyncListResponseNoArgs.getVectorsList().size(), 4);
+        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-id1"));
+        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-id2"));
+        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-prefix-id3"));
+        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-prefix-id4"));
 
         // Confirm all vector IDs from custom namespace are returned when pass customNamespace
         ListenableFuture<ListResponse> futureResponseCustomNamespace = asyncIndexConnection.list(customNamespace);
         ListResponse asyncListResponseCustomNamespace = Futures.getUnchecked(futureResponseCustomNamespace);
-
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains(customVectorIDs.get(0)));
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains(customVectorIDs.get(1)));
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains(customVectorIDs.get(2)));
+        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-id1"));
+        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-id2"));
+        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id4"));
 
         // Confirm all vector IDs from custom namespace are returned, filtered by given prefix
         ListenableFuture<ListResponse> futureResponseCustomNamespaceWithPrefix =
                 asyncIndexConnection.list(customNamespace, "cus-prefix-");
         ListResponse asyncListResponseCustomNamespaceWithPrefix = Futures.getUnchecked(futureResponseCustomNamespaceWithPrefix);
-
-        List<String> filteredCustomVectorIDs = new ArrayList<>();
-        for (String vectorID : customVectorIDs) {
-            if (vectorID.startsWith("cus-prefix-")) {
-                filteredCustomVectorIDs.add(vectorID);
-            }
-        }
-        assertEquals(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().size(), filteredCustomVectorIDs.size());
-
-        assertTrue(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains(customVectorIDs.get(2)));
-        assertTrue(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains(customVectorIDs.get(3)));
+        assertEquals(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().size(), 2);
+        assertTrue(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id4"));
 
         // Confirm all vector IDs from custom namespace are returned when limit is specified
         ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list(customNamespace, 1);
         ListResponse asyncListResponseWithLimit = Futures.getUnchecked(futureResponseWithLimit);
-
         assertEquals(1, asyncListResponseWithLimit.getVectorsList().size());
     }
 

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -16,12 +16,16 @@ public class ListEndpointTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
     private static Index indexConnection;
     private static AsyncIndex asyncIndexConnection;
+    private static String customNamespace;
+    private static String defaultNamespace;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexManager.getServerlessIndexName(); // create serverless index
+        indexManager.getServerlessIndexName(); // creates serverless index
         indexConnection = indexManager.getServerlessIndexConnection();
         asyncIndexConnection = indexManager.getServerlessAsyncIndexConnection();
+        customNamespace = indexManager.getCustomNamespace();
+        defaultNamespace = indexManager.getDefaultNamespace();
     }
 
     @AfterAll
@@ -32,41 +36,56 @@ public class ListEndpointTest {
 
     @Test
     public void testSyncListEndpoint() throws InterruptedException {
+        // Confirm all vector IDs from index are returned when do not pass namespace
+        String listResponseNoArgs = indexConnection.list().toString();
+        assertTrue(listResponseNoArgs.contains("id1"));
+        assertTrue(listResponseNoArgs.contains("id2"));
+        assertTrue(listResponseNoArgs.contains("prefix-id3"));
+        assertEquals(defaultNamespace, indexConnection.list().getNamespace()); // namespace should be defaultNamespace
+
         // Confirm all vector IDs from namespace are returned
-        String listResponse = indexConnection.list("example-namespace").toString();
+        String listResponse = indexConnection.list(customNamespace).toString();
         assertTrue(listResponse.contains("id1"));
         assertTrue(listResponse.contains("id2"));
         assertTrue(listResponse.contains("prefix-id3"));
 
         // Confirm all vector IDs from namespace are returned
-        String listResponseWithPrefix = indexConnection.list("example-namespace", "i").toString();
+        String listResponseWithPrefix = indexConnection.list(customNamespace, "i").toString();
         assertTrue(listResponseWithPrefix.contains("id1"));
         assertTrue(listResponseWithPrefix.contains("id2"));
         assertFalse(listResponseWithPrefix.contains("prefix-id3")); // should not be in response
 
         // Confirm all vector IDs from namespace are returned, with a limit of 1
-        ListResponse listResponseWithLimit = indexConnection.list("example-namespace", 1);
+        ListResponse listResponseWithLimit = indexConnection.list(customNamespace, 1);
         assertEquals(1, listResponseWithLimit.getVectorsList().size());
     }
 
     @Test
     public void testAsyncListEndpoint() throws InterruptedException {
+        // Confirm all vector IDs from index are returned when do not pass namespace
+        ListenableFuture<ListResponse> futureResponseNoArgs = asyncIndexConnection.list();
+        ListResponse asyncListResponseNoArgs = Futures.getUnchecked(futureResponseNoArgs);
+        assertTrue(asyncListResponseNoArgs.toString().contains("id1"));
+        assertTrue(asyncListResponseNoArgs.toString().contains("id2"));
+        assertTrue(asyncListResponseNoArgs.toString().contains("prefix-id3"));
+        assertEquals(defaultNamespace, asyncListResponseNoArgs.getNamespace()); // namespace should be defaultNamespace
+
         // Confirm all vector IDs from namespace are returned
-        ListenableFuture<ListResponse> futureResponse = asyncIndexConnection.list("example-namespace");
+        ListenableFuture<ListResponse> futureResponse = asyncIndexConnection.list(customNamespace);
         ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
         assertTrue(asyncListResponse.toString().contains("id1"));
         assertTrue(asyncListResponse.toString().contains("id2"));
         assertTrue(asyncListResponse.toString().contains("prefix-id3"));
 
         // Confirm all vector IDs from namespace are returned, filtered by given prefix
-        ListenableFuture<ListResponse> futureResponseWithPrefix = asyncIndexConnection.list("example-namespace", "i");
+        ListenableFuture<ListResponse> futureResponseWithPrefix = asyncIndexConnection.list(customNamespace, "i");
         ListResponse asyncListResponseWithPrefix = Futures.getUnchecked(futureResponseWithPrefix);
         assertTrue(asyncListResponseWithPrefix.toString().contains("id1"));
         assertTrue(asyncListResponseWithPrefix.toString().contains("id2"));
         assertFalse(asyncListResponseWithPrefix.toString().contains("prefix-id3"));
 
         // Confirm all vector IDs from namespace are returned, with a limit of 1
-        ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list("example-namespace", 1);
+        ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list(customNamespace, 1);
         ListResponse asyncListResponseWithLimit = Futures.getUnchecked(futureResponseWithLimit);
         assertEquals(1, asyncListResponseWithLimit.getVectorsList().size());
     }

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -4,7 +4,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.TestIndexResourcesManager;
 import io.pinecone.proto.ListResponse;
 import org.junit.jupiter.api.AfterAll;
@@ -15,64 +14,61 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ListEndpointTest {
     private static final TestIndexResourcesManager indexManager = TestIndexResourcesManager.getInstance();
-    private static String indexName ;
     private static Index indexConnection;
     private static AsyncIndex asyncIndexConnection;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
-        indexName = indexManager.getServerlessIndexName();
+        indexManager.getServerlessIndexName(); // create serverless index
         indexConnection = indexManager.getServerlessIndexConnection();
         asyncIndexConnection = indexManager.getServerlessAsyncIndexConnection();
     }
 
     @AfterAll
     public static void cleanUp() {
-        String apiKey = System.getenv("PINECONE_API_KEY");
-        Pinecone pinecone = new Pinecone.Builder(apiKey).build();
-        pinecone.deleteIndex(indexName);
         indexConnection.close();
         asyncIndexConnection.close();
     }
 
     @Test
-    public void testListEndpoint() throws InterruptedException {
-        Thread.sleep(10000); // wait for the index to be ready for operations
-
-        // Sync
+    public void testSyncListEndpoint() throws InterruptedException {
+        // Confirm all vector IDs from namespace are returned
         String listResponse = indexConnection.list("example-namespace").toString();
         assertTrue(listResponse.contains("id1"));
         assertTrue(listResponse.contains("id2"));
-        assertTrue(listResponse.contains("cidddd3"));
+        assertTrue(listResponse.contains("prefix-id3"));
 
+        // Confirm all vector IDs from namespace are returned
         String listResponseWithPrefix = indexConnection.list("example-namespace", "i").toString();
         assertTrue(listResponseWithPrefix.contains("id1"));
         assertTrue(listResponseWithPrefix.contains("id2"));
-        assertFalse(listResponseWithPrefix.contains("cidddd3")); // should not be in response
+        assertFalse(listResponseWithPrefix.contains("prefix-id3")); // should not be in response
 
-        String listResponseWithLimit = indexConnection.list("example-namespace", 1).toString();
-        assertTrue(listResponseWithLimit.contains("cidddd3")); // (IDs returned in LIFO order)
-        assertFalse(listResponseWithLimit.contains("id2")); // should not be in response
-        assertFalse(listResponseWithLimit.contains("id1")); // should not be in response
+        // Confirm all vector IDs from namespace are returned, with a limit of 1
+        ListResponse listResponseWithLimit = indexConnection.list("example-namespace", 1);
+        assertEquals(1, listResponseWithLimit.getVectorsList().size());
+    }
 
-        //Async
+    @Test
+    public void testAsyncListEndpoint() throws InterruptedException {
+        // Confirm all vector IDs from namespace are returned
         ListenableFuture<ListResponse> futureResponse = asyncIndexConnection.list("example-namespace");
         ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
         assertTrue(asyncListResponse.toString().contains("id1"));
         assertTrue(asyncListResponse.toString().contains("id2"));
-        assertTrue(asyncListResponse.toString().contains("cidddd3"));
+        assertTrue(asyncListResponse.toString().contains("prefix-id3"));
 
+        // Confirm all vector IDs from namespace are returned, filtered by given prefix
         ListenableFuture<ListResponse> futureResponseWithPrefix = asyncIndexConnection.list("example-namespace", "i");
         ListResponse asyncListResponseWithPrefix = Futures.getUnchecked(futureResponseWithPrefix);
         assertTrue(asyncListResponseWithPrefix.toString().contains("id1"));
         assertTrue(asyncListResponseWithPrefix.toString().contains("id2"));
-        assertFalse(asyncListResponseWithPrefix.toString().contains("cidddd3"));
+        assertFalse(asyncListResponseWithPrefix.toString().contains("prefix-id3"));
 
+        // Confirm all vector IDs from namespace are returned, with a limit of 1
         ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list("example-namespace", 1);
         ListResponse asyncListResponseWithLimit = Futures.getUnchecked(futureResponseWithLimit);
-        assertTrue(asyncListResponseWithLimit.toString().contains("cidddd3"));
-        assertFalse(asyncListResponseWithLimit.toString().contains("id2"));
-        assertFalse(asyncListResponseWithLimit.toString().contains("id1"));
+        assertEquals(1, asyncListResponseWithLimit.getVectorsList().size());
     }
 
 }

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -850,7 +850,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     *
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -871,7 +872,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     *
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -892,7 +894,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     *
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -913,7 +916,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     *
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -934,7 +938,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     *
+     * <p>Example>
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -956,7 +961,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     *
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -977,14 +983,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     }
 
     /**
-     * Base method that retrieves a list of vector IDs from a specific namespace within an index.
+     * <p>Base method that retrieves a list of vector IDs from a specific namespace within an index.
      *
      * <p>The method internally constructs a {@link ListRequest} using the provided namespace
      * and the provided limit, which cuts off the response after the specified number of IDs. It filters the
      * retrieve IDs to match a provided prefix. It also can accept a pagination token to deterministically paginate
      * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.</p>
      *
-     * <p>Example</p>
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -994,16 +1000,15 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken", 10);
      *     ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *  * }</pre>
+     *  }</pre>
      *
-     * @param namespace The namespace that holds the vector IDs you want to retrieve. Cannot be {@code null} or empty.
+     * @param namespace The namespace that holds the vector IDs you want to retrieve. If namespace is not specified,
+     *      *                  the default namespace is used.
      * @param prefix The prefix with which vector IDs must start to be included in the response.
      * @param paginationToken The token to paginate through the list of vector IDs.
      * @param limit The maximum number of vector IDs you want to retrieve.
      * @return {@link ListResponse} containing the list of vector IDs fetched from the specified namespace.
-     *         The response includes vector IDs up to 100 items.
-     * @throws IllegalArgumentException if the namespace parameter is {@code null} or empty, as validated
-     *         by {@link #validateListEndpointParameters}.
+     *         The response includes vector IDs up to {@code 100} items.
      * @throws RuntimeException if there are issues processing the request or communicating with the server.
      *         This includes network issues, server errors, or serialization issues with the request or response.
      */

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -939,7 +939,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example>
+     * <p>Example
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -908,7 +908,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *  }</pre>
      */
     @Override
-    public ListenableFuture<ListResponse> list(String namespace, Integer limit) {
+    public ListenableFuture<ListResponse> list(String namespace, int limit) {
         validateListEndpointParameters(namespace, null, null, limit, true, false, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return asyncStub.list(listRequest);
@@ -952,7 +952,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *  }</pre>
      */
     @Override
-    public ListenableFuture<ListResponse> list(String namespace, String prefix, Integer limit) {
+    public ListenableFuture<ListResponse> list(String namespace, String prefix, int limit) {
         validateListEndpointParameters(namespace, prefix, null, limit, true, true, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setLimit(limit).build();
@@ -1013,7 +1013,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *         This includes network issues, server errors, or serialization issues with the request or response.
      */
     @Override
-    public ListenableFuture<ListResponse> list(String namespace, String prefix, String paginationToken, Integer limit) {
+    public ListenableFuture<ListResponse> list(String namespace, String prefix, String paginationToken, int limit) {
         validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -851,7 +851,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -873,7 +873,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -895,7 +895,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -917,7 +917,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -939,7 +939,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -962,7 +962,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     /**
      * {@inheritDoc}
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;
@@ -990,7 +990,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      * retrieve IDs to match a provided prefix. It also can accept a pagination token to deterministically paginate
      * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.</p>
      *
-     * <p>Example
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *     import com.google.common.util.concurrent.Futures;

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -13,7 +13,6 @@ import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 
 import java.util.List;
 
-import static io.pinecone.clients.Index.validateListEndpointParameters;
 
 /**
  * A client for interacting with a Pinecone index via GRPC asynchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
@@ -853,16 +852,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-async-index";
-     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *     ...
+     *
      *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace");
      *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *      System.out.println(asyncListResponse);
      *  }</pre>
      */
     @Override
@@ -876,16 +873,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-async-index";
-     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *     ...
+     *
      *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", 10);
      *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *      System.out.println(asyncListResponse);
      *  }</pre>
      */
     @Override
@@ -899,16 +894,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-    *       String indexName = "example-async-index";
-     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
-     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-");
-     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *      System.out.println(asyncListResponse);
+     *     ...
+     *
+     *     ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-");
+     *     ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
      *  }</pre>
      */
     @Override
@@ -922,16 +915,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-async-index";
-     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
-     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", 10);
-     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *      System.out.println(asyncListResponse);
+     *     ...
+     *
+     *     ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", 10);
+     *     ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
      *  }</pre>
      */
     @Override
@@ -946,16 +937,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-    *       String indexName = "example-async-index";
-     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
-     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken");
-     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *      System.out.println(asyncListResponse);
+     *     ...
+     *
+     *     ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken");
+     *     ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
      *  }</pre>
      */
     @Override
@@ -976,16 +965,14 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-    *       String indexName = "example-async-index";
-     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
-     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken", 10);
-     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
-     *      System.out.println(asyncListResponse);
+     *     ...
+     *
+     *     ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken", 10);
+     *     ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
      *  * }</pre>
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve. Cannot be {@code null} or empty.

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -31,7 +31,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         ListenableFuture<FetchResponse>,
         ListenableFuture<UpdateResponse>,
         ListenableFuture<DeleteResponse>,
-        ListenableFuture<DescribeIndexStatsResponse>> {
+        ListenableFuture<DescribeIndexStatsResponse>,
+        ListenableFuture<ListResponse>>{
 
     private final PineconeConnection connection;
     private final VectorServiceGrpc.VectorServiceFutureStub asyncStub;
@@ -844,6 +845,71 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         DescribeIndexStatsRequest describeIndexStatsRequest = validateDescribeIndexStatsRequest(filter);
 
         return asyncStub.describeIndexStats(describeIndexStatsRequest);
+    }
+
+    @Override
+    public ListenableFuture<ListResponse>  list(String prefix) {
+        validateListEndpointParameters(prefix, null, null, null, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setLimit(100).build();
+        return asyncStub.list(listRequest);
+    }
+
+    @Override
+    public ListenableFuture<ListResponse>  list(String prefix, Integer limit) {
+        validateListEndpointParameters(prefix, null, null, limit, false, false, true);
+
+        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setLimit(limit).build();
+        return asyncStub.list(listRequest);
+    }
+
+    @Override
+    public ListenableFuture<ListResponse> list(String prefix, String namespace) {
+        validateListEndpointParameters(prefix, namespace, null, null, true, false, false);
+
+        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+                setLimit(100).build();
+        return asyncStub.list(listRequest);
+    }
+
+    @Override
+    public ListenableFuture<ListResponse>  list(String prefix, String namespace, Integer limit) {
+        validateListEndpointParameters(prefix, namespace, null, limit, true, false, true);
+
+        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+                setLimit(limit).build();
+        return asyncStub.list(listRequest);
+    }
+
+    @Override
+    public ListenableFuture<ListResponse>  list(String prefix, String namespace, String paginationToken) {
+        validateListEndpointParameters(prefix, namespace, paginationToken, null, true, true, false);
+
+        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+                setPaginationToken(paginationToken).setLimit(100).build();
+        return asyncStub.list(listRequest);
+    }
+
+    @Override
+    public ListenableFuture<ListResponse>  list(String prefix, String namespace, String paginationToken, Integer limit) {
+        validateListEndpointParameters(prefix, namespace, paginationToken, limit, true, true, true);
+        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+                setPaginationToken(paginationToken).setLimit(limit).build();
+        return asyncStub.list(listRequest);
+    }
+
+    public void validateListEndpointParameters(String prefix, String namespace, String paginationToken, Integer limit, boolean namespaceRequired, boolean paginationTokenRequired, boolean limitRequired) {
+        if (prefix == null || prefix.isEmpty()) {
+            throw new PineconeValidationException("Prefix cannot be null or empty");
+        }
+        if (namespaceRequired && (namespace == null || namespace.isEmpty())) {
+            throw new PineconeValidationException("Namespace cannot be null or empty");
+        }
+        if (paginationTokenRequired && (paginationToken == null || paginationToken.isEmpty())) {
+            throw new PineconeValidationException("Pagination token cannot be null or empty");
+        }
+        if (limitRequired && (limit == null || limit <= 0)) {
+            throw new PineconeValidationException("Limit must be a positive integer");
+        }
     }
 
     /**

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -849,20 +849,68 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.describeIndexStats(describeIndexStatsRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-async-index";
+     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace");
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *      System.out.println(asyncListResponse);
+     *  }</pre>
+     */
     @Override
-    public ListenableFuture<ListResponse>  list(String namespace) {
+    public ListenableFuture<ListResponse> list(String namespace) {
         validateListEndpointParameters(namespace, null, null, null, false, false, false);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(100).build();
         return asyncStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-async-index";
+     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", 10);
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *      System.out.println(asyncListResponse);
+     *  }</pre>
+     */
     @Override
-    public ListenableFuture<ListResponse>  list(String namespace, Integer limit) {
+    public ListenableFuture<ListResponse> list(String namespace, Integer limit) {
         validateListEndpointParameters(namespace, null, null, limit, false, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return asyncStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    *       String indexName = "example-async-index";
+     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-");
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *      System.out.println(asyncListResponse);
+     *  }</pre>
+     */
     @Override
     public ListenableFuture<ListResponse> list(String namespace, String prefix) {
         validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
@@ -870,24 +918,89 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
         return asyncStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-async-index";
+     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", 10);
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *      System.out.println(asyncListResponse);
+     *  }</pre>
+     */
     @Override
-    public ListenableFuture<ListResponse>  list(String namespace, String prefix, Integer limit) {
+    public ListenableFuture<ListResponse> list(String namespace, String prefix, Integer limit) {
         validateListEndpointParameters(namespace, prefix, null, limit, true, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setLimit(limit).build();
         return asyncStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    *       String indexName = "example-async-index";
+     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken");
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *      System.out.println(asyncListResponse);
+     *  }</pre>
+     */
     @Override
-    public ListenableFuture<ListResponse>  list(String namespace, String prefix, String paginationToken) {
+    public ListenableFuture<ListResponse> list(String namespace, String prefix, String paginationToken) {
         validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(100).build();
         return asyncStub.list(listRequest);
     }
 
+    /**
+     * Base method that retrieves a list of vector IDs from a specific namespace within an index.
+     *
+     * <p>The method internally constructs a {@link ListRequest} using the provided namespace
+     * and the provided limit, which cuts off the response after the specified number of IDs. It filters the
+     * retrieve IDs to match a provided prefix. It also can accept a pagination token to deterministically paginate
+     * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.</p>
+     *
+     * <p>Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    *       String indexName = "example-async-index";
+     *      AsyncIndex asyncIndex = pc.getAsyncIndexConnection(indexName);
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", "prefix-", "some-pagToken", 10);
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *      System.out.println(asyncListResponse);
+     *  * }</pre>
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve. Cannot be {@code null} or empty.
+     * @param prefix The prefix with which vector IDs must start to be included in the response.
+     * @param paginationToken The token to paginate through the list of vector IDs.
+     * @param limit The maximum number of vector IDs you want to retrieve.
+     * @return {@link ListResponse} containing the list of vector IDs fetched from the specified namespace.
+     *         The response includes vector IDs up to 100 items.
+     * @throws IllegalArgumentException if the namespace parameter is {@code null} or empty, as validated
+     *         by {@link #validateListEndpointParameters}.
+     * @throws RuntimeException if there are issues processing the request or communicating with the server.
+     *         This includes network issues, server errors, or serialization issues with the request or response.
+     */
     @Override
-    public ListenableFuture<ListResponse>  list(String namespace, String prefix, String paginationToken, Integer limit) {
+    public ListenableFuture<ListResponse> list(String namespace, String prefix, String paginationToken, Integer limit) {
         validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -13,6 +13,8 @@ import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 
 import java.util.List;
 
+import static io.pinecone.clients.Index.validateListEndpointParameters;
+
 /**
  * A client for interacting with a Pinecone index via GRPC asynchronously. Allows for upserting, querying, fetching, updating, and deleting vectors.
  * This class provides a direct interface to interact with a specific index, encapsulating network communication and request validation.
@@ -848,68 +850,48 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
     }
 
     @Override
-    public ListenableFuture<ListResponse>  list(String prefix) {
-        validateListEndpointParameters(prefix, null, null, null, false, false, false);
-        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setLimit(100).build();
+    public ListenableFuture<ListResponse>  list(String namespace) {
+        validateListEndpointParameters(namespace, null, null, null, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(100).build();
         return asyncStub.list(listRequest);
     }
 
     @Override
-    public ListenableFuture<ListResponse>  list(String prefix, Integer limit) {
-        validateListEndpointParameters(prefix, null, null, limit, false, false, true);
-
-        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setLimit(limit).build();
+    public ListenableFuture<ListResponse>  list(String namespace, Integer limit) {
+        validateListEndpointParameters(namespace, null, null, limit, false, false, true);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return asyncStub.list(listRequest);
     }
 
     @Override
-    public ListenableFuture<ListResponse> list(String prefix, String namespace) {
-        validateListEndpointParameters(prefix, namespace, null, null, true, false, false);
-
-        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
-                setLimit(100).build();
+    public ListenableFuture<ListResponse> list(String namespace, String prefix) {
+        validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).setLimit(100).build();
         return asyncStub.list(listRequest);
     }
 
     @Override
-    public ListenableFuture<ListResponse>  list(String prefix, String namespace, Integer limit) {
-        validateListEndpointParameters(prefix, namespace, null, limit, true, false, true);
-
-        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+    public ListenableFuture<ListResponse>  list(String namespace, String prefix, Integer limit) {
+        validateListEndpointParameters(namespace, prefix, null, limit, true, false, true);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setLimit(limit).build();
         return asyncStub.list(listRequest);
     }
 
     @Override
-    public ListenableFuture<ListResponse>  list(String prefix, String namespace, String paginationToken) {
-        validateListEndpointParameters(prefix, namespace, paginationToken, null, true, true, false);
-
-        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+    public ListenableFuture<ListResponse>  list(String namespace, String prefix, String paginationToken) {
+        validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(100).build();
         return asyncStub.list(listRequest);
     }
 
     @Override
-    public ListenableFuture<ListResponse>  list(String prefix, String namespace, String paginationToken, Integer limit) {
-        validateListEndpointParameters(prefix, namespace, paginationToken, limit, true, true, true);
-        ListRequest listRequest = ListRequest.newBuilder().setPrefix(prefix).setNamespace(namespace).
+    public ListenableFuture<ListResponse>  list(String namespace, String prefix, String paginationToken, Integer limit) {
+        validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();
         return asyncStub.list(listRequest);
-    }
-
-    public void validateListEndpointParameters(String prefix, String namespace, String paginationToken, Integer limit, boolean namespaceRequired, boolean paginationTokenRequired, boolean limitRequired) {
-        if (prefix == null || prefix.isEmpty()) {
-            throw new PineconeValidationException("Prefix cannot be null or empty");
-        }
-        if (namespaceRequired && (namespace == null || namespace.isEmpty())) {
-            throw new PineconeValidationException("Namespace cannot be null or empty");
-        }
-        if (paginationTokenRequired && (paginationToken == null || paginationToken.isEmpty())) {
-            throw new PineconeValidationException("Pagination token cannot be null or empty");
-        }
-        if (limitRequired && (limit == null || limit <= 0)) {
-            throw new PineconeValidationException("Limit must be a positive integer");
-        }
     }
 
     /**

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -858,14 +858,35 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      *
      *     ...
      *
+     *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("");
+     *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *  }</pre>
+     */
+    @Override
+    public ListenableFuture<ListResponse> list() {
+        validateListEndpointParameters(null, null, null, null, false, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().build();
+        return asyncStub.list(listRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *     import io.pinecone.proto.ListResponse;
+     *     import com.google.common.util.concurrent.Futures;
+     *     import com.google.common.util.concurrent.ListenableFuture;
+     *
+     *     ...
+     *
      *      ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace");
      *      ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
      *  }</pre>
      */
     @Override
     public ListenableFuture<ListResponse> list(String namespace) {
-        validateListEndpointParameters(namespace, null, null, null, false, false, false);
-        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(100).build();
+        validateListEndpointParameters(namespace, null, null, null, true, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).build();
         return asyncStub.list(listRequest);
     }
 
@@ -885,7 +906,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      */
     @Override
     public ListenableFuture<ListResponse> list(String namespace, Integer limit) {
-        validateListEndpointParameters(namespace, null, null, limit, false, false, true);
+        validateListEndpointParameters(namespace, null, null, limit, true, false, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return asyncStub.list(listRequest);
     }
@@ -906,8 +927,8 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      */
     @Override
     public ListenableFuture<ListResponse> list(String namespace, String prefix) {
-        validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
-        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).setLimit(100).build();
+        validateListEndpointParameters(namespace, prefix, null, null, true, true, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).build();
         return asyncStub.list(listRequest);
     }
 
@@ -927,7 +948,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      */
     @Override
     public ListenableFuture<ListResponse> list(String namespace, String prefix, Integer limit) {
-        validateListEndpointParameters(namespace, prefix, null, limit, true, false, true);
+        validateListEndpointParameters(namespace, prefix, null, limit, true, true, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setLimit(limit).build();
         return asyncStub.list(listRequest);
@@ -949,9 +970,9 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      */
     @Override
     public ListenableFuture<ListResponse> list(String namespace, String prefix, String paginationToken) {
-        validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
+        validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, true, false);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
-                setPaginationToken(paginationToken).setLimit(100).build();
+                setPaginationToken(paginationToken).build();
         return asyncStub.list(listRequest);
     }
 
@@ -988,7 +1009,7 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
      */
     @Override
     public ListenableFuture<ListResponse> list(String namespace, String prefix, String paginationToken, Integer limit) {
-        validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
+        validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();
         return asyncStub.list(listRequest);

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -782,7 +782,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     * <p> Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
@@ -801,7 +801,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
@@ -819,7 +819,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
@@ -837,7 +837,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
@@ -856,7 +856,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     * <p> Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
@@ -876,7 +876,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p>Example</p>
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
@@ -894,30 +894,28 @@ public class Index implements IndexInterface<UpsertResponse,
     }
 
     /**
-     * Base method that retrieves a list of vector IDs from a specific namespace within an index.
+     * <p>Base method that retrieves a list of vector IDs from a specific namespace within an index.
      *
      * <p>The method internally constructs a {@link ListRequest} using the provided namespace
      * and the provided limit, which cuts off the response after the specified number of IDs. It filters the
      * retrieve IDs to match a provided prefix. It also can accept a pagination token to deterministically paginate
-     * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.</p>
+     * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.
      *
-     * <p>Example</p>
+     * <p>Example:
      *  <pre>{@code
      *     import io.pinecone.proto.ListResponse;
      *
      *     ...
      *
      *     ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken", 10);
-     *  * }</pre>
-     *
-     * @param namespace The namespace that holds the vector IDs you want to retrieve. Cannot be {@code null} or empty.
+     *   }</pre>
+     * @param namespace The namespace that holds the vector IDs you want to retrieve. If namespace is not specified,
+     *                  the default namespace is used.
      * @param prefix The prefix with which vector IDs must start to be included in the response.
      * @param paginationToken The token to paginate through the list of vector IDs.
      * @param limit The maximum number of vector IDs you want to retrieve.
      * @return {@link ListResponse} containing the list of vector IDs fetched from the specified namespace.
-     *         The response includes vector IDs up to 100 items.
-     * @throws IllegalArgumentException if the namespace parameter is {@code null} or empty, as validated
-     *         by {@link #validateListEndpointParameters}.
+     *         The response includes vector IDs up to {@code 100} items.
      * @throws RuntimeException if there are issues processing the request or communicating with the server.
      *         This includes network issues, server errors, or serialization issues with the request or response.
      */

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -788,13 +788,32 @@ public class Index implements IndexInterface<UpsertResponse,
      *
      *     ...
      *
+     *     ListResponse listResponse = index.list();
+     *  }</pre>
+     */
+    @Override
+    public ListResponse list() {
+        validateListEndpointParameters(null, null, null, null, false, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().build();
+        return blockingStub.list(listRequest);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     * <p>Example</p>
+     *  <pre>{@code
+     *     import io.pinecone.proto.ListResponse;
+     *
+     *     ...
+     *
      *     ListResponse listResponse = index.list("example-namespace");
      *  }</pre>
      */
     @Override
     public ListResponse list(String namespace) {
-        validateListEndpointParameters(namespace, null, null, null, false, false, false);
-        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(100).build();
+        validateListEndpointParameters(namespace, null, null, null, true, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).build();
         return blockingStub.list(listRequest);
     }
 
@@ -811,7 +830,7 @@ public class Index implements IndexInterface<UpsertResponse,
      */
     @Override
     public ListResponse list(String namespace, Integer limit) {
-        validateListEndpointParameters(namespace, null, null, limit, false, false, true);
+        validateListEndpointParameters(namespace, null, null, limit, true, false, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return blockingStub.list(listRequest);
     }
@@ -829,9 +848,9 @@ public class Index implements IndexInterface<UpsertResponse,
      */
     @Override
     public ListResponse list(String namespace, String prefix) {
-        validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
+        validateListEndpointParameters(namespace, prefix, null, null, true, true, false, false);
         ListRequest listRequest =
-                ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).setLimit(100).build();
+                ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).build();
         return blockingStub.list(listRequest);
     }
 
@@ -848,7 +867,7 @@ public class Index implements IndexInterface<UpsertResponse,
      */
     @Override
     public ListResponse list(String namespace, String prefix, Integer limit) {
-        validateListEndpointParameters(namespace, prefix, null, limit, true, false, true);
+        validateListEndpointParameters(namespace, prefix, null, limit, true, true, false, true);
 
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setLimit(limit).build();
@@ -868,9 +887,9 @@ public class Index implements IndexInterface<UpsertResponse,
      */
     @Override
     public ListResponse list(String namespace, String prefix, String paginationToken) {
-        validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
+        validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, true, false);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
-                setPaginationToken(paginationToken).setLimit(100).build();
+                setPaginationToken(paginationToken).build();
         return blockingStub.list(listRequest);
     }
 
@@ -903,7 +922,7 @@ public class Index implements IndexInterface<UpsertResponse,
      *         This includes network issues, server errors, or serialization issues with the request or response.
      */
     public ListResponse list(String namespace, String prefix, String paginationToken, Integer limit) {
-        validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
+        validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();
         return blockingStub.list(listRequest);

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -782,7 +782,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p> Example</p>
+     * <p>Example</p>
      *  <pre>{@code
      *      import io.pinecone.clients.Index;
      *      import io.pinecone.clients.Pinecone;
@@ -804,7 +804,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p> Example</p>
+     * <p>Example</p>
      *  <pre>{@code
      *      import io.pinecone.clients.Index;
      *      import io.pinecone.clients.Pinecone;
@@ -826,7 +826,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p> Example</p>
+     * <p>Example</p>
      *  <pre>{@code
      *      import io.pinecone.clients.Index;
      *      import io.pinecone.clients.Pinecone;
@@ -849,7 +849,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p> Example</p>
+     * <p>Example</p>
      *  <pre>{@code
      *      import io.pinecone.clients.Index;
      *      import io.pinecone.clients.Pinecone;
@@ -873,7 +873,7 @@ public class Index implements IndexInterface<UpsertResponse,
 
     /**
      * {@inheritDoc}
-     * <p> Example</p>
+     * <p>Example</p>
      *  <pre>{@code
      *      import io.pinecone.clients.Index;
      *      import io.pinecone.clients.Pinecone;
@@ -902,7 +902,7 @@ public class Index implements IndexInterface<UpsertResponse,
      * retrieve IDs to match a provided prefix. It also can accept a pagination token to deterministically paginate
      * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.</p>
      *
-     * <p> Example</p>
+     * <p>Example</p>
      *  <pre>{@code
      *      import io.pinecone.clients.Index;
      *      import io.pinecone.clients.Pinecone;
@@ -931,53 +931,6 @@ public class Index implements IndexInterface<UpsertResponse,
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();
         return blockingStub.list(listRequest);
-    }
-
-
-    /**
-     * Validates the parameters for a list endpoint operation.
-     *
-     * <p>It throws a {@link PineconeValidationException} if any required validation fails.</p>
-     *
-     * <p>Example</p>
-     * <pre>{@code
-     *      try {
-     *          String namespace = "example-namespace";
-     *          String prefix = "example-prefix";
-     *          String paginationToken = "token123";
-     *          Integer limit = 50;
-     *
-     *           // Indicate which parameters are required
-     *          validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
-     *
-     *          } catch (PineconeValidationException e) {
-     *           System.err.println("Validation error: " + e.getMessage());
-     *          }
-     * }</pre>
-     *
-     * @param namespace The namespace parameter which cannot be null or empty.
-     * @param prefix The prefix parameter which is validated based on the {@code prefixRequired} flag.
-     * @param paginationToken The pagination token parameter which is validated based on the {@code paginationTokenRequired} flag.
-     * @param limit The limit for the number of items, validated to be a positive integer if {@code limitRequired} is true.
-     * @param prefixRequired Specifies if the prefix parameter is required and should be validated.
-     * @param paginationTokenRequired Specifies if the pagination token parameter is required and should be validated.
-     * @param limitRequired Specifies if the limit parameter is required and should be a positive integer.
-     * @throws PineconeValidationException if any parameter fails its validation check based on its requirements.
-     */
-    public static void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
-            , boolean prefixRequired, boolean paginationTokenRequired, boolean limitRequired) {
-        if (namespace == null || namespace.isEmpty()) {
-            throw new PineconeValidationException("Namespace cannot be null or empty");
-        }
-        if (prefixRequired && (prefix == null || prefix.isEmpty())) {
-            throw new PineconeValidationException("Prefix cannot be null or empty");
-        }
-        if (paginationTokenRequired && (paginationToken == null || paginationToken.isEmpty())) {
-            throw new PineconeValidationException("Pagination token cannot be null or empty");
-        }
-        if (limitRequired && (limit == null || limit <= 0)) {
-            throw new PineconeValidationException("Limit must be a positive integer");
-        }
     }
 
 

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -790,7 +790,6 @@ public class Index implements IndexInterface<UpsertResponse,
     @Override
     public ListResponse list(String namespace, Integer limit) {
         validateListEndpointParameters(namespace, null, null, limit, false, false, true);
-
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return blockingStub.list(listRequest);
     }
@@ -798,7 +797,6 @@ public class Index implements IndexInterface<UpsertResponse,
     @Override
     public ListResponse list(String namespace, String prefix) {
         validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
-
         ListRequest listRequest =
                 ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).setLimit(100).build();
         return blockingStub.list(listRequest);
@@ -816,7 +814,6 @@ public class Index implements IndexInterface<UpsertResponse,
     @Override
     public ListResponse list(String namespace, String prefix, String paginationToken) {
         validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
-
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(100).build();
         return blockingStub.list(listRequest);

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -780,6 +780,21 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.describeIndexStats(describeIndexStatsRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p> Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-index";
+     *      Index index = pc.getIndexConnection(indexName);
+     *      ListResponse listResponse = index.list("example-namespace");
+     *      System.out.println(listResponse);
+     *  }</pre>
+     */
     @Override
     public ListResponse list(String namespace) {
         validateListEndpointParameters(namespace, null, null, null, false, false, false);
@@ -787,6 +802,21 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p> Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-index";
+     *      Index index = pc.getIndexConnection(indexName);
+     *      ListResponse listResponse = index.list("example-namespace", 10);
+     *      System.out.println(listResponse);
+     *  }</pre>
+     */
     @Override
     public ListResponse list(String namespace, Integer limit) {
         validateListEndpointParameters(namespace, null, null, limit, false, false, true);
@@ -794,6 +824,21 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p> Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-index";
+     *      Index index = pc.getIndexConnection(indexName);
+     *      ListResponse listResponse = index.list("example-namespace", "st-");
+     *      System.out.println(listResponse);
+     *  }</pre>
+     */
     @Override
     public ListResponse list(String namespace, String prefix) {
         validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
@@ -802,6 +847,21 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p> Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-index";
+     *      Index index = pc.getIndexConnection(indexName);
+     *      ListResponse listResponse = index.list("example-namespace", "st-", 10);
+     *      System.out.println(listResponse);
+     *  }</pre>
+     */
     @Override
     public ListResponse list(String namespace, String prefix, Integer limit) {
         validateListEndpointParameters(namespace, prefix, null, limit, true, false, true);
@@ -811,6 +871,21 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.list(listRequest);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p> Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-index";
+     *      Index index = pc.getIndexConnection(indexName);
+     *      ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken");
+     *      System.out.println(listResponse);
+     *  }</pre>
+     */
     @Override
     public ListResponse list(String namespace, String prefix, String paginationToken) {
         validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
@@ -819,7 +894,38 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.list(listRequest);
     }
 
-    @Override
+    /**
+     * Base method that retrieves a list of vector IDs from a specific namespace within an index.
+     *
+     * <p>The method internally constructs a {@link ListRequest} using the provided namespace
+     * and the provided limit, which cuts off the response after the specified number of IDs. It filters the
+     * retrieve IDs to match a provided prefix. It also can accept a pagination token to deterministically paginate
+     * through a list of vector IDs. It then makes a synchronous RPC call to fetch the list of vector IDs.</p>
+     *
+     * <p> Example</p>
+     *  <pre>{@code
+     *      import io.pinecone.clients.Index;
+     *      import io.pinecone.clients.Pinecone;
+     *      import io.pinecone.proto.ListResponse;
+     *
+     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+     *      String indexName = "example-index";
+     *      Index index = pc.getIndexConnection(indexName);
+     *      ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken", 10);
+     *      System.out.println(listResponse);
+     *  * }</pre>
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve. Cannot be {@code null} or empty.
+     * @param prefix The prefix with which vector IDs must start to be included in the response.
+     * @param paginationToken The token to paginate through the list of vector IDs.
+     * @param limit The maximum number of vector IDs you want to retrieve.
+     * @return {@link ListResponse} containing the list of vector IDs fetched from the specified namespace.
+     *         The response includes vector IDs up to 100 items.
+     * @throws IllegalArgumentException if the namespace parameter is {@code null} or empty, as validated
+     *         by {@link #validateListEndpointParameters}.
+     * @throws RuntimeException if there are issues processing the request or communicating with the server.
+     *         This includes network issues, server errors, or serialization issues with the request or response.
+     */
     public ListResponse list(String namespace, String prefix, String paginationToken, Integer limit) {
         validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
@@ -827,6 +933,37 @@ public class Index implements IndexInterface<UpsertResponse,
         return blockingStub.list(listRequest);
     }
 
+
+    /**
+     * Validates the parameters for a list endpoint operation.
+     *
+     * <p>It throws a {@link PineconeValidationException} if any required validation fails.</p>
+     *
+     * <p>Example</p>
+     * <pre>{@code
+     *      try {
+     *          String namespace = "example-namespace";
+     *          String prefix = "example-prefix";
+     *          String paginationToken = "token123";
+     *          Integer limit = 50;
+     *
+     *           // Indicate which parameters are required
+     *          validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
+     *
+     *          } catch (PineconeValidationException e) {
+     *           System.err.println("Validation error: " + e.getMessage());
+     *          }
+     * }</pre>
+     *
+     * @param namespace The namespace parameter which cannot be null or empty.
+     * @param prefix The prefix parameter which is validated based on the {@code prefixRequired} flag.
+     * @param paginationToken The pagination token parameter which is validated based on the {@code paginationTokenRequired} flag.
+     * @param limit The limit for the number of items, validated to be a positive integer if {@code limitRequired} is true.
+     * @param prefixRequired Specifies if the prefix parameter is required and should be validated.
+     * @param paginationTokenRequired Specifies if the pagination token parameter is required and should be validated.
+     * @param limitRequired Specifies if the limit parameter is required and should be a positive integer.
+     * @throws PineconeValidationException if any parameter fails its validation check based on its requirements.
+     */
     public static void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
             , boolean prefixRequired, boolean paginationTokenRequired, boolean limitRequired) {
         if (namespace == null || namespace.isEmpty()) {

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -28,7 +28,8 @@ public class Index implements IndexInterface<UpsertResponse,
         FetchResponse,
         UpdateResponse,
         DeleteResponse,
-        DescribeIndexStatsResponse> {
+        DescribeIndexStatsResponse,
+        ListResponse> {
 
     private final PineconeConnection connection;
     private final String indexName;
@@ -778,6 +779,73 @@ public class Index implements IndexInterface<UpsertResponse,
 
         return blockingStub.describeIndexStats(describeIndexStatsRequest);
     }
+
+    @Override
+    public ListResponse list(String namespace) {
+        validateListEndpointParameters(namespace, null, null, null, false, false, false);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(100).build();
+        return blockingStub.list(listRequest);
+    }
+
+    @Override
+    public ListResponse list(String namespace, Integer limit) {
+        validateListEndpointParameters(namespace, null, null, limit, false, false, true);
+
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
+        return blockingStub.list(listRequest);
+    }
+
+    @Override
+    public ListResponse list(String namespace, String prefix) {
+        validateListEndpointParameters(namespace, prefix, null, null, true, false, false);
+
+        ListRequest listRequest =
+                ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).setLimit(100).build();
+        return blockingStub.list(listRequest);
+    }
+
+    @Override
+    public ListResponse list(String namespace, String prefix, Integer limit) {
+        validateListEndpointParameters(namespace, prefix, null, limit, true, false, true);
+
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
+                setLimit(limit).build();
+        return blockingStub.list(listRequest);
+    }
+
+    @Override
+    public ListResponse list(String namespace, String prefix, String paginationToken) {
+        validateListEndpointParameters(namespace, prefix, paginationToken, null, true, true, false);
+
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
+                setPaginationToken(paginationToken).setLimit(100).build();
+        return blockingStub.list(listRequest);
+    }
+
+    @Override
+    public ListResponse list(String namespace, String prefix, String paginationToken, Integer limit) {
+        validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
+                setPaginationToken(paginationToken).setLimit(limit).build();
+        return blockingStub.list(listRequest);
+    }
+
+    public static void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
+            , boolean prefixRequired, boolean paginationTokenRequired, boolean limitRequired) {
+        if (namespace == null || namespace.isEmpty()) {
+            throw new PineconeValidationException("Namespace cannot be null or empty");
+        }
+        if (prefixRequired && (prefix == null || prefix.isEmpty())) {
+            throw new PineconeValidationException("Prefix cannot be null or empty");
+        }
+        if (paginationTokenRequired && (paginationToken == null || paginationToken.isEmpty())) {
+            throw new PineconeValidationException("Pagination token cannot be null or empty");
+        }
+        if (limitRequired && (limit == null || limit <= 0)) {
+            throw new PineconeValidationException("Limit must be a positive integer");
+        }
+    }
+
 
     /**
      * {@inheritDoc}

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -784,15 +784,11 @@ public class Index implements IndexInterface<UpsertResponse,
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-index";
-     *      Index index = pc.getIndexConnection(indexName);
-     *      ListResponse listResponse = index.list("example-namespace");
-     *      System.out.println(listResponse);
+     *     ...
+     *
+     *     ListResponse listResponse = index.list("example-namespace");
      *  }</pre>
      */
     @Override
@@ -806,15 +802,11 @@ public class Index implements IndexInterface<UpsertResponse,
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-index";
-     *      Index index = pc.getIndexConnection(indexName);
-     *      ListResponse listResponse = index.list("example-namespace", 10);
-     *      System.out.println(listResponse);
+     *     ...
+     *
+     *     ListResponse listResponse = index.list("example-namespace", 10);
      *  }</pre>
      */
     @Override
@@ -828,15 +820,11 @@ public class Index implements IndexInterface<UpsertResponse,
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-index";
-     *      Index index = pc.getIndexConnection(indexName);
-     *      ListResponse listResponse = index.list("example-namespace", "st-");
-     *      System.out.println(listResponse);
+     *     ...
+     *
+     *     ListResponse listResponse = index.list("example-namespace", "st-");
      *  }</pre>
      */
     @Override
@@ -851,15 +839,11 @@ public class Index implements IndexInterface<UpsertResponse,
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-index";
-     *      Index index = pc.getIndexConnection(indexName);
-     *      ListResponse listResponse = index.list("example-namespace", "st-", 10);
-     *      System.out.println(listResponse);
+     *     ...
+     *
+     *     ListResponse listResponse = index.list("example-namespace", "st-", 10);
      *  }</pre>
      */
     @Override
@@ -875,15 +859,11 @@ public class Index implements IndexInterface<UpsertResponse,
      * {@inheritDoc}
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-index";
-     *      Index index = pc.getIndexConnection(indexName);
-     *      ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken");
-     *      System.out.println(listResponse);
+     *     ...
+     *
+     *     ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken");
      *  }</pre>
      */
     @Override
@@ -904,15 +884,11 @@ public class Index implements IndexInterface<UpsertResponse,
      *
      * <p>Example</p>
      *  <pre>{@code
-     *      import io.pinecone.clients.Index;
-     *      import io.pinecone.clients.Pinecone;
-     *      import io.pinecone.proto.ListResponse;
+     *     import io.pinecone.proto.ListResponse;
      *
-     *      Pinecone pc = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
-     *      String indexName = "example-index";
-     *      Index index = pc.getIndexConnection(indexName);
-     *      ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken", 10);
-     *      System.out.println(listResponse);
+     *     ...
+     *
+     *     ListResponse listResponse = index.list("example-namespace", "st-", "some-pagToken", 10);
      *  * }</pre>
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve. Cannot be {@code null} or empty.

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -829,7 +829,7 @@ public class Index implements IndexInterface<UpsertResponse,
      *  }</pre>
      */
     @Override
-    public ListResponse list(String namespace, Integer limit) {
+    public ListResponse list(String namespace, int limit) {
         validateListEndpointParameters(namespace, null, null, limit, true, false, false, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).build();
         return blockingStub.list(listRequest);
@@ -866,7 +866,7 @@ public class Index implements IndexInterface<UpsertResponse,
      *  }</pre>
      */
     @Override
-    public ListResponse list(String namespace, String prefix, Integer limit) {
+    public ListResponse list(String namespace, String prefix, int limit) {
         validateListEndpointParameters(namespace, prefix, null, limit, true, true, false, true);
 
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
@@ -919,7 +919,7 @@ public class Index implements IndexInterface<UpsertResponse,
      * @throws RuntimeException if there are issues processing the request or communicating with the server.
      *         This includes network issues, server errors, or serialization issues with the request or response.
      */
-    public ListResponse list(String namespace, String prefix, String paginationToken, Integer limit) {
+    public ListResponse list(String namespace, String prefix, String paginationToken, int limit) {
         validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setPrefix(prefix).
                 setPaginationToken(paginationToken).setLimit(limit).build();

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -25,7 +25,7 @@ import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSig
  * @param <X> The return type for delete operations.
  * @param <Y> The return type for describing index stats.
  */
-public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
+public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
 
     /**
      * Validates and builds an upsert request with a single vector and optional namespace.
@@ -697,4 +697,23 @@ public interface IndexInterface<T, U, V, W, X, Y> extends AutoCloseable {
      * @return A generic type {@code Y} that contains the stats about the index.
      */
     Y describeIndexStats(Struct filter);
+
+//    TODO: Add docstrings
+//    TODO: Make one for just IDs in a namespace, no prefix?
+    Z list(String namespace);
+
+    Z list(String namespace, Integer limit);
+
+    Z list(String namespace, String prefix);
+
+    Z list(String namespace, String prefix, Integer limit);
+
+    Z list(String namespace, String prefix, String paginationToken);
+
+    Z list(String namespace, String prefix, String paginationToken, Integer limit);
+
+
+
+
+
 }

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -698,22 +698,62 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      */
     Y describeIndexStats(Struct filter);
 
-//    TODO: Add docstrings
-//    TODO: Make one for just IDs in a namespace, no prefix?
+    /**
+     * Retrieves up to 100 vector IDs from a given namespace.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
     Z list(String namespace);
 
+    /**
+     * Retrieves up to `n` vector IDs from a given namespace, where `limit` == `n`.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @param limit The maximum number of vector IDs to retrieve.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
     Z list(String namespace, Integer limit);
 
+    /**
+     * Retrieves up to 100 vector IDs from a given namespace, filtered by a given prefix.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @param prefix: The prefix to filter the vector IDs by.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
     Z list(String namespace, String prefix);
 
+    /**
+     * Retrieves up to `n` vector IDs from a given namespace, filtered by a given prefix, where `limit` == `n`.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @param prefix The prefix to filter the vector IDs by.
+     * @param limit The maximum number of vector IDs to retrieve.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
     Z list(String namespace, String prefix, Integer limit);
 
+    /**
+     * Retrieves up to 100 vector IDs from a given namespace, filtered by a given prefix, targeted with a specific
+     * paginationToken.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @param paginationToken The token to paginate through the list of vector IDs.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
     Z list(String namespace, String prefix, String paginationToken);
 
+    /**
+     * Retrieves up to `n` vector IDs from a given namespace, filtered by a given prefix, targeted with a specific
+     * paginationToken, where `limit` == `n`.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @param prefix The prefix to filter the vector IDs by.
+     * @param paginationToken The token to paginate through the list of vector IDs.
+     * @param limit The maximum number of vector IDs to retrieve.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
     Z list(String namespace, String prefix, String paginationToken, Integer limit);
-
-
-
-
 
 }

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -770,7 +770,7 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      * @param limit The maximum number of vector IDs to retrieve.
      * @return A generic type {@code Y} that contains vector IDs.
      */
-    Z list(String namespace, Integer limit);
+    Z list(String namespace, int limit);
 
     /**
      * Retrieves up to {@code 100} vector IDs from a given namespace, filtered by a given prefix.
@@ -789,7 +789,7 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      * @param limit The maximum number of vector IDs to retrieve.
      * @return A generic type {@code Y} that contains vector IDs.
      */
-    Z list(String namespace, String prefix, Integer limit);
+    Z list(String namespace, String prefix, int limit);
 
     /**
      * Retrieves up to {@code 100} vector IDs from a given namespace, filtered by a given prefix, targeted with a
@@ -812,6 +812,6 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      * @param limit The maximum number of vector IDs to retrieve.
      * @return A generic type {@code Y} that contains vector IDs.
      */
-    Z list(String namespace, String prefix, String paginationToken, Integer limit);
+    Z list(String namespace, String prefix, String paginationToken, int limit);
 
 }

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -699,12 +699,12 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Y describeIndexStats(Struct filter);
 
     /**
-     * Validates the parameters for a list endpoint operation.
+     * <p>Validates the parameters for a list endpoint operation.
      *
-     * <p>It throws a {@link PineconeValidationException} if any required validation fails. The "...Required"
-     * parameters are to indicate which method signature is used.</p>
+     * <p>It throws a {@link PineconeValidationException} if any required validation fails. The {@code "...Required"}
+     * parameters indicate which method signature is used.
      *
-     * <p>Example</p>
+     * <p>Example
      * <pre>{@code
      *      try {
      *          String namespace = "example-namespace";
@@ -720,17 +720,18 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      *          }
      * }</pre>
      *:
-     * @param namespace The namespace parameter which cannot be null or empty.
+     * @param namespace The namespace parameter which is validated based on the {@code namespaceRequired} flag.
      * @param prefix The prefix parameter which is validated based on the {@code prefixRequired} flag.
      * @param paginationToken The pagination token parameter which is validated based on the {@code paginationTokenRequired} flag.
      * @param limit The limit for the number of items, validated to be a positive integer if {@code limitRequired} is true.
+     * @param namespaceRequired Specifies if the namespace parameter is required and should be validated.
      * @param prefixRequired Specifies if the prefix parameter is required and should be validated.
      * @param paginationTokenRequired Specifies if the pagination token parameter is required and should be validated.
      * @param limitRequired Specifies if the limit parameter is required and should be a positive integer.
      * @throws PineconeValidationException if any parameter fails its validation check based on its requirements.
      */
     default void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
-            ,boolean namespaceRequired , boolean prefixRequired, boolean paginationTokenRequired,
+            , boolean namespaceRequired, boolean prefixRequired, boolean paginationTokenRequired,
                                                 boolean limitRequired) {
         if (namespaceRequired && (namespace == null || namespace.isEmpty())) {
             throw new PineconeValidationException("Namespace cannot be null or empty");
@@ -747,14 +748,14 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     }
 
     /**
-     * Retrieves up to 100 vector IDs from an index.
+     * Retrieves up to {@code 100} vector IDs from an index from the default namespace.
      *
      * @return A generic type {@code Y} that contains vector IDs.
      */
     Z list();
 
     /**
-     * Retrieves up to 100 vector IDs from a given namespace.
+     * Retrieves up to {@code 100} vector IDs from a given namespace.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.
      * @return A generic type {@code Y} that contains vector IDs.
@@ -762,7 +763,7 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Z list(String namespace);
 
     /**
-     * Retrieves up to `n` vector IDs from a given namespace, where `limit` == `n`.
+     * Retrieves up to {@code n} vector IDs from a given namespace, where {@code limit} == {@code n}.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.
      * @param limit The maximum number of vector IDs to retrieve.
@@ -771,7 +772,7 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Z list(String namespace, Integer limit);
 
     /**
-     * Retrieves up to 100 vector IDs from a given namespace, filtered by a given prefix.
+     * Retrieves up to {@code 100} vector IDs from a given namespace, filtered by a given prefix.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.
      * @param prefix: The prefix to filter the vector IDs by.
@@ -780,7 +781,7 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Z list(String namespace, String prefix);
 
     /**
-     * Retrieves up to `n` vector IDs from a given namespace, filtered by a given prefix, where `limit` == `n`.
+     * Retrieves up to {@code n} vector IDs from a given namespace, filtered by a given prefix, where {@code limit}` == {@code n}.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.
      * @param prefix The prefix to filter the vector IDs by.
@@ -790,7 +791,8 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Z list(String namespace, String prefix, Integer limit);
 
     /**
-     * Retrieves up to 100 vector IDs from a given namespace, filtered by a given prefix, targeted with a specific
+     * Retrieves up to {@code 100} vector IDs from a given namespace, filtered by a given prefix, targeted with a
+     * specific
      * paginationToken.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.
@@ -800,8 +802,8 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Z list(String namespace, String prefix, String paginationToken);
 
     /**
-     * Retrieves up to `n` vector IDs from a given namespace, filtered by a given prefix, targeted with a specific
-     * paginationToken, where `limit` == `n`.
+     * Retrieves up to {@code n} vector IDs from a given namespace, filtered by a given prefix, targeted with a specific
+     * paginationToken, where {@code limit} == {@code n}.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.
      * @param prefix The prefix to filter the vector IDs by.

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -701,7 +701,8 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     /**
      * Validates the parameters for a list endpoint operation.
      *
-     * <p>It throws a {@link PineconeValidationException} if any required validation fails.</p>
+     * <p>It throws a {@link PineconeValidationException} if any required validation fails. The "...Required"
+     * parameters are to indicate which method signature is used.</p>
      *
      * <p>Example</p>
      * <pre>{@code
@@ -718,7 +719,7 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      *           System.err.println("Validation error: " + e.getMessage());
      *          }
      * }</pre>
-     *
+     *:
      * @param namespace The namespace parameter which cannot be null or empty.
      * @param prefix The prefix parameter which is validated based on the {@code prefixRequired} flag.
      * @param paginationToken The pagination token parameter which is validated based on the {@code paginationTokenRequired} flag.

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -699,6 +699,52 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Y describeIndexStats(Struct filter);
 
     /**
+     * Validates the parameters for a list endpoint operation.
+     *
+     * <p>It throws a {@link PineconeValidationException} if any required validation fails.</p>
+     *
+     * <p>Example</p>
+     * <pre>{@code
+     *      try {
+     *          String namespace = "example-namespace";
+     *          String prefix = "example-prefix";
+     *          String paginationToken = "token123";
+     *          Integer limit = 50;
+     *
+     *           // Indicate which parameters are required
+     *          validateListEndpointParameters(namespace, prefix, paginationToken, limit, true, true, true);
+     *
+     *          } catch (PineconeValidationException e) {
+     *           System.err.println("Validation error: " + e.getMessage());
+     *          }
+     * }</pre>
+     *
+     * @param namespace The namespace parameter which cannot be null or empty.
+     * @param prefix The prefix parameter which is validated based on the {@code prefixRequired} flag.
+     * @param paginationToken The pagination token parameter which is validated based on the {@code paginationTokenRequired} flag.
+     * @param limit The limit for the number of items, validated to be a positive integer if {@code limitRequired} is true.
+     * @param prefixRequired Specifies if the prefix parameter is required and should be validated.
+     * @param paginationTokenRequired Specifies if the pagination token parameter is required and should be validated.
+     * @param limitRequired Specifies if the limit parameter is required and should be a positive integer.
+     * @throws PineconeValidationException if any parameter fails its validation check based on its requirements.
+     */
+    default void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
+            , boolean prefixRequired, boolean paginationTokenRequired, boolean limitRequired) {
+        if (namespace == null || namespace.isEmpty()) {
+            throw new PineconeValidationException("Namespace cannot be null or empty");
+        }
+        if (prefixRequired && (prefix == null || prefix.isEmpty())) {
+            throw new PineconeValidationException("Prefix cannot be null or empty");
+        }
+        if (paginationTokenRequired && (paginationToken == null || paginationToken.isEmpty())) {
+            throw new PineconeValidationException("Pagination token cannot be null or empty");
+        }
+        if (limitRequired && (limit == null || limit <= 0)) {
+            throw new PineconeValidationException("Limit must be a positive integer");
+        }
+    }
+
+    /**
      * Retrieves up to 100 vector IDs from a given namespace.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -731,9 +731,9 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      * @param limitRequired Specifies if the limit parameter is required and should be a positive integer.
      * @throws PineconeValidationException if any parameter fails its validation check based on its requirements.
      */
-    default void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
-            , boolean namespaceRequired, boolean prefixRequired, boolean paginationTokenRequired,
-                                                boolean limitRequired) {
+    default void validateListEndpointParameters(String namespace, String prefix, String paginationToken,
+                                                Integer limit, boolean namespaceRequired, boolean prefixRequired,
+                                                boolean paginationTokenRequired, boolean limitRequired) {
         if (namespaceRequired && (namespace == null || namespace.isEmpty())) {
             throw new PineconeValidationException("Namespace cannot be null or empty");
         }

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -730,8 +730,9 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
      * @throws PineconeValidationException if any parameter fails its validation check based on its requirements.
      */
     default void validateListEndpointParameters(String namespace, String prefix, String paginationToken, Integer limit
-            , boolean prefixRequired, boolean paginationTokenRequired, boolean limitRequired) {
-        if (namespace == null || namespace.isEmpty()) {
+            ,boolean namespaceRequired , boolean prefixRequired, boolean paginationTokenRequired,
+                                                boolean limitRequired) {
+        if (namespaceRequired && (namespace == null || namespace.isEmpty())) {
             throw new PineconeValidationException("Namespace cannot be null or empty");
         }
         if (prefixRequired && (prefix == null || prefix.isEmpty())) {
@@ -744,6 +745,13 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
             throw new PineconeValidationException("Limit must be a positive integer");
         }
     }
+
+    /**
+     * Retrieves up to 100 vector IDs from an index.
+     *
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
+    Z list();
 
     /**
      * Retrieves up to 100 vector IDs from a given namespace.

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -24,6 +24,7 @@ import static io.pinecone.utils.SparseIndicesConverter.convertUnsigned32IntToSig
  * @param <W> The return type for update operations.
  * @param <X> The return type for delete operations.
  * @param <Y> The return type for describing index stats.
+ * @param <Z> The return type for listing vector IDs.
  */
 public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
 

--- a/src/test/java/io/pinecone/ListEndpointValidationTest.java
+++ b/src/test/java/io/pinecone/ListEndpointValidationTest.java
@@ -35,11 +35,8 @@ public class ListEndpointValidationTest {
         index = new Index(connectionMock, indexName);
     }
 
-    // TODO: write one for no args
-    // TODO: write ones for async
-
     @Test
-    public void testValidateSyncListNamespace() throws IOException {
+    public void testValidateListNamespace() throws IOException {
         PineconeValidationException thrownNullNamespace = assertThrows(PineconeValidationException.class, () -> {
             index.validateListEndpointParameters(null, null, null, null, true, true, true, true);
         });
@@ -49,11 +46,10 @@ public class ListEndpointValidationTest {
             index.validateListEndpointParameters("", null, null, null, true, true, true, true);
         });
         assertEquals("Namespace cannot be null or empty", thrownEmptyNamespace.getMessage());
-
     }
 
     @Test
-    public void testValidateSyncListPrefix() throws IOException {
+    public void testValidateListPrefix() throws IOException {
         PineconeValidationException thrownNullPrefix = assertThrows(PineconeValidationException.class, () -> {
             index.validateListEndpointParameters("test-namespace", null, null, null, true, true, true, true);
         });
@@ -69,7 +65,7 @@ public class ListEndpointValidationTest {
     }
 
     @Test
-    public void testValidateSyncListPagToken() throws IOException {
+    public void testValidateListPagToken() throws IOException {
         PineconeValidationException thrownNullPagToken = assertThrows(PineconeValidationException.class, () -> {
             index.validateListEndpointParameters("test-namespace", "", null, null, false, false, true, true);
         });
@@ -85,7 +81,7 @@ public class ListEndpointValidationTest {
     }
 
     @Test
-    public void testValidateSyncListLimit() throws IOException {
+    public void testValidateListLimit() throws IOException {
         PineconeValidationException thrownNegativeLimit = assertThrows(PineconeValidationException.class, () -> {
             index.validateListEndpointParameters("test-namespace", "", "", -1, false, false, false, true);
         });

--- a/src/test/java/io/pinecone/ListEndpointValidationTest.java
+++ b/src/test/java/io/pinecone/ListEndpointValidationTest.java
@@ -35,66 +35,70 @@ public class ListEndpointValidationTest {
         index = new Index(connectionMock, indexName);
     }
 
+    // TODO: write one for no args
+    // TODO: write ones for async
+
     @Test
-    public void testValidateListNamespace() throws IOException {
+    public void testValidateSyncListNamespace() throws IOException {
         PineconeValidationException thrownNullNamespace = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters(null, null, null, null, true, true, true);
+            index.validateListEndpointParameters(null, null, null, null, true, true, true, true);
         });
         assertEquals("Namespace cannot be null or empty", thrownNullNamespace.getMessage());
 
         PineconeValidationException thrownEmptyNamespace = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("", null, null, null, true, true, true);
+            index.validateListEndpointParameters("", null, null, null, true, true, true, true);
         });
         assertEquals("Namespace cannot be null or empty", thrownEmptyNamespace.getMessage());
 
     }
 
     @Test
-    public void testValidateListPrefix() throws IOException {
+    public void testValidateSyncListPrefix() throws IOException {
         PineconeValidationException thrownNullPrefix = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("test-namespace", null, null, null, true, true, true);
+            index.validateListEndpointParameters("test-namespace", null, null, null, true, true, true, true);
         });
         assertEquals("Prefix cannot be null or empty", thrownNullPrefix.getMessage());
 
         PineconeValidationException thrownEmptyPrefix = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("test-namespace", "", null, null, true, true, true);
+            index.validateListEndpointParameters("test-namespace", "", null, null, true, true, true, true);
         });
         assertEquals("Prefix cannot be null or empty", thrownEmptyPrefix.getMessage());
 
         // Confirm can pass null prefix if prefixRequired=false
-        index.validateListEndpointParameters("test-namespace", null, "someToken", 1, false, true, true);
+        index.validateListEndpointParameters("test-namespace", null, "someToken", 1, false, false, true, true);
     }
 
     @Test
-    public void testValidateListPagToken() throws IOException {
+    public void testValidateSyncListPagToken() throws IOException {
         PineconeValidationException thrownNullPagToken = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("test-namespace", "", null, null, false, true, true);
+            index.validateListEndpointParameters("test-namespace", "", null, null, false, false, true, true);
         });
         assertEquals("Pagination token cannot be null or empty", thrownNullPagToken.getMessage());
 
         PineconeValidationException thrownEmptyPagToken = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("test-namespace", "", "", null, false, true, true);
+            index.validateListEndpointParameters("test-namespace", "", "", null, false, false, true, true);
         });
         assertEquals("Pagination token cannot be null or empty", thrownEmptyPagToken.getMessage());
 
         // Confirm can pass null paginationToken if paginationToken=false
-        index.validateListEndpointParameters("test-namespace", "somePrefix", null, 1, true, false, true);
+        index.validateListEndpointParameters("test-namespace", "somePrefix", null, 1, true, true, false, true);
     }
 
     @Test
-    public void testValidateListLimit() throws IOException {
+    public void testValidateSyncListLimit() throws IOException {
         PineconeValidationException thrownNegativeLimit = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("test-namespace", "", "", -1, false, false, true);
+            index.validateListEndpointParameters("test-namespace", "", "", -1, false, false, false, true);
         });
         assertEquals("Limit must be a positive integer", thrownNegativeLimit.getMessage());
 
         PineconeValidationException thrownNullLimit = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("test-namespace", "", "", null, false, false, true);
+            index.validateListEndpointParameters("test-namespace", "", "", null, false, false, false, true);
         });
         assertEquals("Limit must be a positive integer", thrownNullLimit.getMessage());
 
         // Confirm can pass null limit if limit=false
-        index.validateListEndpointParameters("test-namespace", "somePrefix", "someToken", null, true, true, false);
+        index.validateListEndpointParameters("test-namespace", "somePrefix", "someToken", null, true, true, true,
+                false);
     }
 
 }

--- a/src/test/java/io/pinecone/ListEndpointValidationTest.java
+++ b/src/test/java/io/pinecone/ListEndpointValidationTest.java
@@ -1,64 +1,100 @@
 package io.pinecone;
 
 import io.pinecone.clients.Index;
+import io.pinecone.configs.PineconeConnection;
 import io.pinecone.exceptions.PineconeValidationException;
+import io.pinecone.proto.VectorServiceGrpc;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ListEndpointValidationTest {
-    @Test
-    public void testValidateListEndpointParameters() {
 
-        PineconeValidationException thrownNullNamespace =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters(null, null, null, null, true, true, true);
+    private String indexName;
+    private PineconeConnection connectionMock;
+    private VectorServiceGrpc.VectorServiceBlockingStub stubMock;
+    private Index index;
+
+    @BeforeAll
+    public void setUp() {
+        indexName = "test-index";
+
+        // Mock sync Pinecone connection
+        connectionMock = mock(PineconeConnection.class);
+        stubMock = mock(VectorServiceGrpc.VectorServiceBlockingStub.class);
+        when(connectionMock.getBlockingStub()).thenReturn(stubMock);
+
+        index = new Index(connectionMock, indexName);
+    }
+
+    @Test
+    public void testValidateListNamespace() throws IOException {
+        PineconeValidationException thrownNullNamespace = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters(null, null, null, null, true, true, true);
         });
         assertEquals("Namespace cannot be null or empty", thrownNullNamespace.getMessage());
 
-        PineconeValidationException thrownEmptyNamespace =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("", null, null, null, true, true, true);
+        PineconeValidationException thrownEmptyNamespace = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("", null, null, null, true, true, true);
         });
         assertEquals("Namespace cannot be null or empty", thrownEmptyNamespace.getMessage());
 
-        PineconeValidationException thrownNullPrefix =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("test-namespace", null, null, null, true, true, true);
+    }
+
+    @Test
+    public void testValidateListPrefix() throws IOException {
+        PineconeValidationException thrownNullPrefix = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("test-namespace", null, null, null, true, true, true);
         });
         assertEquals("Prefix cannot be null or empty", thrownNullPrefix.getMessage());
 
-        PineconeValidationException thrownEmptyPrefix =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("test-namespace", "", null, null, true, true, true);
+        PineconeValidationException thrownEmptyPrefix = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("test-namespace", "", null, null, true, true, true);
         });
         assertEquals("Prefix cannot be null or empty", thrownEmptyPrefix.getMessage());
 
         // Confirm can pass null prefix if prefixRequired=false
-        Index.validateListEndpointParameters("test-namespace", null, "someToken", 1, false, true, true);
+        index.validateListEndpointParameters("test-namespace", null, "someToken", 1, false, true, true);
+    }
 
-        PineconeValidationException thrownNullPagToken =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("test-namespace", "", null, null, false, true, true);
+    @Test
+    public void testValidateListPagToken() throws IOException {
+        PineconeValidationException thrownNullPagToken = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("test-namespace", "", null, null, false, true, true);
         });
         assertEquals("Pagination token cannot be null or empty", thrownNullPagToken.getMessage());
 
-        PineconeValidationException thrownEmptyPagToken =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("test-namespace", "", "", null, false, true, true);
+        PineconeValidationException thrownEmptyPagToken = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("test-namespace", "", "", null, false, true, true);
         });
         assertEquals("Pagination token cannot be null or empty", thrownEmptyPagToken.getMessage());
 
         // Confirm can pass null paginationToken if paginationToken=false
-        Index.validateListEndpointParameters("test-namespace", "somePrefix", null, 1, true, false, true);
+        index.validateListEndpointParameters("test-namespace", "somePrefix", null, 1, true, false, true);
+    }
 
-        PineconeValidationException thrownNegativeLimit =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("test-namespace", "", "", -1, false, false, true);
+    @Test
+    public void testValidateListLimit() throws IOException {
+        PineconeValidationException thrownNegativeLimit = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("test-namespace", "", "", -1, false, false, true);
         });
         assertEquals("Limit must be a positive integer", thrownNegativeLimit.getMessage());
 
-        PineconeValidationException thrownNullLimit =assertThrows(PineconeValidationException.class, () -> {
-            Index.validateListEndpointParameters("test-namespace", "", "", null, false, false, true);
+        PineconeValidationException thrownNullLimit = assertThrows(PineconeValidationException.class, () -> {
+            index.validateListEndpointParameters("test-namespace", "", "", null, false, false, true);
         });
         assertEquals("Limit must be a positive integer", thrownNullLimit.getMessage());
 
         // Confirm can pass null limit if limit=false
-        Index.validateListEndpointParameters("test-namespace", "somePrefix", "someToken", null, true, true, false);
+        index.validateListEndpointParameters("test-namespace", "somePrefix", "someToken", null, true, true, false);
     }
 
 }

--- a/src/test/java/io/pinecone/ListEndpointValidationTest.java
+++ b/src/test/java/io/pinecone/ListEndpointValidationTest.java
@@ -1,0 +1,64 @@
+package io.pinecone;
+
+import io.pinecone.clients.Index;
+import io.pinecone.exceptions.PineconeValidationException;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ListEndpointValidationTest {
+    @Test
+    public void testValidateListEndpointParameters() {
+
+        PineconeValidationException thrownNullNamespace =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters(null, null, null, null, true, true, true);
+        });
+        assertEquals("Namespace cannot be null or empty", thrownNullNamespace.getMessage());
+
+        PineconeValidationException thrownEmptyNamespace =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("", null, null, null, true, true, true);
+        });
+        assertEquals("Namespace cannot be null or empty", thrownEmptyNamespace.getMessage());
+
+        PineconeValidationException thrownNullPrefix =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("test-namespace", null, null, null, true, true, true);
+        });
+        assertEquals("Prefix cannot be null or empty", thrownNullPrefix.getMessage());
+
+        PineconeValidationException thrownEmptyPrefix =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("test-namespace", "", null, null, true, true, true);
+        });
+        assertEquals("Prefix cannot be null or empty", thrownEmptyPrefix.getMessage());
+
+        // Confirm can pass null prefix if prefixRequired=false
+        Index.validateListEndpointParameters("test-namespace", null, "someToken", 1, false, true, true);
+
+        PineconeValidationException thrownNullPagToken =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("test-namespace", "", null, null, false, true, true);
+        });
+        assertEquals("Pagination token cannot be null or empty", thrownNullPagToken.getMessage());
+
+        PineconeValidationException thrownEmptyPagToken =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("test-namespace", "", "", null, false, true, true);
+        });
+        assertEquals("Pagination token cannot be null or empty", thrownEmptyPagToken.getMessage());
+
+        // Confirm can pass null paginationToken if paginationToken=false
+        Index.validateListEndpointParameters("test-namespace", "somePrefix", null, 1, true, false, true);
+
+        PineconeValidationException thrownNegativeLimit =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("test-namespace", "", "", -1, false, false, true);
+        });
+        assertEquals("Limit must be a positive integer", thrownNegativeLimit.getMessage());
+
+        PineconeValidationException thrownNullLimit =assertThrows(PineconeValidationException.class, () -> {
+            Index.validateListEndpointParameters("test-namespace", "", "", null, false, false, true);
+        });
+        assertEquals("Limit must be a positive integer", thrownNullLimit.getMessage());
+
+        // Confirm can pass null limit if limit=false
+        Index.validateListEndpointParameters("test-namespace", "somePrefix", "someToken", null, true, true, false);
+    }
+
+}


### PR DESCRIPTION
## Problem

We need a `list` endpoint in the Java SDK to gain parity with our other SDKs. 

Asana ticket: https://app.asana.com/0/1203260648987893/1206928025656980/f

Documentation on this API endpoint: https://docs.pinecone.io/guides/data/manage-rag-documents#use-id-prefixes

## Solution

This PR enables this endpoint (generated code already provided syntax, it just was lacking implementation details in the SDK itself). 

New files: 
- `ListEndpointTest`: integration test for new endpoint
- `ListEndpointValidationTest`: unit tests for validation that occurs in new endpoint 

Updates to existing files:
- Updated `README`
- Updated `TestIndexResourcesManager`. Updates include:
    - Renamed `podIndexVectorIDs` to just `vectorIDs` so they can be used for serverless tests, too
    - Changed the content of this ^ ID list so that it contains IDs that start with different letters, in order to test the prefix filtering for the new endpoint
    - Added a `getServerlessIndexConnection` method b/c an `Index` obj is necessary to test the new endpoint (also made for `async`)
    - Made `seedIndex` accept a `namespace` parameter in order to test new endpoint + added it to the `getOrCreateServerlessIndex` method, so now that method seeds an index as well as builds one
-  Added `list` endpoint override and base methods in both `AsyncIndex.java` and`Index.java`
- Added abstract `list` definition in `IndexInterface.java` file

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

All tests locally and in GH are running successfully at the time of this writing.