### PR TITLE
Add new `build-and-publish-docs.yml` GitHub Workflow

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -8,7 +8,7 @@ inputs:
   gradle-version:
     description: 'The Gradle version to use'
     required: false
-    default: '7.3'
+    default: '6.8'
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,0 +1,27 @@
+name: 'Build client documentation'
+description: 'Generates client documentation using Javadoc'
+inputs:
+  java-version:
+    description: 'The Java version to use'
+    required: false
+    default: '8'
+  gradle-version:
+    description: 'The Gradle version to use'
+    required: false
+    default: '7.3'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+    - name: Setup Gradle
+      uses: gradle/setup-gradle@v3
+      with:
+        gradle-version: ${{ inputs.java-version }}
+    - name: Build Javadoc documentation
+      shell: bash
+      run: | 
+        gradle generateJavadoc

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -1,0 +1,38 @@
+name: 'Build and publish documentation to sdk-docs'
+
+on:
+  workflow_dispatch: {}
+  workflow_call:
+    secrets:
+      SSH_DEPLOY_KEY:
+        required: true
+
+jobs:
+  build-and-deploy-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/setup-gradle@v3
+        with:
+          gradle-version: '7.3'
+      - name: Build Javadoc documentation
+        run: gradle generateJavadoc
+      - name: Push documentation artifacts to sdk-docs
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: docs
+          destination-github-username: pinecone-io
+          destination-repository-name: sdk-docs
+          user-email: clients@pinecone.io
+          target-branch: main
+          target-directory: java
+          commit-message: "Java: automated documentation build \n\n pinecone-java-client merge SHA: ${{ github.sha }}"

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -13,17 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '8'
-      - name: Setup Gradle
-        uses: gradle/setup-gradle@v3
-        with:
-          gradle-version: '7.3'
-      - name: Build Javadoc documentation
-        run: gradle generateJavadoc
+      - name: Generate Javadoc documentation
+        uses: ./.github/actions/build-docs
       - name: Push documentation artifacts to sdk-docs
         uses: cpina/github-action-push-to-another-repository@main
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ javadoc {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-task generateJavadoc(type: Javadoc) {
+tasks.register('generateJavadoc', Javadoc) {
     source = sourceSets.main.allJava
     options.memberLevel = JavadocMemberLevel.PUBLIC
     destinationDir = file("${projectDir}/docs")


### PR DESCRIPTION
## Problem
The `pinecone-java-client` repo doesn't currently support building and pushing client reference documentation to our docs repo like the TypeScript and Python clients.

## Solution
Add new `build-and-publish-docs.yml` file to create a new workflow that allows triggering a docs build and deployment.

For now I've left this as a workflow which can be manually dispatched, or called from another workflow. We're reusing the `gradle generateJavadoc` task which was added to the `build.gradle` file previously.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
We'll need to trigger the workflow once it's in `main`.
