### PR TITLE
Update pinecone client version to 1.2.2 and remove redundant client version declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
+### 1.2.2
+- Add support for proxy configuration
+- Fix user-agent for grpc
+
 ### 1.2.1
 - Fix uber jar
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Maven:
 <dependency>
   <groupId>io.pinecone</groupId>
   <artifactId>pinecone-client</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
 </dependency>
 ```
 
@@ -23,12 +23,12 @@ Maven:
 
 Gradle:
 ```
-implementation "io.pinecone:pinecone-client:1.2.1"
+implementation "io.pinecone:pinecone-client:1.2.2"
 ```
 
 [comment]: <> (^ [pc:VERSION_LATEST_RELEASE])
 
-Alternatively, you can use our standalone uberjar [pinecone-client-1.2.1-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/1.2.1/pinecone-client-1.2.1-all.jar), which bundles the pinecone 
+Alternatively, you can use our standalone uberjar [pinecone-client-1.2.2-all.jar](https://repo1.maven.org/maven2/io/pinecone/pinecone-client/1.2.2/pinecone-client-1.2.2-all.jar), which bundles the pinecone 
 client and all dependencies together. You can include this in your classpath like you do with any 3rd party JAR without 
 having to obtain the *pinecone-client* dependencies separately.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pineconeClientVersion = 1.2.1
+pineconeClientVersion = 1.2.2

--- a/src/main/java/io/pinecone/commons/Constants.java
+++ b/src/main/java/io/pinecone/commons/Constants.java
@@ -1,0 +1,5 @@
+package io.pinecone.commons;
+
+public class Constants {
+    public static final String pineconeClientVersion = "v1.2.2";
+}

--- a/src/main/java/io/pinecone/configs/PineconeConfig.java
+++ b/src/main/java/io/pinecone/configs/PineconeConfig.java
@@ -3,6 +3,8 @@ package io.pinecone.configs;
 import io.grpc.ManagedChannel;
 import io.pinecone.exceptions.PineconeConfigurationException;
 
+import static io.pinecone.commons.Constants.pineconeClientVersion;
+
 /**
  * The {@link PineconeConfig} class is responsible for managing the configuration settings
  * required to interact with the Pinecone API. It provides methods to set and retrieve
@@ -206,7 +208,7 @@ public class PineconeConfig {
     }
 
     private String buildUserAgent() {
-        String userAgent = String.format("lang=java; %s=%s", "pineconeClientVersion", "v1.2.1");
+        String userAgent = String.format("lang=java; %s=%s", "pineconeClientVersion", pineconeClientVersion);
         if (this.getSourceTag() != null && !this.getSourceTag().isEmpty()) {
             userAgent += "; source_tag=" + this.getSourceTag();
         }

--- a/src/test/java/io/pinecone/PineconeBuilderTest.java
+++ b/src/test/java/io/pinecone/PineconeBuilderTest.java
@@ -13,12 +13,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
 
+import static io.pinecone.commons.Constants.pineconeClientVersion;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class PineconeBuilderTest {
     private static final Gson gson = new Gson();
-    private static final String pineconeClientVersion = "v1.2.1";
 
     private static AbstractMap.SimpleEntry<Call, OkHttpClient> buildMockCallAndClient(ResponseBody response) throws IOException {
         Response mockResponse = new Response.Builder()

--- a/src/test/java/io/pinecone/PineconeConfigTest.java
+++ b/src/test/java/io/pinecone/PineconeConfigTest.java
@@ -4,11 +4,10 @@ import io.pinecone.configs.PineconeConfig;
 import io.pinecone.exceptions.PineconeConfigurationException;
 import org.junit.jupiter.api.Test;
 
+import static io.pinecone.commons.Constants.pineconeClientVersion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PineconeConfigTest {
-
-    private static final String pineconeClientVersion = "v1.2.1";
 
     @Test
     public void testValidateWithNullApiKey() {


### PR DESCRIPTION
## Problem

Prepare for releasing v1.2.2 and remove some redundancies when it comes to declaring pinecone client version in the config and unit tests.

## Solution

Update pineconeClientVersion to v1.2.2 and remove redundancies for updating pineconeClientVersion.

## Type of Change

- [X] None of the above: Refactoring codebase and updating client version.

## Test Plan

Ran unit tests and tested with a locally published jar.
