### PR TITLE
Shadow META-INF directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,13 @@ task relocateShadowJar(type: ConfigureShadowRelocation) {
 
 tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
+// Shadow META-INF directory
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
+
+shadowJar {
+    transform(ServiceFileTransformer)
+}
+
 publishing {
     publications {
         pineconeClientMaven(MavenPublication) {


### PR DESCRIPTION
## Problem

[META-INF directory](https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#The_META-INF_directory) contains NameResolverProvider which wasn't shaded but the provider is used by gRPC to resolve the host and it causes the following error:
```
io.pinecone.shadow.io.grpc.NameResolverRegistry getDefaultRegistry
WARNING: No NameResolverProviders found via ServiceLoader, including for DNS. This is probably due to a broken build. If using ProGuard, check your configuration
Exception in thread "main" java.lang.IllegalArgumentException: Could not find a NameResolverProvider for index-name-somehost.pinecone.io
```

## Solution

Use ServiceFileTransformer provided by `com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer` to shadow the `META-INF/services` directory. Note the difference between the file name (the prefix `io.pinecone.shadow`) and the content of `NameResolverProvider`:

Before shadowing the `META-INF/services`, it contained the file `io.grpc.NameResolverProvider`:
```
io.grpc.netty.UdsNameResolverProvider
```

After shadowing the `META-INF/services` directory, the file is now named `io.pinecone.shadow.io.grpc.NameResolverProvider` and contains:
```
io.pinecone.shadow.io.grpc.netty.UdsNameResolverProvider
io.pinecone.shadow.io.grpc.internal.DnsNameResolverProvider
```

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Published and imported the uber jar locally in a maven project (as shown below) and successfully upserted data.
```
  <dependencies>
    <dependency>
      <groupId>io.pinecone</groupId>
      <artifactId>pinecone-client</artifactId>
      <version>1.2.1</version>
      <classifier>all</classifier>
    </dependency>
  </dependencies>
```
