### PR TITLE
Fix `setup-gradle` step in `build-docs` action

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -18,7 +18,7 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
-      uses: gradle/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: ${{ inputs.java-version }}
     - name: Build Javadoc documentation


### PR DESCRIPTION
## Problem
I added a new action and workflow for building and generating client reference docs. Upon running the workflow, I realized I forgot the `/actions/` part of the `setup-gradle` action. 🤦‍♂️ 

https://github.com/pinecone-io/pinecone-java-client/actions/runs/9020304652/job/24785162144

## Solution
Update the `uses` field for the `Setup Gradle` step to point at the proper external action.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Try re-running the action once it's pushed to main
