### PR TITLE
Add additional list functions to reach parity with RESTful list requests

### DIFF
--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -45,6 +45,7 @@ public class ListEndpointTest {
 
         // Confirm all vector IDs from custom namespace are returned when pass customNamespace
         ListResponse listResponseCustomNamespace = indexConnection.list(customNamespace);
+        assertEquals(listResponseCustomNamespace.getVectorsList().size(), 4);
         assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-id1"));
         assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-id2"));
         assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id3"));
@@ -59,6 +60,23 @@ public class ListEndpointTest {
         // Confirm all vector IDs from custom namespace are returned when limit is specified
         ListResponse listResponseWithLimit = indexConnection.list(customNamespace, 1);
         assertEquals(1, listResponseWithLimit.getVectorsList().size());
+
+        // Confirm all vector IDs from custom namespace are returned using pagination
+        ListResponse listResponseWithPaginationNoPrefix1 = indexConnection.list(customNamespace, 2);
+        assertEquals(listResponseWithPaginationNoPrefix1.getVectorsList().size(), 2);
+        ListResponse listResponseWithPaginationNoPrefix2 = indexConnection.list(
+                customNamespace,
+                2,
+                listResponseWithPaginationNoPrefix1.getPagination().getNext()
+        );
+        assertEquals(listResponseWithPaginationNoPrefix2.getVectorsList().size(), 2);
+        ListResponse listResponseWithPaginationNoPrefix3 = indexConnection.list(
+                customNamespace,
+                2,
+                listResponseWithPaginationNoPrefix2.getPagination().getNext()
+        );
+        assertEquals(listResponseWithPaginationNoPrefix3.getVectorsList().size(), 0);
+        assertEquals(listResponseWithPaginationNoPrefix3.getPagination().getNext(), "");
     }
 
     @Test
@@ -92,6 +110,26 @@ public class ListEndpointTest {
         ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list(customNamespace, 1);
         ListResponse asyncListResponseWithLimit = Futures.getUnchecked(futureResponseWithLimit);
         assertEquals(1, asyncListResponseWithLimit.getVectorsList().size());
+
+        // Confirm all vector IDs from custom namespace are returned using pagination
+        ListenableFuture<ListResponse> futureResponseWithPaginationNoPrefix1 = asyncIndexConnection.list(customNamespace, 2);
+        ListResponse asyncListResponseWithPaginationNoPrefix1 = Futures.getUnchecked(futureResponseWithPaginationNoPrefix1);
+        assertEquals(asyncListResponseWithPaginationNoPrefix1.getVectorsList().size(), 2);
+        ListenableFuture<ListResponse> futureResponseWithPaginationNoPrefix2 = asyncIndexConnection.list(
+                customNamespace,
+                2,
+                asyncListResponseWithPaginationNoPrefix1.getPagination().getNext()
+        );
+        ListResponse asyncListResponseWithPaginationNoPrefix2 = Futures.getUnchecked(futureResponseWithPaginationNoPrefix2);
+        assertEquals(asyncListResponseWithPaginationNoPrefix2.getVectorsList().size(), 2);
+        ListenableFuture<ListResponse> futureResponseWithPaginationNoPrefix3 = asyncIndexConnection.list(
+                customNamespace,
+                2,
+                asyncListResponseWithPaginationNoPrefix2.getPagination().getNext()
+        );
+        ListResponse asyncListResponseWithPaginationNoPrefix3 = Futures.getUnchecked(futureResponseWithPaginationNoPrefix3);
+        assertEquals(asyncListResponseWithPaginationNoPrefix3.getVectorsList().size(), 0);
+        assertEquals(asyncListResponseWithPaginationNoPrefix3.getPagination().getNext(), "");
     }
 
 }

--- a/src/main/java/io/pinecone/clients/AsyncIndex.java
+++ b/src/main/java/io/pinecone/clients/AsyncIndex.java
@@ -894,6 +894,25 @@ public class AsyncIndex implements IndexInterface<ListenableFuture<UpsertRespons
 
     /**
      * {@inheritDoc}
+     * <p>Example:
+     *  <pre>{@code
+     *     import io.pinecone.proto.ListResponse;
+     *
+     *     ...
+     *
+     *     ListenableFuture<ListResponse> futureResponse = asyncIndex.list("example-namespace", 10, "some-pagToken");
+     *     ListResponse asyncListResponse = Futures.getUnchecked(futureResponse);
+     *  }</pre>
+     */
+    @Override
+    public ListenableFuture<ListResponse> list(String namespace, int limit, String paginationToken) {
+        validateListEndpointParameters(namespace, null, paginationToken, limit, true, false, true, true);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).setPaginationToken(paginationToken).build();
+        return asyncStub.list(listRequest);
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * <p>Example:
      *  <pre>{@code

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -830,7 +830,7 @@ public class Index implements IndexInterface<UpsertResponse,
      */
     @Override
     public ListResponse list(String namespace, int limit, String paginationToken) {
-        validateListEndpointParameters(namespace, null, paginationToken, null, true, false, true, true);
+        validateListEndpointParameters(namespace, null, paginationToken, limit, true, false, true, true);
         ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).setPaginationToken(paginationToken).build();
         return blockingStub.list(listRequest);
     }

--- a/src/main/java/io/pinecone/clients/Index.java
+++ b/src/main/java/io/pinecone/clients/Index.java
@@ -825,6 +825,24 @@ public class Index implements IndexInterface<UpsertResponse,
      *
      *     ...
      *
+     *     ListResponse listResponse = index.list("example-namespace", 10, "some-pagToken");
+     *  }</pre>
+     */
+    @Override
+    public ListResponse list(String namespace, int limit, String paginationToken) {
+        validateListEndpointParameters(namespace, null, paginationToken, null, true, false, true, true);
+        ListRequest listRequest = ListRequest.newBuilder().setNamespace(namespace).setLimit(limit).setPaginationToken(paginationToken).build();
+        return blockingStub.list(listRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>Example:
+     *  <pre>{@code
+     *     import io.pinecone.proto.ListResponse;
+     *
+     *     ...
+     *
      *     ListResponse listResponse = index.list("example-namespace", 10);
      *  }</pre>
      */

--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -764,6 +764,17 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     Z list(String namespace);
 
     /**
+     * Retrieves up to {@code n} vector IDs from a given namespace, targeted with a specific
+     * paginationToken, where {@code limit} == {@code n}.
+     *
+     * @param namespace The namespace that holds the vector IDs you want to retrieve.
+     * @param limit The maximum number of vector IDs to retrieve.
+     * @param paginationToken The token to paginate through the list of vector IDs.
+     * @return A generic type {@code Y} that contains vector IDs.
+     */
+    Z list(String namespace, int limit, String paginationToken);
+
+    /**
      * Retrieves up to {@code n} vector IDs from a given namespace, where {@code limit} == {@code n}.
      *
      * @param namespace The namespace that holds the vector IDs you want to retrieve.


### PR DESCRIPTION
## Problem

https://github.com/pinecone-io/pinecone-java-client/issues/126

## Solution

With REST, we are currently able to list vectors without a prefix but with a pagination token.
This is not currently available with v1 of the pinecone-java-client.

With this PR, we have added a function list with a pagination token and limit but no prefix.
