### PR TITLE
Allow : in the source tag and add pinecone_test as a source tag for all integration tests

### DIFF
--- a/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
@@ -58,7 +58,7 @@ public class TestResourcesManager {
     private static final String region = System.getenv("REGION") == null
             ? "us-west-2"
             : System.getenv("REGION");
-    private Pinecone pineconeClient;
+    private final Pinecone pineconeClient;
     private String podIndexName;
     private IndexModel podIndexModel;
     private IndexModel serverlessIndexModel;
@@ -73,7 +73,10 @@ public class TestResourcesManager {
 
 
     private TestResourcesManager() {
-        pineconeClient = new Pinecone.Builder(apiKey).build();
+        pineconeClient = new Pinecone
+                .Builder(apiKey)
+                .withSourceTag("pinecone_test")
+                .build();
     }
 
     /**

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -24,7 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CollectionTest {
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
-    private static final Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final Pinecone pineconeClient = new Pinecone
+            .Builder(System.getenv("PINECONE_API_KEY"))
+            .withSourceTag("pinecone_test")
+            .build();
     private static final Logger logger = LoggerFactory.getLogger(CollectionTest.class);
     private static final ArrayList<String> indexesToCleanUp = new ArrayList<>();
     private static final String sourceIndexMetric = indexManager.getMetric();

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -20,7 +20,10 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ConfigureIndexTest {
     private static final Logger logger = LoggerFactory.getLogger(ConfigureIndexTest.class);
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
-    private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final Pinecone controlPlaneClient = new Pinecone
+            .Builder(System.getenv("PINECONE_API_KEY"))
+            .withSourceTag("pinecone_test")
+            .build();
     private static String indexName;
 
     @BeforeAll

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CreateDescribeListAndDeleteIndexTest.java
@@ -13,7 +13,10 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CreateDescribeListAndDeleteIndexTest {
 
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
-    private static Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final Pinecone controlPlaneClient = new Pinecone
+            .Builder(System.getenv("PINECONE_API_KEY"))
+            .withSourceTag("pinecone_test")
+            .build();
     private static String indexName;
     private static int indexDimension;
     private static String indexPodType;

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/CreateDescribeListAndDeleteIndexTest.java
@@ -16,7 +16,10 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CreateDescribeListAndDeleteIndexTest {
 
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
-    private static final Pinecone controlPlaneClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
+    private static final Pinecone controlPlaneClient = new Pinecone
+            .Builder(System.getenv("PINECONE_API_KEY"))
+            .withSourceTag("pinecone_test")
+            .build();
     private static String indexName;
     private static int dimension;
 

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -191,12 +191,12 @@ public class PineconeConfig {
         /*
          * Normalize the source tag
          * 1. Lowercase
-         * 2. Limit charset to [a-z0-9_ ]
+         * 2. Limit charset to [a-z0-9_: ]
          * 3. Trim left/right empty space
          * 4. Condense multiple spaces to one, and replace with underscore
          */
         return input.toLowerCase()
-                .replaceAll("[^a-z0-9_ ]", "")
+                .replaceAll("[^a-z0-9_: ]", "")
                 .trim()
                 .replaceAll("\\s+", "_");
     }

--- a/src/test/java/io/pinecone/PineconeConfigTest.java
+++ b/src/test/java/io/pinecone/PineconeConfigTest.java
@@ -55,11 +55,11 @@ public class PineconeConfigTest {
     @Test
     public void testSourceTagIsNormalized() {
         PineconeConfig config = new PineconeConfig("testApiKey");
-        config.setSourceTag("test source tag !! @@ ##");
-        assertEquals(config.getSourceTag(), "test_source_tag");
+        config.setSourceTag("test source tag !! @@ ## :");
+        assertEquals(config.getSourceTag(), "test_source_tag_:");
 
-        config.setSourceTag("TEST SOURCE Tag     ----");
-        assertEquals(config.getSourceTag(), "test_source_tag");
+        config.setSourceTag("TEST SOURCE : Tag     ----");
+        assertEquals(config.getSourceTag(), "test_source_:_tag");
 
         config.setSourceTag("TEST      SOURCE TAG 2.4.5");
         assertEquals(config.getSourceTag(), "test_source_tag_245");


### PR DESCRIPTION

## Problem

Some customers have requested to allow : in the source tag field and for all internal pinecone integration tests, add source tag as pinecone_test.

## Solution

Allow : as a part of source tag and set pinecone_test as a source tag for integration test

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: (explain here)

## Test Plan

Updated unit test and ran integration tests 
