### PR TITLE
Added ApiException as a cause to mapHttpStatusError

### DIFF
--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -791,7 +791,7 @@ public class Pinecone {
         int statusCode = apiException.getCode();
         String responseBody = apiException.getResponseBody();
         FailedRequestInfo failedRequestInfo = new FailedRequestInfo(statusCode, responseBody);
-        HttpErrorMapper.mapHttpStatusError(failedRequestInfo);
+        HttpErrorMapper.mapHttpStatusError(failedRequestInfo, apiException);
     }
 
 

--- a/src/main/java/io/pinecone/exceptions/HttpErrorMapper.java
+++ b/src/main/java/io/pinecone/exceptions/HttpErrorMapper.java
@@ -1,24 +1,27 @@
 package io.pinecone.exceptions;
 
+import org.openapitools.client.ApiException;
+
 public class HttpErrorMapper {
 
-    public static void mapHttpStatusError(FailedRequestInfo failedRequestInfo) throws PineconeException {
+    public static void mapHttpStatusError(FailedRequestInfo failedRequestInfo,
+                                          ApiException apiException) throws PineconeException {
         int statusCode = failedRequestInfo.getStatus();
         switch (statusCode) {
             case 400:
-                throw new PineconeBadRequestException(failedRequestInfo.getMessage());
+                throw new PineconeBadRequestException(failedRequestInfo.getMessage(), apiException);
             case 401:
-                throw new PineconeAuthorizationException(failedRequestInfo.getMessage());
+                throw new PineconeAuthorizationException(failedRequestInfo.getMessage(), apiException);
             case 403:
-                throw new PineconeForbiddenException(failedRequestInfo.getMessage());
+                throw new PineconeForbiddenException(failedRequestInfo.getMessage(), apiException);
             case 404:
-                throw new PineconeNotFoundException(failedRequestInfo.getMessage());
+                throw new PineconeNotFoundException(failedRequestInfo.getMessage(), apiException);
             case 409:
-                throw new PineconeAlreadyExistsException(failedRequestInfo.getMessage());
+                throw new PineconeAlreadyExistsException(failedRequestInfo.getMessage(), apiException);
             case 500:
-                throw new PineconeInternalServerException(failedRequestInfo.getMessage());
+                throw new PineconeInternalServerException(failedRequestInfo.getMessage(), apiException);
             default:
-                throw new PineconeUnmappedHttpException(failedRequestInfo.getMessage());
+                throw new PineconeUnmappedHttpException(failedRequestInfo.getMessage(), apiException);
         }
     }
 }


### PR DESCRIPTION
## Problem

When the request fails before sending a request / receiving an HTTP response, the exception cause is ignored, and the client returns an empty error message:
```
Caused by: io.pinecone.exceptions.PineconeUnmappedHttpException: null
	at io.pinecone.exceptions.HttpErrorMapper.mapHttpStatusError(HttpErrorMapper.java:21)
	at io.pinecone.clients.Pinecone.handleApiException(Pinecone.java:794)
	at io.pinecone.clients.Pinecone.describeIndex(Pinecone.java:441) 
``` 

## Solution

Added the apiException as the cause HttpErrorMapper.mapHttpStatusError to make debugging easier.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

not required
