### PR TITLE
support default namespace for list api

### DIFF
--- a/src/main/java/io/pinecone/commons/IndexInterface.java
+++ b/src/main/java/io/pinecone/commons/IndexInterface.java
@@ -734,8 +734,8 @@ public interface IndexInterface<T, U, V, W, X, Y, Z> extends AutoCloseable {
     default void validateListEndpointParameters(String namespace, String prefix, String paginationToken,
                                                 Integer limit, boolean namespaceRequired, boolean prefixRequired,
                                                 boolean paginationTokenRequired, boolean limitRequired) {
-        if (namespaceRequired && (namespace == null || namespace.isEmpty())) {
-            throw new PineconeValidationException("Namespace cannot be null or empty");
+        if (namespaceRequired && (namespace == null)) {
+            throw new PineconeValidationException("Namespace cannot be null");
         }
         if (prefixRequired && (prefix == null || prefix.isEmpty())) {
             throw new PineconeValidationException("Prefix cannot be null or empty");

--- a/src/test/java/io/pinecone/ListEndpointValidationTest.java
+++ b/src/test/java/io/pinecone/ListEndpointValidationTest.java
@@ -40,12 +40,7 @@ public class ListEndpointValidationTest {
         PineconeValidationException thrownNullNamespace = assertThrows(PineconeValidationException.class, () -> {
             index.validateListEndpointParameters(null, null, null, null, true, true, true, true);
         });
-        assertEquals("Namespace cannot be null or empty", thrownNullNamespace.getMessage());
-
-        PineconeValidationException thrownEmptyNamespace = assertThrows(PineconeValidationException.class, () -> {
-            index.validateListEndpointParameters("", null, null, null, true, true, true, true);
-        });
-        assertEquals("Namespace cannot be null or empty", thrownEmptyNamespace.getMessage());
+        assertEquals("Namespace cannot be null", thrownNullNamespace.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Problem

in pinecone, the default namespace is "", the check in list will throw exception if namespace is ""

## Solution

remove the empty namespace check, only check namespace is null

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
./gradlew build, passed all tests
