### PR TITLE
add getSerializedSize()

### DIFF
--- a/src/main/java/io/pinecone/unsigned_indices_model/SparseValuesWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/SparseValuesWithUnsignedIndices.java
@@ -123,4 +123,31 @@ public class SparseValuesWithUnsignedIndices {
         sb.append("}");
         return sb.toString();
     }
+
+    public int getSerializedSize() {
+        int size = 0;
+        {
+            int dataSize = 0;
+            for (int i = 0; i < indicesWithUnsigned32Int.size(); i++) {
+                dataSize += com.google.protobuf.CodedOutputStream
+                        .computeInt64SizeNoTag(indicesWithUnsigned32Int.get(i));
+            }
+            size += dataSize;
+            if (!getIndicesWithUnsigned32IntList().isEmpty()) {
+                size += 1;
+                size += com.google.protobuf.CodedOutputStream
+                        .computeInt32SizeNoTag(dataSize);
+            }
+        }
+        {
+            int dataSize = 4 * getValuesList().size();
+            size += dataSize;
+            if (!getValuesList().isEmpty()) {
+                size += 1;
+                size += com.google.protobuf.CodedOutputStream
+                        .computeInt32SizeNoTag(dataSize);
+            }
+        }
+        return size;
+    }
 }

--- a/src/main/java/io/pinecone/unsigned_indices_model/VectorWithUnsignedIndices.java
+++ b/src/main/java/io/pinecone/unsigned_indices_model/VectorWithUnsignedIndices.java
@@ -1,8 +1,12 @@
 package io.pinecone.unsigned_indices_model;
 
 import com.google.protobuf.Struct;
+import com.google.protobuf.CodedOutputStream;
 
 import java.util.List;
+
+import static com.google.protobuf.CodedOutputStream.computeTagSize;
+import static com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag;
 
 /**
  * This class represents a vector with sparse values, where the indices of the sparse values are represented
@@ -141,5 +145,30 @@ public class VectorWithUnsignedIndices {
      */
     public void setSparseValuesWithUnsignedIndices(SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices) {
         this.sparseValuesWithUnsignedIndices = sparseValuesWithUnsignedIndices;
+    }
+
+    public int getSerializedSize() {
+        int size = 0;
+        if (id != null && !id.isEmpty()) {
+            size += CodedOutputStream.computeStringSize(1, id);
+        }
+        if (values != null && !values.isEmpty()) {
+            int dataSize = 0;
+            dataSize = 4 * getValuesList().size();
+            size += dataSize;
+            if (!getValuesList().isEmpty()) {
+                size += 1;
+                size += com.google.protobuf.CodedOutputStream
+                        .computeInt32SizeNoTag(dataSize);
+            }
+        }
+        if (metadata != null) {
+            size += CodedOutputStream.computeMessageSize(3, metadata);
+        }
+        if (sparseValuesWithUnsignedIndices != null) {
+            int fieldLength = sparseValuesWithUnsignedIndices.getSerializedSize();
+            size += computeTagSize(4) + computeUInt32SizeNoTag(fieldLength) + fieldLength;
+        }
+        return size;
     }
 }

--- a/src/test/java/io/pinecone/GetSerializedSizeTest.java
+++ b/src/test/java/io/pinecone/GetSerializedSizeTest.java
@@ -1,0 +1,109 @@
+package io.pinecone;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import io.pinecone.proto.SparseValues;
+import io.pinecone.proto.Vector;
+import io.pinecone.unsigned_indices_model.SparseValuesWithUnsignedIndices;
+import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GetSerializedSizeTest {
+
+    @Test
+    public void testGetSerializedSize_WithIdAndValues() {
+        String id = "v1";
+        List<Float> values = Arrays.asList(1f, 2f, 3f);
+
+        Vector vector = Vector.newBuilder()
+                .setId(id)
+                .addAllValues(values)
+                .build();
+        VectorWithUnsignedIndices vectorWithUnsignedIndices = new VectorWithUnsignedIndices(id,
+                Arrays.asList(1f, 2f, 3f));
+
+        int expectedSize = vector.getSerializedSize();
+        int actualSize = vectorWithUnsignedIndices.getSerializedSize();
+
+        assertEquals(expectedSize, actualSize);
+    }
+
+    @Test
+    public void testGetSerializedSize_EmptyVector() {
+        Vector vector = Vector.newBuilder().build();
+        VectorWithUnsignedIndices vectorWithUnsignedIndices = new VectorWithUnsignedIndices();
+
+        int expectedSize = vector.getSerializedSize();
+        int actualSize = vectorWithUnsignedIndices.getSerializedSize();
+
+        assertEquals(expectedSize, actualSize);
+    }
+
+    @Test
+    public void testGetSerializedSize_WithMetadata() {
+        String id = "v1";
+        List<Float> values = Arrays.asList(1f, 2f, 3f);
+
+        Struct.Builder metadataBuilder = Struct.newBuilder();
+
+        for(int i=0; i<1500; i++) {
+            metadataBuilder.putFields("somerandomfield" + i, Value.newBuilder().setStringValue("thriller").build());
+        }
+
+        Vector vector = Vector.newBuilder()
+                .setId(id).
+                addAllValues(values).
+                setMetadata(metadataBuilder.build())
+                .build();
+
+        VectorWithUnsignedIndices vectorWithUnsignedIndices = new VectorWithUnsignedIndices(id,
+                values,
+                metadataBuilder.build(),
+                null);
+
+        int expectedSize = vector.getSerializedSize();
+        int actualSize = vectorWithUnsignedIndices.getSerializedSize();
+
+        assertEquals(expectedSize, actualSize);
+    }
+
+    @Test
+    public void testGetSerializedSize_WithSparseValues() {
+        String id = "v1";
+        List<Float> values = Arrays.asList(1f, 2f, 3f);
+        Struct metadata = Struct.newBuilder()
+                .putFields("genre", Value.newBuilder().setStringValue("thriller").build())
+                .putFields("year", Value.newBuilder().setNumberValue(2020).build())
+                .build();
+        List<Long> unsignedSparseIndices = Arrays.asList(1L, 2L, 3L);
+        SparseValues sparseValues = SparseValues.newBuilder()
+                .addAllIndices(Arrays.asList(1, 2, 3))
+                .addAllValues(values)
+                .build();
+
+        SparseValuesWithUnsignedIndices sparseValuesWithUnsignedIndices = new SparseValuesWithUnsignedIndices(unsignedSparseIndices, values);
+
+        Vector vector = Vector.newBuilder()
+                .setId(id)
+                .addAllValues(values)
+                .setMetadata(metadata)
+                .setSparseValues(sparseValues)
+                .build();
+
+        VectorWithUnsignedIndices vectorWithUnsignedIndices = new VectorWithUnsignedIndices(id,
+                values,
+                metadata,
+                sparseValuesWithUnsignedIndices);
+
+        int expectedSize = vector.getSerializedSize();
+        int actualSize = vectorWithUnsignedIndices.getSerializedSize();
+
+        assertEquals(expectedSize, actualSize);
+    }
+}


### PR DESCRIPTION
## Problem

`SparseValuesWithUnsignedIndices` and `VectorWithUnsignedIndices` classes reflect proto generated classes `SparseValues` and `Vector` respectively. The proto generated classes contains the `getSerializedSize()` while the user generated classes currently lacks this method which is needed in Pinecone-Spark SDK. The method outputs the serialized size in bytes of the object. 

## Solution

Add getSerializedSize() for `SparseValuesWithUnsignedIndices` and `VectorWithUnsignedIndices` classes.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

Add unit tests
