### PR TITLE
Add proxy configuration for OkHTTPClient and NettyChannelBuilder 

### DIFF
--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -49,6 +49,10 @@ public class Pinecone {
         this.manageIndexesApi = manageIndexesApi;
     }
 
+    public PineconeConfig getConfig() {
+        return config;
+    }
+
     /**
      * Creates a new serverless index with the specified parameters.
      * <p>

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -807,8 +807,7 @@ public class Pinecone {
 
         // Optional fields
         private String sourceTag;
-        private ProxyConfig controlPlaneProxyConfig;
-        private ProxyConfig dataPlaneProxyConfig;
+        private ProxyConfig proxyConfig;
         private final OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
         private OkHttpClient customOkHttpClient = new OkHttpClient();
         private boolean isCustomOkHttpClient = false;
@@ -909,8 +908,7 @@ public class Pinecone {
          * @return This {@link Builder} instance for chaining method calls.
          */
         public Builder withProxy(String proxyHost, int proxyPort) {
-            this.controlPlaneProxyConfig = new ProxyConfig(proxyHost, proxyPort);
-            this.dataPlaneProxyConfig = new ProxyConfig(proxyHost, proxyPort);
+            this.proxyConfig = new ProxyConfig(proxyHost, proxyPort);
             Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
             okHttpClientBuilder.proxy(proxy);
             return this;
@@ -926,7 +924,7 @@ public class Pinecone {
          * @return A new {@link Pinecone} instance configured based on the builder parameters.
          */
         public Pinecone build() {
-            PineconeConfig config = new PineconeConfig(apiKey, sourceTag, controlPlaneProxyConfig, dataPlaneProxyConfig);
+            PineconeConfig config = new PineconeConfig(apiKey, sourceTag, proxyConfig);
             config.validate();
 
             ApiClient apiClient = (isCustomOkHttpClient) ? new ApiClient(customOkHttpClient) : new ApiClient(okHttpClientBuilder.build());

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -879,10 +879,10 @@ public class Pinecone {
         }
 
         /**
-         * Sets a proxy for the Pinecone client to use for control plane requests.
+         * Sets a proxy for the Pinecone client to use for control and data plane requests.
          * <p>
-         * When a proxy is configured using this method, all control plane requests made by the Pinecone client will be routed
-         * through the specified proxy server.
+         * When a proxy is configured using this method, all control and data plane requests made by the Pinecone client
+         * will be routed through the specified proxy server.
          * <p>
          * It's important to note that both proxyHost and proxyPort parameters should be provided to establish
          * the connection to the proxy server.
@@ -893,41 +893,11 @@ public class Pinecone {
          * String proxyHost = System.getenv("PROXY_HOST");
          * int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));
          * Pinecone pinecone = new Pinecone.Builder("PINECONE_API_KEY")
-         *     .withControlPlaneProxy(proxyHost, proxyPort)
+         *     .withProxy(proxyHost, proxyPort)
          *     .build();
          *
          * // Network requests for control plane operations will now be made using the specified proxy.
          * pinecone.listIndexes();
-         * }</pre>
-         *
-         * @param proxyHost The hostname or IP address of the proxy server. Must not be null.
-         * @param proxyPort The port number of the proxy server. Must not be null.
-         * @return This {@link Builder} instance for chaining method calls.
-         */
-        public Builder withControlPlaneProxy(String proxyHost, int proxyPort) {
-            this.controlPlaneProxyConfig = new ProxyConfig(proxyHost, proxyPort);
-            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
-            okHttpClientBuilder.proxy(proxy);
-            return this;
-        }
-
-        /**
-         * Sets a proxy for the Pinecone client to use for data plane requests.
-         * <p>
-         * When a proxy is configured using this method, all data plane requests made by the Pinecone client will be routed
-         * through the specified proxy server.
-         * <p>
-         * It's important to note that both the proxyHost and proxyPort parameters should be provided to establish
-         * the connection to the proxy server.
-         * <p>
-         * Example usage:
-         * <pre>{@code
-         *
-         * String proxyHost = System.getenv("PROXY_HOST");
-         * int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));
-         * Pinecone pinecone = new Pinecone.Builder("PINECONE_API_KEY")
-         *     .withDataPlaneProxy(proxyHost, proxyPort)
-         *     .build();
          *
          * // Network requests for data plane operations will now be made using the specified proxy.
          * Index index = pinecone.getIndexConnection("PINECONE_INDEX");
@@ -938,8 +908,11 @@ public class Pinecone {
          * @param proxyPort The port number of the proxy server. Must not be null.
          * @return This {@link Builder} instance for chaining method calls.
          */
-        public Builder withDataPlaneProxy(String proxyHost, int proxyPort) {
+        public Builder withProxy(String proxyHost, int proxyPort) {
+            this.controlPlaneProxyConfig = new ProxyConfig(proxyHost, proxyPort);
             this.dataPlaneProxyConfig = new ProxyConfig(proxyHost, proxyPort);
+            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+            okHttpClientBuilder.proxy(proxy);
             return this;
         }
 

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -891,7 +891,7 @@ public class Pinecone {
          * <pre>{@code
          *
          * String proxyHost = System.getenv("PROXY_HOST");
-         * String proxyPort = System.getenv("PROXY_PORT");
+         * int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));
          * Pinecone pinecone = new Pinecone.Builder("PINECONE_API_KEY")
          *     .withControlPlaneProxy(proxyHost, proxyPort)
          *     .build();
@@ -924,7 +924,7 @@ public class Pinecone {
          * <pre>{@code
          *
          * String proxyHost = System.getenv("PROXY_HOST");
-         * String proxyPort = System.getenv("PROXY_PORT");
+         * int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));
          * Pinecone pinecone = new Pinecone.Builder("PINECONE_API_KEY")
          *     .withDataPlaneProxy(proxyHost, proxyPort)
          *     .build();

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -6,7 +6,7 @@ import io.pinecone.exceptions.PineconeConfigurationException;
 /**
  * The {@link PineconeConfig} class is responsible for managing the configuration settings
  * required to interact with the Pinecone API. It provides methods to set and retrieve
- * the necessary API key, host, source tag, and custom managed channel.
+ * the necessary API key, host, source tag, controlPlaneProxyConfig, dataPlaneProxyConfig, and custom managed channel.
  * <pre>{@code
  *
  *     import io.grpc.ManagedChannel;
@@ -48,6 +48,8 @@ public class PineconeConfig {
     // Optional fields
     private String host;
     private String sourceTag;
+    private ProxyConfig controlPlaneProxyConfig;
+    private ProxyConfig dataPlaneProxyConfig;
     private ManagedChannel customManagedChannel;
 
     /**
@@ -66,8 +68,24 @@ public class PineconeConfig {
      * @param sourceTag An optional source tag to be included in the user agent.
      */
     public PineconeConfig(String apiKey, String sourceTag) {
+        // ToDo: add a test for null proxyConfig
+        this(apiKey, sourceTag, null, null);
+    }
+
+    /**
+     * Constructs a {@link PineconeConfig} instance with the specified API key, source tag, control plane proxy
+     * configuration, and data plane proxy configuration.
+     *
+     * @param apiKey                    The API key required to authenticate with the Pinecone API.
+     * @param sourceTag                 An optional source tag to be included in the user agent.
+     * @param controlPlaneProxyConfig   The proxy configuration for control plane requests. Can be null if not set.
+     * @param dataPlaneProxyConfig      The proxy configuration for data plane requests. Can be null if not set.
+     */
+    public PineconeConfig(String apiKey, String sourceTag, ProxyConfig controlPlaneProxyConfig, ProxyConfig dataPlaneProxyConfig) {
         this.apiKey = apiKey;
         this.sourceTag = sourceTag;
+        this.controlPlaneProxyConfig = controlPlaneProxyConfig;
+        this.dataPlaneProxyConfig = dataPlaneProxyConfig;
     }
 
     /**
@@ -125,6 +143,42 @@ public class PineconeConfig {
     }
 
     /**
+     * Returns the proxy configuration for control plane requests.
+     *
+     * @return The proxy configuration for control plane requests, or null if not set.
+     */
+    public ProxyConfig getControlPlaneProxyConfig() {
+        return controlPlaneProxyConfig;
+    }
+
+    /**
+     * Sets the proxy configuration for control plane requests.
+     *
+     * @param controlPlaneProxyConfig The new proxy configuration for control plane requests.
+     */
+    public void setControlPlaneProxyConfig(ProxyConfig controlPlaneProxyConfig) {
+        this.controlPlaneProxyConfig = controlPlaneProxyConfig;
+    }
+
+    /**
+     * Returns the proxy configuration for data plane requests.
+     *
+     * @return The proxy configuration for data plane requests, or null if not set.
+     */
+    public ProxyConfig getDataPlaneProxyConfig() {
+        return dataPlaneProxyConfig;
+    }
+
+    /**
+     * Sets the proxy configuration for data plane requests.
+     *
+     * @param dataPlaneProxyConfig The new proxy configuration for data plane requests.
+     */
+    public void setDataPlaneProxyConfig(ProxyConfig dataPlaneProxyConfig) {
+        this.dataPlaneProxyConfig = dataPlaneProxyConfig;
+    }
+
+    /**
      * Returns the custom gRPC managed channel.
      *
      * @return The custom gRPC managed channel.
@@ -148,13 +202,24 @@ public class PineconeConfig {
     }
 
     /**
-     * Validates the configuration, ensuring that the API key is not null or empty.
+     * Validates the configuration settings of the Pinecone client.
+     * This method ensures that the API key is not null or empty, and validates the proxy configurations if set.
+     * Throws a PineconeConfigurationException if the API key is null or empty, or if any of the proxy configurations are invalid.
      *
-     * @throws PineconeConfigurationException if the API key is null or empty.
+     * @throws PineconeConfigurationException If the API key is null or empty, or if any of the proxy configurations are invalid.
      */
     public void validate() {
         if (apiKey == null || apiKey.isEmpty())
             throw new PineconeConfigurationException("The API key is required and must not be empty or null");
+
+        // proxyConfig is set to null by default indicating the user is not interested in configuring the proxy
+        if(controlPlaneProxyConfig != null) {
+            controlPlaneProxyConfig.validate();
+        }
+
+        if(dataPlaneProxyConfig != null) {
+            dataPlaneProxyConfig.validate();
+        }
     }
 
     /**

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -67,7 +67,6 @@ public class PineconeConfig {
      * @param sourceTag An optional source tag to be included in the user agent.
      */
     public PineconeConfig(String apiKey, String sourceTag) {
-        // ToDo: add a test for null proxyConfig
         this(apiKey, sourceTag, null);
     }
 
@@ -75,9 +74,9 @@ public class PineconeConfig {
      * Constructs a {@link PineconeConfig} instance with the specified API key, source tag, control plane proxy
      * configuration, and data plane proxy configuration.
      *
-     * @param apiKey                    The API key required to authenticate with the Pinecone API.
-     * @param sourceTag                 An optional source tag to be included in the user agent.
-     * @param proxyConfig   The proxy configuration for control and data plane requests. Can be null if not set.
+     * @param apiKey The API key required to authenticate with the Pinecone API.
+     * @param sourceTag An optional source tag to be included in the user agent.
+     * @param proxyConfig The proxy configuration for control and data plane requests. Can be null if not set.
      */
     public PineconeConfig(String apiKey, String sourceTag, ProxyConfig proxyConfig) {
         this.apiKey = apiKey;

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -6,7 +6,7 @@ import io.pinecone.exceptions.PineconeConfigurationException;
 /**
  * The {@link PineconeConfig} class is responsible for managing the configuration settings
  * required to interact with the Pinecone API. It provides methods to set and retrieve
- * the necessary API key, host, source tag, controlPlaneProxyConfig, dataPlaneProxyConfig, and custom managed channel.
+ * the necessary API key, host, source tag, proxyConfig, and custom managed channel.
  * <pre>{@code
  *
  *     import io.grpc.ManagedChannel;
@@ -48,8 +48,7 @@ public class PineconeConfig {
     // Optional fields
     private String host;
     private String sourceTag;
-    private ProxyConfig controlPlaneProxyConfig;
-    private ProxyConfig dataPlaneProxyConfig;
+    private ProxyConfig proxyConfig;
     private ManagedChannel customManagedChannel;
 
     /**
@@ -69,7 +68,7 @@ public class PineconeConfig {
      */
     public PineconeConfig(String apiKey, String sourceTag) {
         // ToDo: add a test for null proxyConfig
-        this(apiKey, sourceTag, null, null);
+        this(apiKey, sourceTag, null);
     }
 
     /**
@@ -78,14 +77,12 @@ public class PineconeConfig {
      *
      * @param apiKey                    The API key required to authenticate with the Pinecone API.
      * @param sourceTag                 An optional source tag to be included in the user agent.
-     * @param controlPlaneProxyConfig   The proxy configuration for control plane requests. Can be null if not set.
-     * @param dataPlaneProxyConfig      The proxy configuration for data plane requests. Can be null if not set.
+     * @param proxyConfig   The proxy configuration for control and data plane requests. Can be null if not set.
      */
-    public PineconeConfig(String apiKey, String sourceTag, ProxyConfig controlPlaneProxyConfig, ProxyConfig dataPlaneProxyConfig) {
+    public PineconeConfig(String apiKey, String sourceTag, ProxyConfig proxyConfig) {
         this.apiKey = apiKey;
         this.sourceTag = sourceTag;
-        this.controlPlaneProxyConfig = controlPlaneProxyConfig;
-        this.dataPlaneProxyConfig = dataPlaneProxyConfig;
+        this.proxyConfig = proxyConfig;
     }
 
     /**
@@ -143,39 +140,21 @@ public class PineconeConfig {
     }
 
     /**
-     * Returns the proxy configuration for control plane requests.
+     * Returns the proxy configuration for control and data plane requests.
      *
-     * @return The proxy configuration for control plane requests, or null if not set.
+     * @return The proxy configuration for control and data plane requests, or null if not set.
      */
-    public ProxyConfig getControlPlaneProxyConfig() {
-        return controlPlaneProxyConfig;
+    public ProxyConfig getProxyConfig() {
+        return proxyConfig;
     }
 
     /**
-     * Sets the proxy configuration for control plane requests.
+     * Sets the proxy configuration for control and data plane requests.
      *
-     * @param controlPlaneProxyConfig The new proxy configuration for control plane requests.
+     * @param proxyConfig The new proxy configuration for control and data plane requests.
      */
-    public void setControlPlaneProxyConfig(ProxyConfig controlPlaneProxyConfig) {
-        this.controlPlaneProxyConfig = controlPlaneProxyConfig;
-    }
-
-    /**
-     * Returns the proxy configuration for data plane requests.
-     *
-     * @return The proxy configuration for data plane requests, or null if not set.
-     */
-    public ProxyConfig getDataPlaneProxyConfig() {
-        return dataPlaneProxyConfig;
-    }
-
-    /**
-     * Sets the proxy configuration for data plane requests.
-     *
-     * @param dataPlaneProxyConfig The new proxy configuration for data plane requests.
-     */
-    public void setDataPlaneProxyConfig(ProxyConfig dataPlaneProxyConfig) {
-        this.dataPlaneProxyConfig = dataPlaneProxyConfig;
+    public void setProxyConfig(ProxyConfig proxyConfig) {
+        this.proxyConfig = proxyConfig;
     }
 
     /**
@@ -213,12 +192,8 @@ public class PineconeConfig {
             throw new PineconeConfigurationException("The API key is required and must not be empty or null");
 
         // proxyConfig is set to null by default indicating the user is not interested in configuring the proxy
-        if(controlPlaneProxyConfig != null) {
-            controlPlaneProxyConfig.validate();
-        }
-
-        if(dataPlaneProxyConfig != null) {
-            dataPlaneProxyConfig.validate();
+        if(proxyConfig != null) {
+            proxyConfig.validate();
         }
     }
 

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -107,21 +107,6 @@ public class PineconeConnection implements AutoCloseable {
     }
 
     /**
-     * Close the connection and release all resources. A PineconeConnection's underlying gRPC components use resources
-     * like threads and TCP connections. To prevent leaking these resources the connection should be closed when it
-     * will no longer be used. If it may be used again leave it running.
-     */
-    @Override
-    public void close() {
-        try {
-            logger.debug("closing channel");
-            channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            logger.warn("Channel shutdown interrupted before termination confirmed");
-        }
-    }
-
-    /**
      * Returns the gRPC channel.
      */
     public ManagedChannel getChannel() {
@@ -193,6 +178,21 @@ public class PineconeConnection implements AutoCloseable {
             return host.replaceFirst("https?://", "");
         } else {
             throw new PineconeValidationException("Index host cannot be null or empty");
+        }
+    }
+
+    /**
+     * Close the connection and release all resources. A PineconeConnection's underlying gRPC components use resources
+     * like threads and TCP connections. To prevent leaking these resources the connection should be closed when it
+     * will no longer be used. If it may be used again leave it running.
+     */
+    @Override
+    public void close() {
+        try {
+            logger.debug("closing channel");
+            channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("Channel shutdown interrupted before termination confirmed");
         }
     }
 }

--- a/src/main/java/io/pinecone/configs/ProxyConfig.java
+++ b/src/main/java/io/pinecone/configs/ProxyConfig.java
@@ -1,0 +1,76 @@
+package io.pinecone.configs;
+
+import io.pinecone.exceptions.PineconeConfigurationException;
+import io.pinecone.exceptions.PineconeValidationException;
+
+/**
+ * Represents the configuration for a proxy server.
+ * This class encapsulates the host and port of the proxy server.
+ */
+public class ProxyConfig {
+
+    private String host;
+    private int port;
+
+    /**
+     * Constructs a ProxyConfig object with the specified host and port.
+     *
+     * @param host The hostname or IP address of the proxy server.
+     * @param port The port number of the proxy server.
+     */
+    public ProxyConfig(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Gets the hostname or IP address of the proxy server.
+     *
+     * @return The hostname or IP address of the proxy server.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the hostname or IP address of the proxy server.
+     *
+     * @param host The hostname or IP address of the proxy server.
+     */
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    /**
+     * Gets the port number of the proxy server.
+     *
+     * @return The port number of the proxy server.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Sets the port number of the proxy server.
+     *
+     * @param port The port number of the proxy server.
+     */
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    /**
+     * Validates the proxy configuration.
+     * Throws a PineconeValidationException if the host is null or empty, or if the port is less than or equal to 0.
+     *
+     * @throws PineconeConfigurationException If the proxy configuration is invalid.
+     */
+    public void validate() {
+        if (host == null || host.isEmpty()) {
+            throw new PineconeConfigurationException("Proxy host cannot be null or empty.");
+        }
+        if (port <= 0) {
+            throw new PineconeConfigurationException("Proxy port must be greater than 0.");
+        }
+    }
+}

--- a/src/test/java/io/pinecone/PineconeBuilderTest.java
+++ b/src/test/java/io/pinecone/PineconeBuilderTest.java
@@ -106,6 +106,6 @@ public class PineconeBuilderTest {
 
         assertEquals(expectedIndex, index);
         verify(mockClient, times(1)).newCall(requestCaptor.capture());
-        assertEquals("lang=java; pineconeClientVersion=" + pineconeClientVersion + "; source_tag=testsourcetag", requestCaptor.getValue().header("User-Agent"));
+        assertEquals("lang=java; pineconeClientVersion=" + pineconeClientVersion + "; source_tag=testSourceTag", requestCaptor.getValue().header("User-Agent"));
     }
 }

--- a/src/test/java/io/pinecone/clients/PineconeProxyTest.java
+++ b/src/test/java/io/pinecone/clients/PineconeProxyTest.java
@@ -1,0 +1,71 @@
+package io.pinecone.clients;
+
+import io.pinecone.configs.PineconeConfig;
+import io.pinecone.configs.ProxyConfig;
+import io.pinecone.exceptions.PineconeConfigurationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PineconeProxyTest {
+
+    @Test
+    void testConstructorAndGetters() {
+        ProxyConfig proxyConfig = new ProxyConfig("localhost", 8080);
+        assertEquals("localhost", proxyConfig.getHost());
+        assertEquals(8080, proxyConfig.getPort());
+    }
+
+    @Test
+    void testSetters() {
+        ProxyConfig proxyConfig = new ProxyConfig("localhost", 8080);
+        proxyConfig.setHost("127.0.0.1");
+        proxyConfig.setPort(9090);
+
+        assertEquals("127.0.0.1", proxyConfig.getHost());
+        assertEquals(9090, proxyConfig.getPort());
+    }
+
+    @Test
+    void testValidateInvalidHost() {
+        ProxyConfig proxyConfig = new ProxyConfig(null, 8080);
+        Exception exception = assertThrows(PineconeConfigurationException.class, proxyConfig::validate);
+        assertEquals("Proxy host cannot be null or empty.", exception.getMessage());
+    }
+
+    @Test
+    void testValidateEmptyHost() {
+        ProxyConfig proxyConfig = new ProxyConfig("", 8080);
+        Exception exception = assertThrows(PineconeConfigurationException.class, proxyConfig::validate);
+        assertEquals("Proxy host cannot be null or empty.", exception.getMessage());
+    }
+
+    @Test
+    void testValidateInvalidPort() {
+        ProxyConfig proxyConfig = new ProxyConfig("localhost", 0);
+        Exception exception = assertThrows(PineconeConfigurationException.class, proxyConfig::validate);
+        assertEquals("Proxy port must be greater than 0.", exception.getMessage());
+    }
+
+    @Test
+    void testValidateNegativePort() {
+        ProxyConfig proxyConfig = new ProxyConfig("localhost", -1);
+        Exception exception = assertThrows(PineconeConfigurationException.class, proxyConfig::validate);
+        assertEquals("Proxy port must be greater than 0.", exception.getMessage());
+    }
+
+    @Test
+    public void testBuildWithProxy() {
+        String apiKey = "test-api-key";
+        String proxyHost = "proxy.example.com";
+        int proxyPort = 8080;
+
+        Pinecone pinecone = new Pinecone.Builder(apiKey)
+                .withProxy(proxyHost, proxyPort)
+                .build();
+
+        PineconeConfig config = pinecone.getConfig();
+        assertEquals(proxyHost, config.getProxyConfig().getHost());
+        assertEquals(proxyPort, config.getProxyConfig().getPort());
+    }
+}

--- a/src/test/java/io/pinecone/clients/PineconeProxyTest.java
+++ b/src/test/java/io/pinecone/clients/PineconeProxyTest.java
@@ -3,6 +3,7 @@ package io.pinecone.clients;
 import io.pinecone.configs.PineconeConfig;
 import io.pinecone.configs.ProxyConfig;
 import io.pinecone.exceptions.PineconeConfigurationException;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -67,5 +68,20 @@ public class PineconeProxyTest {
         PineconeConfig config = pinecone.getConfig();
         assertEquals(proxyHost, config.getProxyConfig().getHost());
         assertEquals(proxyPort, config.getProxyConfig().getPort());
+    }
+
+    @Test
+    public void testBothCustomOkHttpClientAndProxySet() {
+        String apiKey = "test-api-key";
+        OkHttpClient customOkHttpClient = new OkHttpClient();
+        String proxyHost = "proxy.example.com";
+        int proxyPort = 8080;
+
+        Pinecone.Builder builder = new Pinecone.Builder(apiKey)
+                .withOkHttpClient(customOkHttpClient)
+                .withProxy(proxyHost, proxyPort);
+
+        Exception exception = assertThrows(PineconeConfigurationException.class, builder::build);
+        assertEquals("Invalid configuration: Both Custom OkHttpClient and Proxy are set. Please configure only one of these options.", exception.getMessage());
     }
 }


### PR DESCRIPTION
## Problem

In order to configure a proxy: 
1. For data plane operations, users have to first instantiate the PineconeConfig class followed by defining the custom NettyChannelBuilder and building the managedChannel to configure the proxy. And finally, after setting the customManagedChannel in PineconeConfig, PineConnection and Index/AsyncIndex classes can be instantiated.
2. For control plane operations, users have to define the OkHttpClient, configure the proxy, and set it to the Pinecone builder object.

## Solution

Provide ability to configure proxies using `proxyHost` and `proxyPort` for both control plane (OkHttpClient) and data plane (gRPC calls via NettyChannelBuilder) operations without having the need to instantiate all of the classes as shown in the example below.

1. Data Plane operations via NettyChannelBuilder: 

Before:
```java
import io.grpc.HttpConnectProxiedSocketAddress;
import io.grpc.ManagedChannel;
import io.grpc.ProxiedSocketAddress;
import io.grpc.ProxyDetector;
import io.pinecone.clients.Index;
import io.pinecone.configs.PineconeConfig;
import io.pinecone.configs.PineconeConnection;
import io.grpc.netty.GrpcSslContexts;
import io.grpc.netty.NegotiationType;
import io.grpc.netty.NettyChannelBuilder;
import io.pinecone.exceptions.PineconeException;

import javax.net.ssl.SSLException;
import java.net.InetSocketAddress;
import java.net.SocketAddress;
import java.util.concurrent.TimeUnit;

import java.util.Arrays;

...
        String apiKey = System.getenv("PINECONE_API_KEY");
        String proxyHost = System.getenv("PROXY_HOST");
        int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));

        PineconeConfig config = new PineconeConfig(apiKey);
        String endpoint = System.getenv("PINECONE_HOST");
        NettyChannelBuilder builder = NettyChannelBuilder.forTarget(endpoint);

        ProxyDetector proxyDetector = new ProxyDetector() {
            @Override
            public ProxiedSocketAddress proxyFor(SocketAddress targetServerAddress) {
                SocketAddress proxyAddress = new InetSocketAddress(proxyHost, proxyPort);
                
                return HttpConnectProxiedSocketAddress.newBuilder()
                        .setTargetAddress((InetSocketAddress) targetServerAddress)
                        .setProxyAddress(proxyAddress)
                        .build();
            }
        };

        // Create custom channel
        try {
            builder = builder.overrideAuthority(endpoint)
                    .negotiationType(NegotiationType.TLS)
                    .keepAliveTimeout(5, TimeUnit.SECONDS)
                    .sslContext(GrpcSslContexts.forClient().build())
                    .proxyDetector(proxyDetector);
        } catch (SSLException e) {
            throw new PineconeException("SSL error opening gRPC channel", e);
        }

        // Build the managed channel with the configured options
        ManagedChannel channel = builder.build();
        config.setCustomManagedChannel(channel);
        PineconeConnection connection = new PineconeConnection(config);
        Index index = new Index(connection, "PINECONE_INDEX_NAME");
        // Data plane operations
        // 1. Upsert data
        System.out.println(index.upsert("v1", Arrays.asList(1F, 2F, 3F, 4F)));
        // 2. Describe index stats
        System.out.println(index.describeIndexStats());
```
After:
```java
import io.pinecone.clients.Index;
import io.pinecone.clients.Pinecone;

...
        String apiKey = System.getenv("PINECONE_API_KEY");
        String proxyHost = System.getenv("PROXY_HOST");
        int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));

        Pinecone pinecone = new Pinecone.Builder(apiKey)
                .withProxy(proxyHost, proxyPort)
                .build();

        Index index = pinecone.getIndexConnection("PINECONE_INDEX_NAME");
        // Data plane operation routed through the proxy server
        // 1. Upsert data
        System.out.println(index.upsert("v1", Arrays.asList(1F, 2F, 3F, 4F)));
        // 2. Describe index stats
        System.out.println(index.describeIndexStats());
```

2. Control Plane operations via OkHttpClient:

Before:
```java
import io.pinecone.clients.Pinecone;
import okhttp3.OkHttpClient;
import java.net.InetSocketAddress;
import java.net.Proxy;

...
        String apiKey = System.getenv("PINECONE_API_KEY");
        String proxyHost = System.getenv("PROXY_HOST");
        int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));

        // Instantiate OkHttpClient instance and configure the proxy
        OkHttpClient client = new OkHttpClient.Builder()
                .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort)))
                .build();

        // Instantiate Pinecone class with the custom OkHttpClient object
        Pinecone pinecone = new Pinecone.Builder(apiKey)
                .withOkHttpClient(client)
                .build();

        // Control plane operation routed through the proxy server
        System.out.println(pinecone.describeIndex("PINECONE_INDEX"));
```

After:
```java
import io.pinecone.clients.Pinecone;

...
        String apiKey = System.getenv("PINECONE_API_KEY");
        String proxyHost = System.getenv("PROXY_HOST");
        int proxyPort = Integer.parseInt(System.getenv("PROXY_PORT"));

        Pinecone pinecone = new Pinecone.Builder(apiKey)
                .withProxy(proxyHost, proxyPort)
                .build();

        // Control plane operation routed through the proxy server
        System.out.println(pinecone.describeIndex("PINECONE_INDEX"));
```

Note:
Users need to set up certificate authorities (CAs) to establish secure connections. Certificates verify server identities and encrypt data exchanged between the SDK and servers. By focusing on proxy host and port details, the SDK simplifies network setup while ensuring security.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

Added unit tests. Given that we had issues with adding integration tests with mitm proxy in python SDK, I'm going to skip adding mitm proxy to github CI and have instead tested locally by spinning mitm proxy and successfully ran both control and data plane operations. 

