### PR TITLE
Update the datatype for parameters in rerank()

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ int topN = 2;
 boolean returnDocuments = true;
 
 // Additional model-specific parameters for the reranker
-Map<String, Object> parameters = new HashMap<>();
+Map<String, String> parameters = new HashMap<>();
 parameters.put("truncate", "END");
 
 // Send ranking request

--- a/src/integration/java/io/pinecone/integration/inference/RerankTest.java
+++ b/src/integration/java/io/pinecone/integration/inference/RerankTest.java
@@ -47,7 +47,7 @@ public class RerankTest {
         List<String> rankFields = Arrays.asList("my_field");
         int topN = 2;
         boolean returnDocuments = true;
-        Map<String, Object> parameters = new HashMap<>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("truncate", "END");
 
         RerankResult result = inference.rerank(model, query, documents, rankFields, topN, returnDocuments, parameters);

--- a/src/main/java/io/pinecone/clients/Inference.java
+++ b/src/main/java/io/pinecone/clients/Inference.java
@@ -104,7 +104,7 @@ public class Inference {
                                List<String> rankFields,
                                int topN,
                                boolean returnDocuments,
-                               Map<String, Object> parameters) throws ApiException {
+                               Map<String, String> parameters) throws ApiException {
         RerankRequest rerankRequest = new RerankRequest();
 
         rerankRequest
@@ -114,7 +114,7 @@ public class Inference {
                 .rankFields(rankFields)
                 .topN(topN)
                 .returnDocuments(returnDocuments)
-                .putAdditionalProperty("parameters", parameters);
+                .parameters(parameters);
 
         return inferenceApi.rerank(rerankRequest);
     }


### PR DESCRIPTION
## Problem

Update the datatype of `parameters` in `rerank()` from `Map<String, Object>` to `Map<String, String>` to better match the OAS.

## Solution

Updated the datatype for the rerank() so the base overloaded method is now:
```java
public RerankResult rerank(String model,
                               String query,
                               List<Map<String, String>> documents,
                               List<String> rankFields,
                               int topN,
                               boolean returnDocuments,
                               Map<String, String> parameters)
``` 
As a part of this change, I have also updated the integration test and README.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Updated the integration test for rerank and the rest of them should run as it is.
