### PR TITLE
Builder host configuration

### DIFF
--- a/src/main/java/io/pinecone/clients/Pinecone.java
+++ b/src/main/java/io/pinecone/clients/Pinecone.java
@@ -1778,11 +1778,14 @@ public class Pinecone {
                 apiClient = new ApiClient(customOkHttpClient);
             } else {
                 apiClient = new ApiClient(buildOkHttpClient(proxyConfig));
-                if(host!=null && !host.isEmpty()) {
-                    config.setHost(host);
-                    apiClient.setBasePath(host);
-                }
             }
+
+            // Set host regardless of whether customOkHttpClient is used
+            if(host!=null && !host.isEmpty()) {
+                config.setHost(host);
+                apiClient.setBasePath(host);
+            }
+
             apiClient.setApiKey(config.getApiKey());
             apiClient.setUserAgent(config.getUserAgent());
             apiClient.addDefaultHeader("X-Pinecone-Api-Version", Configuration.VERSION);

--- a/src/test/java/io/pinecone/PineconeBuilderTest.java
+++ b/src/test/java/io/pinecone/PineconeBuilderTest.java
@@ -104,4 +104,42 @@ public class PineconeBuilderTest {
         verify(mockClient, times(1)).newCall(requestCaptor.capture());
         assertEquals("lang=java; pineconeClientVersion=" + pineconeClientVersion + "; source_tag=testSourceTag", requestCaptor.getValue().header("User-Agent"));
     }
+
+    @Test
+    public void PineconeWithHostAndCustomOkHttpClient() {
+        String customHost = "http://localhost:5080";
+        OkHttpClient customClient = new OkHttpClient.Builder().build();
+
+        // Verify that the builder doesn't throw an exception when both host and custom client are set
+        Pinecone client = new Pinecone.Builder("testApiKey")
+                .withHost(customHost)
+                .withOkHttpClient(customClient)
+                .build();
+
+        assertNotNull(client, "Pinecone client should be created successfully with both host and custom OkHttpClient");
+    }
+
+    @Test
+    public void PineconeWithHostButNoCustomOkHttpClient() {
+        String customHost = "http://localhost:5080";
+
+        // Verify that the builder doesn't throw an exception when host is set without custom client
+        Pinecone client = new Pinecone.Builder("testApiKey")
+                .withHost(customHost)
+                .build();
+
+        assertNotNull(client, "Pinecone client should be created successfully with host but no custom OkHttpClient");
+    }
+
+    @Test
+    public void PineconeWithCustomOkHttpClientButNoHost() {
+        OkHttpClient customClient = new OkHttpClient.Builder().build();
+
+        // Verify that the builder doesn't throw an exception when custom client is set without host
+        Pinecone client = new Pinecone.Builder("testApiKey")
+                .withOkHttpClient(customClient)
+                .build();
+
+        assertNotNull(client, "Pinecone client should be created successfully with custom OkHttpClient but no host");
+    }
 }


### PR DESCRIPTION
Fixes a bug where the `host` parameter was ignored when `customOkHttpClient` was also provided in `Pinecone.Builder`.

The host handling logic was previously within the `else` block for default `OkHttpClient` creation, causing the specified `host` to be bypassed when a `customOkHttpClient` was provided. This PR moves the host setting logic outside this conditional block, ensuring it is always applied to the `ApiClient` and `config` regardless of whether a custom client is used.

---
Linear Issue: [SDK-55](https://linear.app/pinecone-io/issue/SDK-55/bug-there-is-no-way-to-specify-host-and-customokhttpclient)

<a href="https://cursor.com/background-agent?bcId=bc-ee07c521-d74a-4fa6-9f85-aa9c1f159669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee07c521-d74a-4fa6-9f85-aa9c1f159669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

