### PR TITLE
Regenerate code based on 2024-10 api spec after two changes: uri & indexTags

### DIFF
--- a/src/main/java/org/openapitools/db_control/client/ApiException.java
+++ b/src/main/java/org/openapitools/db_control/client/ApiException.java
@@ -21,7 +21,7 @@ import java.util.List;
  * <p>ApiException class.</p>
  */
 @SuppressWarnings("serial")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/org/openapitools/db_control/client/Configuration.java
+++ b/src/main/java/org/openapitools/db_control/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.db_control.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class Configuration {
     public static final String VERSION = "2024-10";
 

--- a/src/main/java/org/openapitools/db_control/client/Pair.java
+++ b/src/main/java/org/openapitools/db_control/client/Pair.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.db_control.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/org/openapitools/db_control/client/StringUtil.java
+++ b/src/main/java/org/openapitools/db_control/client/StringUtil.java
@@ -16,7 +16,7 @@ package org.openapitools.db_control.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/org/openapitools/db_control/client/auth/ApiKeyAuth.java
+++ b/src/main/java/org/openapitools/db_control/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/org/openapitools/db_control/client/auth/HttpBearerAuth.java
+++ b/src/main/java/org/openapitools/db_control/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;

--- a/src/main/java/org/openapitools/db_control/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/org/openapitools/db_control/client/model/AbstractOpenApiSchema.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/org/openapitools/db_control/client/model/CollectionList.java
+++ b/src/main/java/org/openapitools/db_control/client/model/CollectionList.java
@@ -52,7 +52,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The list of collections that exist in the project.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class CollectionList {
   public static final String SERIALIZED_NAME_COLLECTIONS = "collections";
   @SerializedName(SERIALIZED_NAME_COLLECTIONS)

--- a/src/main/java/org/openapitools/db_control/client/model/CollectionModel.java
+++ b/src/main/java/org/openapitools/db_control/client/model/CollectionModel.java
@@ -49,7 +49,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The CollectionModel describes the configuration and status of a Pinecone collection.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class CollectionModel {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)

--- a/src/main/java/org/openapitools/db_control/client/model/ConfigureIndexRequest.java
+++ b/src/main/java/org/openapitools/db_control/client/model/ConfigureIndexRequest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.db_control.client.model.ConfigureIndexRequestSpec;
 import org.openapitools.db_control.client.model.DeletionProtection;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,7 +54,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * Configuration used to scale an index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ConfigureIndexRequest {
   public static final String SERIALIZED_NAME_SPEC = "spec";
   @SerializedName(SERIALIZED_NAME_SPEC)
@@ -65,7 +66,7 @@ public class ConfigureIndexRequest {
 
   public static final String SERIALIZED_NAME_TAGS = "tags";
   @SerializedName(SERIALIZED_NAME_TAGS)
-  private Map<String, String> tags = new HashMap<>();
+  private Map<String, String> tags;
 
   public ConfigureIndexRequest() {
   }
@@ -201,9 +202,20 @@ public class ConfigureIndexRequest {
         Objects.equals(this.additionalProperties, configureIndexRequest.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(spec, deletionProtection, tags, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/src/main/java/org/openapitools/db_control/client/model/ConfigureIndexRequestSpec.java
+++ b/src/main/java/org/openapitools/db_control/client/model/ConfigureIndexRequestSpec.java
@@ -50,7 +50,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * ConfigureIndexRequestSpec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ConfigureIndexRequestSpec {
   public static final String SERIALIZED_NAME_POD = "pod";
   @SerializedName(SERIALIZED_NAME_POD)

--- a/src/main/java/org/openapitools/db_control/client/model/ConfigureIndexRequestSpecPod.java
+++ b/src/main/java/org/openapitools/db_control/client/model/ConfigureIndexRequestSpecPod.java
@@ -49,7 +49,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * ConfigureIndexRequestSpecPod
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ConfigureIndexRequestSpecPod {
   public static final String SERIALIZED_NAME_REPLICAS = "replicas";
   @SerializedName(SERIALIZED_NAME_REPLICAS)

--- a/src/main/java/org/openapitools/db_control/client/model/CreateCollectionRequest.java
+++ b/src/main/java/org/openapitools/db_control/client/model/CreateCollectionRequest.java
@@ -49,7 +49,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The configuration needed to create a Pinecone collection.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class CreateCollectionRequest {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)

--- a/src/main/java/org/openapitools/db_control/client/model/CreateIndexRequest.java
+++ b/src/main/java/org/openapitools/db_control/client/model/CreateIndexRequest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openapitools.db_control.client.model.DeletionProtection;
 import org.openapitools.db_control.client.model.IndexSpec;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,7 +54,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The configuration needed to create a Pinecone index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class CreateIndexRequest {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -122,7 +123,7 @@ public class CreateIndexRequest {
 
   public static final String SERIALIZED_NAME_TAGS = "tags";
   @SerializedName(SERIALIZED_NAME_TAGS)
-  private Map<String, String> tags = new HashMap<>();
+  private Map<String, String> tags;
 
   public static final String SERIALIZED_NAME_SPEC = "spec";
   @SerializedName(SERIALIZED_NAME_SPEC)
@@ -330,9 +331,20 @@ public class CreateIndexRequest {
         Objects.equals(this.additionalProperties, createIndexRequest.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(name, dimension, metric, deletionProtection, tags, spec, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/src/main/java/org/openapitools/db_control/client/model/ErrorResponse.java
+++ b/src/main/java/org/openapitools/db_control/client/model/ErrorResponse.java
@@ -50,7 +50,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The response shape used for all error responses.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ErrorResponse {
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)

--- a/src/main/java/org/openapitools/db_control/client/model/ErrorResponseError.java
+++ b/src/main/java/org/openapitools/db_control/client/model/ErrorResponseError.java
@@ -49,7 +49,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * Detailed information about the error that occurred.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ErrorResponseError {
   /**
    * Gets or Sets code

--- a/src/main/java/org/openapitools/db_control/client/model/IndexList.java
+++ b/src/main/java/org/openapitools/db_control/client/model/IndexList.java
@@ -52,7 +52,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The list of indexes that exist in the project.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class IndexList {
   public static final String SERIALIZED_NAME_INDEXES = "indexes";
   @SerializedName(SERIALIZED_NAME_INDEXES)

--- a/src/main/java/org/openapitools/db_control/client/model/IndexModel.java
+++ b/src/main/java/org/openapitools/db_control/client/model/IndexModel.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.openapitools.db_control.client.model.DeletionProtection;
 import org.openapitools.db_control.client.model.IndexModelSpec;
 import org.openapitools.db_control.client.model.IndexModelStatus;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -54,7 +55,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The IndexModel describes the configuration and status of a Pinecone index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class IndexModel {
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -127,7 +128,7 @@ public class IndexModel {
 
   public static final String SERIALIZED_NAME_TAGS = "tags";
   @SerializedName(SERIALIZED_NAME_TAGS)
-  private Map<String, String> tags = new HashMap<>();
+  private Map<String, String> tags;
 
   public static final String SERIALIZED_NAME_SPEC = "spec";
   @SerializedName(SERIALIZED_NAME_SPEC)
@@ -383,9 +384,20 @@ public class IndexModel {
         Objects.equals(this.additionalProperties, indexModel.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(name, dimension, metric, host, deletionProtection, tags, spec, status, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/src/main/java/org/openapitools/db_control/client/model/IndexModelSpec.java
+++ b/src/main/java/org/openapitools/db_control/client/model/IndexModelSpec.java
@@ -51,7 +51,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * IndexModelSpec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class IndexModelSpec {
   public static final String SERIALIZED_NAME_POD = "pod";
   @SerializedName(SERIALIZED_NAME_POD)

--- a/src/main/java/org/openapitools/db_control/client/model/IndexModelStatus.java
+++ b/src/main/java/org/openapitools/db_control/client/model/IndexModelStatus.java
@@ -49,7 +49,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * IndexModelStatus
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class IndexModelStatus {
   public static final String SERIALIZED_NAME_READY = "ready";
   @SerializedName(SERIALIZED_NAME_READY)

--- a/src/main/java/org/openapitools/db_control/client/model/IndexSpec.java
+++ b/src/main/java/org/openapitools/db_control/client/model/IndexSpec.java
@@ -51,7 +51,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * The spec object defines how the index should be deployed.  For serverless indexes, you define only the [cloud and region](http://docs.pinecone.io/guides/indexes/understanding-indexes#cloud-regions) where the index should be hosted. For pod-based indexes, you define the [environment](http://docs.pinecone.io/guides/indexes/understanding-indexes#pod-environments) where the index should be hosted, the [pod type and size](http://docs.pinecone.io/guides/indexes/understanding-indexes#pod-types) to use, and other index characteristics. 
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class IndexSpec {
   public static final String SERIALIZED_NAME_SERVERLESS = "serverless";
   @SerializedName(SERIALIZED_NAME_SERVERLESS)

--- a/src/main/java/org/openapitools/db_control/client/model/PodSpec.java
+++ b/src/main/java/org/openapitools/db_control/client/model/PodSpec.java
@@ -50,7 +50,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * Configuration needed to deploy a pod-based index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class PodSpec {
   public static final String SERIALIZED_NAME_ENVIRONMENT = "environment";
   @SerializedName(SERIALIZED_NAME_ENVIRONMENT)

--- a/src/main/java/org/openapitools/db_control/client/model/PodSpecMetadataConfig.java
+++ b/src/main/java/org/openapitools/db_control/client/model/PodSpecMetadataConfig.java
@@ -51,7 +51,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * Configuration for the behavior of Pinecone&#39;s internal metadata index. By default, all metadata is indexed; when &#x60;metadata_config&#x60; is present, only specified metadata fields are indexed. These configurations are only valid for use with pod-based indexes.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class PodSpecMetadataConfig {
   public static final String SERIALIZED_NAME_INDEXED = "indexed";
   @SerializedName(SERIALIZED_NAME_INDEXED)

--- a/src/main/java/org/openapitools/db_control/client/model/ServerlessSpec.java
+++ b/src/main/java/org/openapitools/db_control/client/model/ServerlessSpec.java
@@ -49,7 +49,7 @@ import org.openapitools.db_control.client.JSON;
 /**
  * Configuration needed to deploy a serverless index.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:14.267412Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:52.118506Z[Etc/UTC]")
 public class ServerlessSpec {
   /**
    * The public cloud where you would like your index hosted.

--- a/src/main/java/org/openapitools/db_data/client/ApiException.java
+++ b/src/main/java/org/openapitools/db_data/client/ApiException.java
@@ -21,7 +21,7 @@ import java.util.List;
  * <p>ApiException class.</p>
  */
 @SuppressWarnings("serial")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/org/openapitools/db_data/client/Configuration.java
+++ b/src/main/java/org/openapitools/db_data/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.db_data.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class Configuration {
     public static final String VERSION = "2024-10";
 

--- a/src/main/java/org/openapitools/db_data/client/Pair.java
+++ b/src/main/java/org/openapitools/db_data/client/Pair.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.db_data.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/org/openapitools/db_data/client/StringUtil.java
+++ b/src/main/java/org/openapitools/db_data/client/StringUtil.java
@@ -16,7 +16,7 @@ package org.openapitools.db_data.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/org/openapitools/db_data/client/auth/ApiKeyAuth.java
+++ b/src/main/java/org/openapitools/db_data/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/org/openapitools/db_data/client/auth/HttpBearerAuth.java
+++ b/src/main/java/org/openapitools/db_data/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;

--- a/src/main/java/org/openapitools/db_data/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/org/openapitools/db_data/client/model/AbstractOpenApiSchema.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/org/openapitools/db_data/client/model/DeleteRequest.java
+++ b/src/main/java/org/openapitools/db_data/client/model/DeleteRequest.java
@@ -51,7 +51,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The request for the &#x60;delete&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class DeleteRequest {
   public static final String SERIALIZED_NAME_IDS = "ids";
   @SerializedName(SERIALIZED_NAME_IDS)

--- a/src/main/java/org/openapitools/db_data/client/model/DescribeIndexStatsRequest.java
+++ b/src/main/java/org/openapitools/db_data/client/model/DescribeIndexStatsRequest.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The request for the &#x60;describe_index_stats&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class DescribeIndexStatsRequest {
   public static final String SERIALIZED_NAME_FILTER = "filter";
   @SerializedName(SERIALIZED_NAME_FILTER)

--- a/src/main/java/org/openapitools/db_data/client/model/FetchResponse.java
+++ b/src/main/java/org/openapitools/db_data/client/model/FetchResponse.java
@@ -53,7 +53,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;fetch&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class FetchResponse {
   public static final String SERIALIZED_NAME_VECTORS = "vectors";
   @SerializedName(SERIALIZED_NAME_VECTORS)

--- a/src/main/java/org/openapitools/db_data/client/model/ImportErrorMode.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ImportErrorMode.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * Indicates how to respond to errors during the import process.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ImportErrorMode {
   /**
    * Indicates how to respond to errors during the import process.

--- a/src/main/java/org/openapitools/db_data/client/model/ImportModel.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ImportModel.java
@@ -50,7 +50,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The model for an import operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ImportModel {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/src/main/java/org/openapitools/db_data/client/model/IndexDescription.java
+++ b/src/main/java/org/openapitools/db_data/client/model/IndexDescription.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;describe_index_stats&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class IndexDescription {
   public static final String SERIALIZED_NAME_NAMESPACES = "namespaces";
   @SerializedName(SERIALIZED_NAME_NAMESPACES)

--- a/src/main/java/org/openapitools/db_data/client/model/ListImportsResponse.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ListImportsResponse.java
@@ -53,7 +53,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;list_imports&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ListImportsResponse {
   public static final String SERIALIZED_NAME_DATA = "data";
   @SerializedName(SERIALIZED_NAME_DATA)

--- a/src/main/java/org/openapitools/db_data/client/model/ListItem.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ListItem.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * ListItem
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ListItem {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/src/main/java/org/openapitools/db_data/client/model/ListResponse.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ListResponse.java
@@ -54,7 +54,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;list&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ListResponse {
   public static final String SERIALIZED_NAME_VECTORS = "vectors";
   @SerializedName(SERIALIZED_NAME_VECTORS)

--- a/src/main/java/org/openapitools/db_data/client/model/NamespaceSummary.java
+++ b/src/main/java/org/openapitools/db_data/client/model/NamespaceSummary.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * A summary of the contents of a namespace.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class NamespaceSummary {
   public static final String SERIALIZED_NAME_VECTOR_COUNT = "vectorCount";
   @SerializedName(SERIALIZED_NAME_VECTOR_COUNT)

--- a/src/main/java/org/openapitools/db_data/client/model/Pagination.java
+++ b/src/main/java/org/openapitools/db_data/client/model/Pagination.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * Pagination
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class Pagination {
   public static final String SERIALIZED_NAME_NEXT = "next";
   @SerializedName(SERIALIZED_NAME_NEXT)

--- a/src/main/java/org/openapitools/db_data/client/model/ProtobufAny.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ProtobufAny.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * ProtobufAny
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ProtobufAny {
   public static final String SERIALIZED_NAME_TYPE_URL = "typeUrl";
   @SerializedName(SERIALIZED_NAME_TYPE_URL)

--- a/src/main/java/org/openapitools/db_data/client/model/QueryRequest.java
+++ b/src/main/java/org/openapitools/db_data/client/model/QueryRequest.java
@@ -53,7 +53,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The request for the &#x60;query&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class QueryRequest {
   public static final String SERIALIZED_NAME_NAMESPACE = "namespace";
   @SerializedName(SERIALIZED_NAME_NAMESPACE)

--- a/src/main/java/org/openapitools/db_data/client/model/QueryResponse.java
+++ b/src/main/java/org/openapitools/db_data/client/model/QueryResponse.java
@@ -54,7 +54,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;query&#x60; operation. These are the matches found for a particular query vector. The matches are ordered from most similar to least similar.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class QueryResponse {
   public static final String SERIALIZED_NAME_RESULTS = "results";
   @Deprecated

--- a/src/main/java/org/openapitools/db_data/client/model/QueryVector.java
+++ b/src/main/java/org/openapitools/db_data/client/model/QueryVector.java
@@ -54,7 +54,7 @@ import org.openapitools.db_data.client.JSON;
  * @deprecated
  */
 @Deprecated
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class QueryVector {
   public static final String SERIALIZED_NAME_VALUES = "values";
   @SerializedName(SERIALIZED_NAME_VALUES)

--- a/src/main/java/org/openapitools/db_data/client/model/RpcStatus.java
+++ b/src/main/java/org/openapitools/db_data/client/model/RpcStatus.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * RpcStatus
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class RpcStatus {
   public static final String SERIALIZED_NAME_CODE = "code";
   @SerializedName(SERIALIZED_NAME_CODE)

--- a/src/main/java/org/openapitools/db_data/client/model/ScoredVector.java
+++ b/src/main/java/org/openapitools/db_data/client/model/ScoredVector.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * ScoredVector
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class ScoredVector {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/src/main/java/org/openapitools/db_data/client/model/SingleQueryResults.java
+++ b/src/main/java/org/openapitools/db_data/client/model/SingleQueryResults.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * SingleQueryResults
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class SingleQueryResults {
   public static final String SERIALIZED_NAME_MATCHES = "matches";
   @SerializedName(SERIALIZED_NAME_MATCHES)

--- a/src/main/java/org/openapitools/db_data/client/model/SparseValues.java
+++ b/src/main/java/org/openapitools/db_data/client/model/SparseValues.java
@@ -51,7 +51,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * Vector sparse data. Represented as a list of indices and a list of  corresponded values, which must be with the same length.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class SparseValues {
   public static final String SERIALIZED_NAME_INDICES = "indices";
   @SerializedName(SERIALIZED_NAME_INDICES)

--- a/src/main/java/org/openapitools/db_data/client/model/StartImportRequest.java
+++ b/src/main/java/org/openapitools/db_data/client/model/StartImportRequest.java
@@ -50,7 +50,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The request for the &#x60;start_import&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class StartImportRequest {
   public static final String SERIALIZED_NAME_INTEGRATION_ID = "integrationId";
   @SerializedName(SERIALIZED_NAME_INTEGRATION_ID)
@@ -98,7 +98,7 @@ public class StartImportRequest {
    * The URI prefix under which the data to import is available. All data within this prefix will be listed then imported into the target index. Currently only &#x60;s3://&#x60; URIs are supported.
    * @return uri
   **/
-  @javax.annotation.Nullable
+  @javax.annotation.Nonnull
   public String getUri() {
     return uri;
   }
@@ -231,6 +231,7 @@ public class StartImportRequest {
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
+    openapiRequiredFields.add("uri");
   }
 
  /**
@@ -245,11 +246,18 @@ public class StartImportRequest {
           throw new IllegalArgumentException(String.format("The required field(s) %s in StartImportRequest is not found in the empty JSON string", StartImportRequest.openapiRequiredFields.toString()));
         }
       }
+
+      // check to make sure all required properties/fields are present in the JSON string
+      for (String requiredField : StartImportRequest.openapiRequiredFields) {
+        if (jsonElement.getAsJsonObject().get(requiredField) == null) {
+          throw new IllegalArgumentException(String.format("The required field `%s` is not found in the JSON string: %s", requiredField, jsonElement.toString()));
+        }
+      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("integrationId") != null && !jsonObj.get("integrationId").isJsonNull()) && !jsonObj.get("integrationId").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `integrationId` to be a primitive type in the JSON string but got `%s`", jsonObj.get("integrationId").toString()));
       }
-      if ((jsonObj.get("uri") != null && !jsonObj.get("uri").isJsonNull()) && !jsonObj.get("uri").isJsonPrimitive()) {
+      if (!jsonObj.get("uri").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `uri` to be a primitive type in the JSON string but got `%s`", jsonObj.get("uri").toString()));
       }
       // validate the optional field `errorMode`

--- a/src/main/java/org/openapitools/db_data/client/model/StartImportResponse.java
+++ b/src/main/java/org/openapitools/db_data/client/model/StartImportResponse.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;start_import&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class StartImportResponse {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/src/main/java/org/openapitools/db_data/client/model/UpdateRequest.java
+++ b/src/main/java/org/openapitools/db_data/client/model/UpdateRequest.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The request for the &#x60;update&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class UpdateRequest {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/src/main/java/org/openapitools/db_data/client/model/UpsertRequest.java
+++ b/src/main/java/org/openapitools/db_data/client/model/UpsertRequest.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The request for the &#x60;upsert&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class UpsertRequest {
   public static final String SERIALIZED_NAME_VECTORS = "vectors";
   @SerializedName(SERIALIZED_NAME_VECTORS)

--- a/src/main/java/org/openapitools/db_data/client/model/UpsertResponse.java
+++ b/src/main/java/org/openapitools/db_data/client/model/UpsertResponse.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * The response for the &#x60;upsert&#x60; operation.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class UpsertResponse {
   public static final String SERIALIZED_NAME_UPSERTED_COUNT = "upsertedCount";
   @SerializedName(SERIALIZED_NAME_UPSERTED_COUNT)

--- a/src/main/java/org/openapitools/db_data/client/model/Usage.java
+++ b/src/main/java/org/openapitools/db_data/client/model/Usage.java
@@ -49,7 +49,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * Usage
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class Usage {
   public static final String SERIALIZED_NAME_READ_UNITS = "readUnits";
   @SerializedName(SERIALIZED_NAME_READ_UNITS)

--- a/src/main/java/org/openapitools/db_data/client/model/Vector.java
+++ b/src/main/java/org/openapitools/db_data/client/model/Vector.java
@@ -52,7 +52,7 @@ import org.openapitools.db_data.client.JSON;
 /**
  * Vector
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:15.649566Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:53.484175Z[Etc/UTC]")
 public class Vector {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/src/main/java/org/openapitools/inference/client/ApiException.java
+++ b/src/main/java/org/openapitools/inference/client/ApiException.java
@@ -21,7 +21,7 @@ import java.util.List;
  * <p>ApiException class.</p>
  */
 @SuppressWarnings("serial")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/org/openapitools/inference/client/Configuration.java
+++ b/src/main/java/org/openapitools/inference/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.inference.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class Configuration {
     public static final String VERSION = "2024-10";
 

--- a/src/main/java/org/openapitools/inference/client/Pair.java
+++ b/src/main/java/org/openapitools/inference/client/Pair.java
@@ -13,7 +13,7 @@
 
 package org.openapitools.inference.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/org/openapitools/inference/client/StringUtil.java
+++ b/src/main/java/org/openapitools/inference/client/StringUtil.java
@@ -16,7 +16,7 @@ package org.openapitools.inference.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/org/openapitools/inference/client/auth/ApiKeyAuth.java
+++ b/src/main/java/org/openapitools/inference/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/org/openapitools/inference/client/auth/HttpBearerAuth.java
+++ b/src/main/java/org/openapitools/inference/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;

--- a/src/main/java/org/openapitools/inference/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/org/openapitools/inference/client/model/AbstractOpenApiSchema.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/org/openapitools/inference/client/model/EmbedRequest.java
+++ b/src/main/java/org/openapitools/inference/client/model/EmbedRequest.java
@@ -53,7 +53,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * EmbedRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class EmbedRequest {
   public static final String SERIALIZED_NAME_MODEL = "model";
   @SerializedName(SERIALIZED_NAME_MODEL)

--- a/src/main/java/org/openapitools/inference/client/model/EmbedRequestInputsInner.java
+++ b/src/main/java/org/openapitools/inference/client/model/EmbedRequestInputsInner.java
@@ -49,7 +49,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * EmbedRequestInputsInner
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class EmbedRequestInputsInner {
   public static final String SERIALIZED_NAME_TEXT = "text";
   @SerializedName(SERIALIZED_NAME_TEXT)

--- a/src/main/java/org/openapitools/inference/client/model/EmbedRequestParameters.java
+++ b/src/main/java/org/openapitools/inference/client/model/EmbedRequestParameters.java
@@ -49,7 +49,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * Model-specific parameters.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class EmbedRequestParameters {
   public static final String SERIALIZED_NAME_INPUT_TYPE = "input_type";
   @SerializedName(SERIALIZED_NAME_INPUT_TYPE)

--- a/src/main/java/org/openapitools/inference/client/model/Embedding.java
+++ b/src/main/java/org/openapitools/inference/client/model/Embedding.java
@@ -52,7 +52,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * Embedding of a single input
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class Embedding {
   public static final String SERIALIZED_NAME_VALUES = "values";
   @SerializedName(SERIALIZED_NAME_VALUES)

--- a/src/main/java/org/openapitools/inference/client/model/EmbeddingsList.java
+++ b/src/main/java/org/openapitools/inference/client/model/EmbeddingsList.java
@@ -53,7 +53,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * Embeddings generated for the input
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class EmbeddingsList {
   public static final String SERIALIZED_NAME_MODEL = "model";
   @SerializedName(SERIALIZED_NAME_MODEL)

--- a/src/main/java/org/openapitools/inference/client/model/EmbeddingsListUsage.java
+++ b/src/main/java/org/openapitools/inference/client/model/EmbeddingsListUsage.java
@@ -49,7 +49,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * Usage statistics for the model inference.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class EmbeddingsListUsage {
   public static final String SERIALIZED_NAME_TOTAL_TOKENS = "total_tokens";
   @SerializedName(SERIALIZED_NAME_TOTAL_TOKENS)

--- a/src/main/java/org/openapitools/inference/client/model/ErrorResponse.java
+++ b/src/main/java/org/openapitools/inference/client/model/ErrorResponse.java
@@ -50,7 +50,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * The response shape used for all error responses.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class ErrorResponse {
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)

--- a/src/main/java/org/openapitools/inference/client/model/ErrorResponseError.java
+++ b/src/main/java/org/openapitools/inference/client/model/ErrorResponseError.java
@@ -49,7 +49,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * Detailed information about the error that occurred.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class ErrorResponseError {
   /**
    * Gets or Sets code

--- a/src/main/java/org/openapitools/inference/client/model/RankedDocument.java
+++ b/src/main/java/org/openapitools/inference/client/model/RankedDocument.java
@@ -52,7 +52,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * A ranked document with a relevance score and an index position.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class RankedDocument {
   public static final String SERIALIZED_NAME_INDEX = "index";
   @SerializedName(SERIALIZED_NAME_INDEX)

--- a/src/main/java/org/openapitools/inference/client/model/RerankRequest.java
+++ b/src/main/java/org/openapitools/inference/client/model/RerankRequest.java
@@ -53,7 +53,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * RerankRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class RerankRequest {
   public static final String SERIALIZED_NAME_MODEL = "model";
   @SerializedName(SERIALIZED_NAME_MODEL)

--- a/src/main/java/org/openapitools/inference/client/model/RerankResult.java
+++ b/src/main/java/org/openapitools/inference/client/model/RerankResult.java
@@ -53,7 +53,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * The result of a reranking request.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class RerankResult {
   public static final String SERIALIZED_NAME_MODEL = "model";
   @SerializedName(SERIALIZED_NAME_MODEL)

--- a/src/main/java/org/openapitools/inference/client/model/RerankResultUsage.java
+++ b/src/main/java/org/openapitools/inference/client/model/RerankResultUsage.java
@@ -49,7 +49,7 @@ import org.openapitools.inference.client.JSON;
 /**
  * Usage statistics for the model inference.
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-18T13:43:17.189741Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2024-10-22T21:23:54.991514Z[Etc/UTC]")
 public class RerankResultUsage {
   public static final String SERIALIZED_NAME_RERANK_UNITS = "rerank_units";
   @SerializedName(SERIALIZED_NAME_RERANK_UNITS)


### PR DESCRIPTION
## Problem

Made two changes to the open api specs.

## Solution

Regenerate code based on the latest changes in the open api specs. Following commands were ran to generate the code:
```
git submodule init && git submodule update
./codegen/build-oas.sh 2024-10
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Existing integration tests should run successfully.
