### PR TITLE
Fix useragent for grpc

### DIFF
--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -202,20 +202,11 @@ public class PineconeConfig {
      * @return The user agent string.
      */
     public String getUserAgent() {
-        return buildUserAgent("pineconeClientVersion");
+        return buildUserAgent();
     }
 
-    /**
-     * Builds the user agent string for the Pinecone client's gRPC requests.
-     *
-     * @return The user agent string for gRPC requests.
-     */
-    public String getUserAgentGrpc() {
-        return buildUserAgent("pineconeClientVersion[grpc]");
-    }
-
-    private String buildUserAgent(String clientId) {
-        String userAgent = String.format("lang=java; %s=%s", clientId, "v1.2.1");
+    private String buildUserAgent() {
+        String userAgent = String.format("lang=java; %s=%s", "pineconeClientVersion", "v1.2.1");
         if (this.getSourceTag() != null && !this.getSourceTag().isEmpty()) {
             userAgent += "; source_tag=" + this.getSourceTag();
         }

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -77,7 +77,7 @@ public class PineconeConnection implements AutoCloseable {
             if (config.getHost() == null || config.getHost().isEmpty()) {
                 throw new PineconeValidationException("Index-name or host is required for data plane operations");
             }
-            channel = buildChannel(config.getHost());
+            channel = buildChannel();
         }
         initialize();
     }
@@ -134,14 +134,15 @@ public class PineconeConnection implements AutoCloseable {
                 channel.getState(false), channel);
     }
 
-    private ManagedChannel buildChannel(String host) {
-        String endpoint = formatEndpoint(host);
+    private ManagedChannel buildChannel() {
+        String endpoint = formatEndpoint(config.getHost());
         NettyChannelBuilder builder = NettyChannelBuilder.forTarget(endpoint);
 
         try {
             builder = builder.overrideAuthority(endpoint)
                     .negotiationType(NegotiationType.TLS)
-                    .sslContext(GrpcSslContexts.forClient().build());
+                    .sslContext(GrpcSslContexts.forClient().build())
+                    .userAgent(config.getUserAgent());
 
             if(config.getProxyConfig() != null) {
                 ProxyDetector proxyDetector = getProxyDetector();
@@ -169,7 +170,6 @@ public class PineconeConnection implements AutoCloseable {
     private static Metadata assembleMetadata(PineconeConfig config) {
         Metadata metadata = new Metadata();
         metadata.put(Metadata.Key.of("api-key", Metadata.ASCII_STRING_MARSHALLER), config.getApiKey());
-        metadata.put(Metadata.Key.of("User-Agent", Metadata.ASCII_STRING_MARSHALLER), config.getUserAgentGrpc());
         return metadata;
     }
 

--- a/src/test/java/io/pinecone/PineconeConfigTest.java
+++ b/src/test/java/io/pinecone/PineconeConfigTest.java
@@ -34,22 +34,10 @@ public class PineconeConfigTest {
     }
 
     @Test
-    public void testGetUserAgentGrpc() {
-        PineconeConfig config = new PineconeConfig("testApiKey");
-        assertEquals(config.getUserAgentGrpc(), "lang=java; pineconeClientVersion[grpc]=" + pineconeClientVersion);
-    }
-    @Test
     public void testGetUserAgentWithSourceTag() {
         PineconeConfig config = new PineconeConfig("testApiKey");
         config.setSourceTag("testSourceTag");
         assertEquals(config.getUserAgent(), "lang=java; pineconeClientVersion=" + pineconeClientVersion + "; source_tag=testsourcetag");
-    }
-
-    @Test
-    public void testGetUserAgentGrpcWithSourceTag() {
-        PineconeConfig config = new PineconeConfig("testApiKey");
-        config.setSourceTag("testSourceTag");
-        assertEquals(config.getUserAgentGrpc(), "lang=java; pineconeClientVersion[grpc]=" + pineconeClientVersion + "; source_tag=testsourcetag");
     }
 
     @Test


### PR DESCRIPTION
## Problem

The user agent string was defaulting to netty-java-grpc/1.60.2 even though the user agent + source tag was passed in.

## Solution

Instead of passing user agent as extra headers to the stubs, set the user agent string using .userAgent() on NettyChannelBuilder object.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Added a screenshot of the user agent being correctly populated in datadog on the internal ticket.
