### PR TITLE
Create new config per connection

### DIFF
--- a/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -1,0 +1,100 @@
+package io.pinecone.clients;
+
+import io.pinecone.configs.PineconeConnection;
+import io.pinecone.exceptions.PineconeNotFoundException;
+import io.pinecone.helpers.RandomStringBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openapitools.db_control.client.model.DeletionProtection;
+import org.openapitools.db_control.client.model.IndexModel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.pinecone.helpers.TestUtilities.waitUntilIndexIsReady;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ConnectionsMapTest {
+    static String indexName1;
+    static String indexName2;
+    static Pinecone pinecone;
+
+    @BeforeAll
+    public static void setUp() throws InterruptedException {
+        indexName1 = RandomStringBuilder.build("conn-map-index1", 5);
+        indexName2 = RandomStringBuilder.build("conn-map-index2", 5);
+        pinecone = new Pinecone
+                .Builder(System.getenv("PINECONE_API_KEY"))
+                .withSourceTag("pinecone_test")
+                .build();
+    }
+
+    @Test
+    public void testMultipleIndexesForSameClient() throws InterruptedException {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("env", "test");
+
+        // Create index-1
+        pinecone.createServerlessIndex(indexName1,
+                null,
+                3,
+                "aws",
+                "us-east-1",
+                DeletionProtection.DISABLED,
+                tags);
+
+        // Wait for index to be ready
+        IndexModel indexModel1 = waitUntilIndexIsReady(pinecone, indexName1);
+
+        // Get index1's host
+        String host1 = indexModel1.getHost();
+
+        // Create index-2
+        pinecone.createServerlessIndex(indexName2,
+                null,
+                3,
+                "aws",
+                "us-east-1",
+                DeletionProtection.DISABLED,
+                tags);
+
+        // Wait for index to be ready
+        IndexModel indexModel2 = waitUntilIndexIsReady(pinecone, indexName2);
+
+        // Get index2's host
+        String host2 = indexModel2.getHost();
+
+        // Establish grpc connection for index-1
+        pinecone.getIndexConnection(indexName1);
+        // Get connections map
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap1 = pinecone.getConnectionsMap();
+
+        // Verify connectionsMap contains only one <indexName, connection> pair i.e. for index1 and its connection
+        assertEquals(pinecone.getConnectionsMap().size(), 1);
+        // Verify the value for index1 by comparing its value with host1 in the connectionsMap
+        assertEquals(host1, connectionsMap1.get(indexName1).toString());
+
+        // Establish grpc connection for index-2
+        pinecone.getIndexConnection(indexName2);
+        // Get connections map after establishing second connection
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap2 = pinecone.getConnectionsMap();
+
+        // Verify connectionsMap contains two <indexName, connection> pairs i.e. for index1 and index2
+        assertEquals(connectionsMap2.size(), 2);
+        // Verify the values by checking host for both indexName1 and indexName2
+        assertEquals(host1, connectionsMap2.get(indexName1).toString());
+        assertEquals(host2, connectionsMap2.get(indexName2).toString());
+
+        pinecone.deleteIndex(indexName1);
+        pinecone.deleteIndex(indexName2);
+
+        // Wait for indexes to be deleted
+        Thread.sleep(5000);
+
+        // Confirm the indexes are deleted by calling describe index which should return resource not found
+        assertThrows(PineconeNotFoundException.class, () -> pinecone.describeIndex(indexName1));
+        assertThrows(PineconeNotFoundException.class, () -> pinecone.describeIndex(indexName2));
+    }
+}

--- a/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -19,25 +19,31 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ConnectionsMapTest {
     static String indexName1;
     static String indexName2;
-    static Pinecone pinecone;
+    static Pinecone pinecone1;
+    static Pinecone pinecone2;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
         indexName1 = RandomStringBuilder.build("conn-map-index1", 5);
         indexName2 = RandomStringBuilder.build("conn-map-index2", 5);
-        pinecone = new Pinecone
+        pinecone1 = new Pinecone
+                .Builder(System.getenv("PINECONE_API_KEY"))
+                .withSourceTag("pinecone_test")
+                .build();
+
+        pinecone2 = new Pinecone
                 .Builder(System.getenv("PINECONE_API_KEY"))
                 .withSourceTag("pinecone_test")
                 .build();
     }
 
     @Test
