### PR TITLE
Use correct input for `gradle-version`

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
-        gradle-version: ${{ inputs.java-version }}
+        gradle-version: ${{ inputs.gradle-version }}
     - name: Build Javadoc documentation
       shell: bash
       run: | 


### PR DESCRIPTION
## Problem
I didn't use `inputs.gradle-version` I used `inputs.java-version`.

## Solution
Use the correct version.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
