### PR TITLE
Fix `generateJavadoc` errors so we can run in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,8 @@ javadoc {
 
 tasks.register('generateJavadoc', Javadoc) {
     source = sourceSets.main.allJava
+    classpath += configurations.runtimeClasspath
+    options.addStringOption('tag', 'http.response.details:a:Http Response Details')
     options.memberLevel = JavadocMemberLevel.PUBLIC
     destinationDir = file("${projectDir}/docs")
 }


### PR DESCRIPTION
## Problem
When we run the `generateJavadoc` command on the codebase we get 40 errors and 100 warnings. The errors cause the task to fail which means it bails in CI even though it's ultimately generating the `/docs` folder.

## Solution
Add a few config lines to the `generateJavadoc` task in `build.gradle`:
- `classpath += configurations.runtimeClasspath` - makes sure we're pulling in dependencies that may be linked to in documentation
- `options.addStringOption('tag', 'http.response.details:a:Http Response Details')` - there are custom `@http-` tags in the docstrings of some generated code. Those need to be included as options to prevent errors from being generated.

| Before | After |
|-----|-----|
|<img width="370" alt="Screenshot 2024-05-10 at 2 43 45 PM" src="https://github.com/pinecone-io/pinecone-java-client/assets/119623786/ea091710-0104-40d8-bc7c-70969bf803a3">|![Screenshot 2024-05-10 at 2 43 31 PM](https://github.com/pinecone-io/pinecone-java-client/assets/119623786/c1961b5a-3b93-4674-92a3-9a9e9adb83a5)|

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Re-run the workflow once this is in `main`. It failed last time but only because of the exist code of the task itself, which this should resolve: https://github.com/pinecone-io/pinecone-java-client/actions/runs/9025007222/job/24799938489