-    public void testMultipleIndexesForSameClient() throws InterruptedException {
+    public void testMultipleIndexesWithMultipleClients() throws InterruptedException {
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
 
         // Create index-1
-        pinecone.createServerlessIndex(indexName1,
+        pinecone1.createServerlessIndex(indexName1,
                 null,
                 3,
                 "aws",
@@ -46,13 +52,13 @@ public class ConnectionsMapTest {
                 tags);
 
         // Wait for index to be ready
-        IndexModel indexModel1 = waitUntilIndexIsReady(pinecone, indexName1);
+        IndexModel indexModel1 = waitUntilIndexIsReady(pinecone1, indexName1);
 
         // Get index1's host
         String host1 = indexModel1.getHost();
 
         // Create index-2
-        pinecone.createServerlessIndex(indexName2,
+        pinecone1.createServerlessIndex(indexName2,
                 null,
                 3,
                 "aws",
@@ -61,40 +67,71 @@ public class ConnectionsMapTest {
                 tags);
 
         // Wait for index to be ready
-        IndexModel indexModel2 = waitUntilIndexIsReady(pinecone, indexName2);
+        IndexModel indexModel2 = waitUntilIndexIsReady(pinecone1, indexName2);
 
         // Get index2's host
         String host2 = indexModel2.getHost();
 
         // Establish grpc connection for index-1
-        pinecone.getIndexConnection(indexName1);
+        Index index1_1 = pinecone1.getIndexConnection(indexName1);
         // Get connections map
-        ConcurrentHashMap<String, PineconeConnection> connectionsMap1 = pinecone.getConnectionsMap();
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap1_1 = pinecone1.getConnectionsMap();
 
         // Verify connectionsMap contains only one <indexName, connection> pair i.e. for index1 and its connection
-        assertEquals(pinecone.getConnectionsMap().size(), 1);
+        assertEquals(pinecone1.getConnectionsMap().size(), 1);
         // Verify the value for index1 by comparing its value with host1 in the connectionsMap
-        assertEquals(host1, connectionsMap1.get(indexName1).toString());
+        assertEquals(host1, connectionsMap1_1.get(indexName1).toString());
 
         // Establish grpc connection for index-2
-        pinecone.getIndexConnection(indexName2);
+        Index index1_2 = pinecone1.getIndexConnection(indexName2);
         // Get connections map after establishing second connection
-        ConcurrentHashMap<String, PineconeConnection> connectionsMap2 = pinecone.getConnectionsMap();
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap1_2 = pinecone1.getConnectionsMap();
 
         // Verify connectionsMap contains two <indexName, connection> pairs i.e. for index1 and index2
-        assertEquals(connectionsMap2.size(), 2);
+        assertEquals(connectionsMap1_2.size(), 2);
         // Verify the values by checking host for both indexName1 and indexName2
-        assertEquals(host1, connectionsMap2.get(indexName1).toString());
-        assertEquals(host2, connectionsMap2.get(indexName2).toString());
+        assertEquals(host1, connectionsMap1_2.get(indexName1).toString());
+        assertEquals(host2, connectionsMap1_2.get(indexName2).toString());
 
-        pinecone.deleteIndex(indexName1);
-        pinecone.deleteIndex(indexName2);
+        // Establishing connections with index1 and index2 using another pinecone client
+        pinecone2.getConnection(indexName1);
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap2_1 = pinecone1.getConnectionsMap();
+        // Verify the new connections map is pointing to the same reference
+        assert connectionsMap2_1 == connectionsMap1_2;
+        // Verify the size of connections map is still 2 since the connection for index2 was not closed
+        assertEquals(2, connectionsMap2_1.size());
+        // Verify the connection value for index1 is host1
+        assertEquals(host1, connectionsMap2_1.get(indexName1).toString());
+
+        pinecone2.getConnection(indexName2);
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap2_2 = pinecone1.getConnectionsMap();
+        // Verify the new connections map is pointing to the same reference
+        assert connectionsMap2_1 == connectionsMap2_2;
+        // Verify the size of connections map is still 2 since the connections are not closed
+        assertEquals(2, connectionsMap2_2.size());
+        // Verify the values by checking host for both indexName1 and indexName2
+        assertEquals(host1, connectionsMap2_2.get(indexName1).toString());
+        assertEquals(host2, connectionsMap2_2.get(indexName2).toString());
+
+        // Close the connections
+        index1_1.close();
+        index1_2.close();
+
+        // Verify the map size is now 0
+        assertEquals(connectionsMap1_1.size(), 0);
+        assertEquals(connectionsMap1_2.size(), 0);
+        assertEquals(connectionsMap2_1.size(), 0);
+        assertEquals(connectionsMap2_2.size(), 0);
+
+        // Delete the indexes
+        pinecone1.deleteIndex(indexName1);
+        pinecone1.deleteIndex(indexName2);
 
         // Wait for indexes to be deleted
         Thread.sleep(5000);
 
         // Confirm the indexes are deleted by calling describe index which should return resource not found
-        assertThrows(PineconeNotFoundException.class, () -> pinecone.describeIndex(indexName1));
-        assertThrows(PineconeNotFoundException.class, () -> pinecone.describeIndex(indexName2));
+        assertThrows(PineconeNotFoundException.class, () -> pinecone1.describeIndex(indexName1));
+        assertThrows(PineconeNotFoundException.class, () -> pinecone1.describeIndex(indexName2));
     }
 }

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -949,7 +949,6 @@ public class Pinecone {
             throw new PineconeValidationException("Index name cannot be null or empty");
         }
 
-        config.setHost(getIndexHost(indexName));
         PineconeConnection connection = getConnection(indexName);
         return new Index(connection, indexName);
     }
@@ -979,7 +978,6 @@ public class Pinecone {
             throw new PineconeValidationException("Index name cannot be null or empty");
         }
 
-        config.setHost(getIndexHost(indexName));
         PineconeConnection connection = getConnection(indexName);
         return new AsyncIndex(config, connection, indexName);
     }
@@ -997,7 +995,9 @@ public class Pinecone {
     }
 
     PineconeConnection getConnection(String indexName) {
-        return connectionsMap.computeIfAbsent(indexName, key -> new PineconeConnection(config));
+        PineconeConfig perConnectionConfig = new PineconeConfig(config.getApiKey());
+        perConnectionConfig.setHost(getIndexHost(indexName));
+        return connectionsMap.computeIfAbsent(indexName, key -> new PineconeConnection(perConnectionConfig));
     }
 
     ConcurrentHashMap<String, PineconeConnection> getConnectionsMap() {

--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -995,7 +995,7 @@ public class Pinecone {
     }
 
     PineconeConnection getConnection(String indexName) {
-        PineconeConfig perConnectionConfig = new PineconeConfig(config.getApiKey());
+        PineconeConfig perConnectionConfig = new PineconeConfig(config.getApiKey(), config.getSourceTag());
         perConnectionConfig.setHost(getIndexHost(indexName));
         return connectionsMap.computeIfAbsent(indexName, key -> new PineconeConnection(perConnectionConfig));
     }

--- a/src/main/java/io/pinecone/configs/PineconeConnection.java
+++ b/src/main/java/io/pinecone/configs/PineconeConnection.java
@@ -203,4 +203,9 @@ public class PineconeConnection implements AutoCloseable {
             logger.warn("Channel shutdown interrupted before termination confirmed");
         }
     }
+
+    @Override
+    public String toString() {
+        return config.getHost();
+    }
 }


### PR DESCRIPTION
## Problem

When connecting to multiple indexes using the same Pinecone instance, the connections for each index are cached in a ConcurrentHashMap called connectionsMap, which maps an indexName to its corresponding PineconeConnection. However, after establishing connections for multiple indexes, all entries in the map incorrectly point to the most recently created PineconeConnection instead of maintaining separate connections for each index.

## Solution

When assigning a host to the PineconeConfig object, which is passed as input for establishing a gRPC connection, create a new PineconeConfig instance instead of modifying the existing one. Otherwise, all connection objects stored in the connectionsMap will share the same PineconeConfig instance, causing them to reference the most recently created PineconeConnection instead of maintaining separate configurations for each index.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Added integration test.
