### PR TITLE
Updating issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ''
+
+---
+
+**Is this a new bug?**
+In other words: Is this an error, flaw, failure or fault? Please search Github issues and check our [Community Forum](https://community.pinecone.io/) to see if someone has already reported the bug you encountered. 
+
+If this is a request for help or troubleshooting code in your own Pinecone project, please join the [Pinecone Community Forum](https://community.pinecone.io/).
+
+- [ ] I believe this is a new bug
+- [ ] I have searched the existing Github issues and Community Forum, and I could not find an existing post for this bug
+
+**Describe the bug**
+Describe the functionality that was working before but is broken now.
+
+**Error information**
+If you have one, please include the full stack trace here. If not, please share as much as you can about the error.
+
+**Steps to reproduce the issue locally**
+Include steps to reproduce the issue here. If you have sample code or a script that can be used to replicate this issue, please include that as well (including any dependent files to run the code).  
+
+**Environment**
+* OS Version: 
+* Java version:
+* Java SDK version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Pinecone Community Forum
+    url: https://community.pinecone.io/
+    about: For support, please see the community forum.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,17 @@
+---
+name: Documentation
+about: Report an issue in our docs
+title: "[Docs] "
+labels: 'documentation'
+assignees: ''
+
+---
+
+**Description**
+Describe the issue that you've encountered with our documentation.
+
+**Suggested solution**
+Describe how this issue could be fixed or improved.
+ 
+**Link to page**
+Add a link to the exact documentation page where the issue occurred.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**What motivated you to submit this feature request?**
+A clear and concise description of why you are requesting this feature - e.g. "Being able to do x would allow me to..." 
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/add-labels.yaml
+++ b/.github/workflows/add-labels.yaml
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: status:needs-triage


### PR DESCRIPTION
## Problem
Making overall changes to the repo to improve our triage process.

## Solution
Adding new issue templates so users can file more specific, actionable issues. Also adding auto-labeling functionality to label new issues as needs-triage when they get opened so that we can properly triage.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Tested the auto-labeler in the Go SDK repo
