### PR TITLE
CI test reports artifacts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,14 @@ jobs:
     - name: Execute Gradle build
       run: gradle clean build
 
+    - name: Upload unit test reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-reports-java-${{ matrix.versions.java }}
+        path: build/reports/tests/test/
+        if-no-files-found: ignore
+
     - name: Build jar
       run: gradle jar
 
@@ -83,6 +91,14 @@ jobs:
       env:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
+
+    - name: Upload integration test reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: integration-test-reports-java-${{ matrix.versions.java }}
+        path: build/reports/tests/integrationTest/
+        if-no-files-found: ignore
 
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,14 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build
 
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-reports-release
+          path: build/reports/tests/test/
+          if-no-files-found: ignore
+
       - name: Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}


### PR DESCRIPTION
Upload unit and integration test reports as GitHub artifacts in CI workflows to make them accessible after job completion.

---
Linear Issue: [SDK-61](https://linear.app/pinecone-io/issue/SDK-61/upload-test-reports-as-github-artifacts-in-ci-workflows)

<a href="https://cursor.com/background-agent?bcId=bc-76beb694-cd36-4f3a-8cdc-937953dcf281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76beb694-cd36-4f3a-8cdc-937953dcf281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds artifact uploads to preserve test outputs across CI.
> 
> - PR workflow: uploads unit test reports (`build/reports/tests/test/`) per Java matrix and integration test reports (`build/reports/tests/integrationTest/`), both with `if: always()` and `if-no-files-found: ignore` via `actions/upload-artifact@v4`.
> - Release workflow: uploads unit test reports (`build/reports/tests/test/`) after build with `actions/upload-artifact@v4`, using `if: always()` and `if-no-files-found: ignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 667ab011efcc854884f119c5c83468eeb35756ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->