### PR TITLE
Remove serverless public preview warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,8 @@ You can use the Java SDK to create two types of indexes: [serverless indexes](ht
 [pod-based indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes#pod-based-indexes) (recommended for high-throughput use cases).
 
 ### Create a serverless index
-
-> [!WARNING]  
-> Serverless indexes are in **public preview** and are available only on AWS in the
-> `us-east-1` and `us-west-2` regions. Check the [current limitations](https://docs.pinecone.io/docs/limits#serverless-index-limitations) and test thoroughly before using it in production.
+The following is an example of creating a serverless index in the `us-west-2` region of AWS. For more information on 
+serverless and regional availability, see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes).
 
 ```java
 import io.pinecone.clients.Pinecone;


### PR DESCRIPTION
## Problem
The serverless public preview warnings are still in the clients' documentation from earlier in the year. Since we've expanded the number of regions available, we should update these.

## Solution
Update the "Create a serverless index" example in the README to link to the serverless documentation page.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI, run the client reference action after merged to main to update reference docs.
