### PR TITLE
 Bump version to `6.2.0`, resolve integration test flakiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [comment]: <> (When bumping [pc:VERSION_LATEST_RELEASE] create a new entry below)
 ### Unreleased version
+### 6.2.0
+- Add readUnits, upsertedCount, and matchedRecords to ResponseMetadata
+- Add List operation to ResponseMetadataInterceptor 
+
 ### 6.1.0
 - Add ResponseMetadataListener for dataplane operation observability
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pineconeClientVersion = 6.1.0
+pineconeClientVersion = 6.2.0

--- a/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -99,17 +99,9 @@ public class ConnectionsMapTest {
         assertEquals(host2, connectionsMap.get(indexName2).toString());
 
         // Connecting a second client to the same indexes should reuse the existing map entries
-        int sizeBeforeSecondClient = connectionsMap.size();
-        pinecone2.getConnection(indexName1, config1);
-        // Verify the map is the same reference and the size did not grow
         assertSame(connectionsMap, pinecone2.getConnectionsMap());
-        assertEquals(sizeBeforeSecondClient, connectionsMap.size());
-        assertEquals(host1, connectionsMap.get(indexName1).toString());
-
-        pinecone2.getConnection(indexName2, config2);
-        assertEquals(sizeBeforeSecondClient, connectionsMap.size());
-        assertEquals(host1, connectionsMap.get(indexName1).toString());
-        assertEquals(host2, connectionsMap.get(indexName2).toString());
+        assertSame(connectionsMap.get(indexName1), pinecone2.getConnection(indexName1, config1));
+        assertSame(connectionsMap.get(indexName2), pinecone2.getConnection(indexName2, config2));
 
         // Close the connections
         index1_1.close();

--- a/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static io.pinecone.helpers.TestUtilities.waitUntilIndexIsReady;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConnectionsMapTest {
@@ -100,7 +102,7 @@ public class ConnectionsMapTest {
         int sizeBeforeSecondClient = connectionsMap.size();
         pinecone2.getConnection(indexName1, config1);
         // Verify the map is the same reference and the size did not grow
-        assert pinecone2.getConnectionsMap() == connectionsMap;
+        assertSame(connectionsMap, pinecone2.getConnectionsMap());
         assertEquals(sizeBeforeSecondClient, connectionsMap.size());
         assertEquals(host1, connectionsMap.get(indexName1).toString());
 
@@ -114,8 +116,8 @@ public class ConnectionsMapTest {
         index1_2.close();
 
         // Verify the specific entries for this test's indexes were removed
-        assert !connectionsMap.containsKey(indexName1);
-        assert !connectionsMap.containsKey(indexName2);
+        assertFalse(connectionsMap.containsKey(indexName1));
+        assertFalse(connectionsMap.containsKey(indexName2));
 
         // Delete the indexes
         pinecone1.deleteIndex(indexName1);

--- a/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
+++ b/src/integration/java/io/pinecone/clients/ConnectionsMapTest.java
@@ -78,59 +78,44 @@ public class ConnectionsMapTest {
 
         // Create config2 for getting index connection and set the host
         PineconeConfig config2 = new PineconeConfig(System.getenv("PINECONE_API_KEY"));
-        config1.setHost(host2);
+        config2.setHost(host2);
 
 
         // Establish grpc connection for index-1
         Index index1_1 = pinecone1.getIndexConnection(indexName1);
         // Get connections map
-        ConcurrentHashMap<String, PineconeConnection> connectionsMap1_1 = pinecone1.getConnectionsMap();
+        ConcurrentHashMap<String, PineconeConnection> connectionsMap = pinecone1.getConnectionsMap();
 
-        // Verify connectionsMap contains only one <indexName, connection> pair i.e. for index1 and its connection
-        assertEquals(pinecone1.getConnectionsMap().size(), 1);
-        // Verify the value for index1 by comparing its value with host1 in the connectionsMap
-        assertEquals(host1, connectionsMap1_1.get(indexName1).toString());
+        // Verify indexName1 is in the map with the correct host
+        assertEquals(host1, connectionsMap.get(indexName1).toString());
 
         // Establish grpc connection for index-2
         Index index1_2 = pinecone1.getIndexConnection(indexName2);
-        // Get connections map after establishing second connection
-        ConcurrentHashMap<String, PineconeConnection> connectionsMap1_2 = pinecone1.getConnectionsMap();
 
-        // Verify connectionsMap contains two <indexName, connection> pairs i.e. for index1 and index2
-        assertEquals(connectionsMap1_2.size(), 2);
-        // Verify the values by checking host for both indexName1 and indexName2
-        assertEquals(host1, connectionsMap1_2.get(indexName1).toString());
-        assertEquals(host2, connectionsMap1_2.get(indexName2).toString());
+        // Verify both indexes are now in the map with the correct hosts
+        assertEquals(host1, connectionsMap.get(indexName1).toString());
+        assertEquals(host2, connectionsMap.get(indexName2).toString());
 
-        // Establishing connections with index1 and index2 using another pinecone client
+        // Connecting a second client to the same indexes should reuse the existing map entries
+        int sizeBeforeSecondClient = connectionsMap.size();
         pinecone2.getConnection(indexName1, config1);
-        ConcurrentHashMap<String, PineconeConnection> connectionsMap2_1 = pinecone1.getConnectionsMap();
-        // Verify the new connections map is pointing to the same reference
-        assert connectionsMap2_1 == connectionsMap1_2;
-        // Verify the size of connections map is still 2 since the connection for index2 was not closed
-        assertEquals(2, connectionsMap2_1.size());
-        // Verify the connection value for index1 is host1
-        assertEquals(host1, connectionsMap2_1.get(indexName1).toString());
+        // Verify the map is the same reference and the size did not grow
+        assert pinecone2.getConnectionsMap() == connectionsMap;
+        assertEquals(sizeBeforeSecondClient, connectionsMap.size());
+        assertEquals(host1, connectionsMap.get(indexName1).toString());
 
         pinecone2.getConnection(indexName2, config2);
-        ConcurrentHashMap<String, PineconeConnection> connectionsMap2_2 = pinecone1.getConnectionsMap();
-        // Verify the new connections map is pointing to the same reference
-        assert connectionsMap2_1 == connectionsMap2_2;
-        // Verify the size of connections map is still 2 since the connections are not closed
-        assertEquals(2, connectionsMap2_2.size());
-        // Verify the values by checking host for both indexName1 and indexName2
-        assertEquals(host1, connectionsMap2_2.get(indexName1).toString());
-        assertEquals(host2, connectionsMap2_2.get(indexName2).toString());
+        assertEquals(sizeBeforeSecondClient, connectionsMap.size());
+        assertEquals(host1, connectionsMap.get(indexName1).toString());
+        assertEquals(host2, connectionsMap.get(indexName2).toString());
 
         // Close the connections
         index1_1.close();
         index1_2.close();
 
-        // Verify the map size is now 0
-        assertEquals(connectionsMap1_1.size(), 0);
-        assertEquals(connectionsMap1_2.size(), 0);
-        assertEquals(connectionsMap2_1.size(), 0);
-        assertEquals(connectionsMap2_2.size(), 0);
+        // Verify the specific entries for this test's indexes were removed
+        assert !connectionsMap.containsKey(indexName1);
+        assert !connectionsMap.containsKey(indexName2);
 
         // Delete the indexes
         pinecone1.deleteIndex(indexName1);

--- a/src/integration/java/io/pinecone/helpers/AssertRetry.java
+++ b/src/integration/java/io/pinecone/helpers/AssertRetry.java
@@ -2,18 +2,15 @@ package io.pinecone.helpers;
 
 import io.pinecone.exceptions.PineconeException;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
 public class AssertRetry {
     private static final int maxRetry = 4;
     private static final int delay = 1500;
 
-    public static void assertWithRetry(AssertionRunnable assertionRunnable) throws InterruptedException, PineconeException {
+    public static void assertWithRetry(AssertionRunnable assertionRunnable) throws Exception {
         assertWithRetry(assertionRunnable, 2);
     }
 
-    public static void assertWithRetry(AssertionRunnable assertionRunnable, int backOff) throws AssertionError, InterruptedException {
+    public static void assertWithRetry(AssertionRunnable assertionRunnable, int backOff) throws Exception {
         int retryCount = 0;
         int delayCount = delay;
         boolean success = false;
@@ -23,7 +20,7 @@ public class AssertRetry {
             try {
                 assertionRunnable.run();
                 success = true;
-            } catch (AssertionError | ExecutionException | IOException e) {
+            } catch (AssertionError | Exception e) {
                 errorMessage = e.getLocalizedMessage();
                 retryCount++;
                 delayCount*=backOff;
@@ -38,6 +35,6 @@ public class AssertRetry {
 
     @FunctionalInterface
     public interface AssertionRunnable {
-        void run() throws AssertionError, ExecutionException, InterruptedException, IOException, PineconeException;
+        void run() throws Exception;
     }
 }

--- a/src/integration/java/io/pinecone/helpers/AssertRetry.java
+++ b/src/integration/java/io/pinecone/helpers/AssertRetry.java
@@ -20,6 +20,9 @@ public class AssertRetry {
             try {
                 assertionRunnable.run();
                 success = true;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
             } catch (AssertionError | Exception e) {
                 errorMessage = e.getLocalizedMessage();
                 retryCount++;

--- a/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class TestResourcesManager {
     private static final Logger logger = LoggerFactory.getLogger(TestUtilities.class);
-    private static TestResourcesManager instance;
+    private static volatile TestResourcesManager instance;
     private static final String apiKey = System.getenv("PINECONE_API_KEY");
     private final int dimension = System.getenv("DIMENSION") == null
             ? 4
@@ -85,7 +85,7 @@ public class TestResourcesManager {
      *
      * @return the {@link TestResourcesManager} instance.
      */
-    public static TestResourcesManager getInstance() {
+    public static synchronized TestResourcesManager getInstance() {
         if (instance == null) {
             instance = new TestResourcesManager();
         }
@@ -225,7 +225,7 @@ public class TestResourcesManager {
      *
      * @return the {@link IndexModel} of the pod index.
      */
-    public IndexModel getOrCreatePodIndexModel() throws InterruptedException {
+    public synchronized IndexModel getOrCreatePodIndexModel() throws InterruptedException {
         podIndexModel = pineconeClient.describeIndex(getOrCreatePodIndex());
         return podIndexModel;
     }
@@ -236,7 +236,7 @@ public class TestResourcesManager {
      *
      * @return the {@link IndexModel} of the serverless index.
      */
-    public IndexModel getOrCreateServerlessIndexModel() throws InterruptedException {
+    public synchronized IndexModel getOrCreateServerlessIndexModel() throws InterruptedException {
         serverlessIndexModel = pineconeClient.describeIndex(getOrCreateServerlessIndex());
         return serverlessIndexModel;
     }
@@ -247,7 +247,7 @@ public class TestResourcesManager {
      *
      * @return the {@link CollectionModel} of the serverless index.
      */
-    public CollectionModel getOrCreateCollectionModel() throws InterruptedException {
+    public synchronized CollectionModel getOrCreateCollectionModel() throws InterruptedException {
         collectionModel = pineconeClient.describeCollection(getOrCreateCollection());
         return collectionModel;
     }
@@ -280,7 +280,7 @@ public class TestResourcesManager {
      * @throws InterruptedException if the thread is interrupted while waiting for the index to be ready.
      * @throws PineconeException if the API encounters an error during index creation or if any of the arguments are invalid.
      */
-    public String getOrCreatePodIndex() throws InterruptedException, PineconeException {
+    public synchronized String getOrCreatePodIndex() throws InterruptedException, PineconeException {
         if (podIndexName != null) {
             return podIndexName;
         }
@@ -311,7 +311,7 @@ public class TestResourcesManager {
      * @throws InterruptedException if the thread is interrupted while waiting for the index to be ready.
      * @throws PineconeException if the API encounters an error during index creation or if any of the arguments are invalid.
      */
-    public String getOrCreateServerlessIndex() throws InterruptedException, PineconeException {
+    public synchronized String getOrCreateServerlessIndex() throws InterruptedException, PineconeException {
         if (this.serverlessIndexName != null) {
             return this.serverlessIndexName;
         }
@@ -344,7 +344,7 @@ public class TestResourcesManager {
      * @throws InterruptedException if the thread is interrupted while waiting for the collection to be ready.
      * @throws PineconeException if the API encounters an error during collection creation.
      */
-    public String getOrCreateCollection() throws InterruptedException, PineconeException {
+    public synchronized String getOrCreateCollection() throws InterruptedException, PineconeException {
         if (collectionName != null) {
             return collectionName;
         }

--- a/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
@@ -359,13 +359,13 @@ public class TestResourcesManager {
         // Wait until collection is ready
         int timeWaited = 0;
         String collectionReady = collectionModel.getStatus().toLowerCase();
-        while (collectionReady != "ready" && timeWaited < 120000) {
+        while (!"ready".equals(collectionReady) && timeWaited < 120000) {
             logger.info("Waiting for collection " + collectionName + " to be ready. Waited " + timeWaited + " " +
                     "milliseconds...");
             Thread.sleep(5000);
             timeWaited += 5000;
             collectionModel = pineconeClient.describeCollection(collectionName);
-            collectionReady = collectionModel.getStatus();
+            collectionReady = collectionModel.getStatus().toLowerCase();
         }
 
         if (timeWaited > 120000) {

--- a/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
@@ -189,6 +189,17 @@ public class TestResourcesManager {
      *
      * @return a {@link Index} connection to the serverless index.
      */
+    /**
+     * Gets the host for the shared serverless index. Creates the index first if it doesn't exist.
+     * Used by tests that need to construct their own PineconeConnection (e.g. to attach a custom listener)
+     * without going through the shared static connection cache.
+     *
+     * @return the host URL of the shared serverless index.
+     */
+    public synchronized String getOrCreateServerlessIndexHost() throws InterruptedException {
+        return pineconeClient.describeIndex(getOrCreateServerlessIndex()).getHost();
+    }
+
     public synchronized Index getOrCreateServerlessIndexConnection() throws InterruptedException {
         if (serverlessIndexConnection == null) {
             serverlessIndexConnection = pineconeClient.getIndexConnection(getOrCreateServerlessIndex());

--- a/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
+++ b/src/integration/java/io/pinecone/helpers/TestResourcesManager.java
@@ -66,6 +66,10 @@ public class TestResourcesManager {
     private String serverlessIndexName;
     private String collectionName;
     private CollectionModel collectionModel;
+    private Index serverlessIndexConnection;
+    private AsyncIndex serverlessAsyncIndexConnection;
+    private Index podIndexConnection;
+    private AsyncIndex podAsyncIndexConnection;
     private final List<String> vectorIdsForDefaultNamespace = Arrays.asList("def-id1", "def-id2", "def-prefix-id3", "def-prefix-id4");
     private final List<String> vectorIdsForCustomNamespace = Arrays.asList("cus-id1", "cus-id2", "cus-prefix-id3", "cus" +
             "-prefix-id4");
@@ -185,8 +189,11 @@ public class TestResourcesManager {
      *
      * @return a {@link Index} connection to the serverless index.
      */
-    public  Index getOrCreateServerlessIndexConnection() throws InterruptedException {
-        return getInstance().pineconeClient.getIndexConnection(getOrCreateServerlessIndex());
+    public synchronized Index getOrCreateServerlessIndexConnection() throws InterruptedException {
+        if (serverlessIndexConnection == null) {
+            serverlessIndexConnection = pineconeClient.getIndexConnection(getOrCreateServerlessIndex());
+        }
+        return serverlessIndexConnection;
     }
 
     /**
@@ -195,8 +202,11 @@ public class TestResourcesManager {
      *
      * @return a {@link AsyncIndex} connection to the serverless index.
      */
-    public AsyncIndex getOrCreateServerlessAsyncIndexConnection() throws InterruptedException {
-        return getInstance().pineconeClient.getAsyncIndexConnection(getOrCreateServerlessIndex());
+    public synchronized AsyncIndex getOrCreateServerlessAsyncIndexConnection() throws InterruptedException {
+        if (serverlessAsyncIndexConnection == null) {
+            serverlessAsyncIndexConnection = pineconeClient.getAsyncIndexConnection(getOrCreateServerlessIndex());
+        }
+        return serverlessAsyncIndexConnection;
     }
 
     /**
@@ -205,8 +215,11 @@ public class TestResourcesManager {
      *
      * @return a {@link Index} connection to the pod index.
      */
-    public  Index getOrCreatePodIndexConnection() throws InterruptedException {
-        return getInstance().pineconeClient.getIndexConnection(getOrCreatePodIndex());
+    public synchronized Index getOrCreatePodIndexConnection() throws InterruptedException {
+        if (podIndexConnection == null) {
+            podIndexConnection = pineconeClient.getIndexConnection(getOrCreatePodIndex());
+        }
+        return podIndexConnection;
     }
 
     /**
@@ -215,8 +228,11 @@ public class TestResourcesManager {
      *
      * @return a {@link AsyncIndex} connection to the pod index.
      */
-    public AsyncIndex getOrCreatePodAsyncIndexConnection() throws InterruptedException {
-        return getInstance().pineconeClient.getAsyncIndexConnection(getOrCreatePodIndex());
+    public synchronized AsyncIndex getOrCreatePodAsyncIndexConnection() throws InterruptedException {
+        if (podAsyncIndexConnection == null) {
+            podAsyncIndexConnection = pineconeClient.getAsyncIndexConnection(getOrCreatePodIndex());
+        }
+        return podAsyncIndexConnection;
     }
 
     /**
@@ -257,6 +273,19 @@ public class TestResourcesManager {
      * after all tests have finished running.
      */
     public void cleanupResources() {
+        if (serverlessIndexConnection != null) {
+            serverlessIndexConnection.close();
+        }
+        if (serverlessAsyncIndexConnection != null) {
+            serverlessAsyncIndexConnection.close();
+        }
+        if (podIndexConnection != null) {
+            podIndexConnection.close();
+        }
+        if (podAsyncIndexConnection != null) {
+            podAsyncIndexConnection.close();
+        }
+
         if (podIndexName != null) {
             pineconeClient.deleteIndex(podIndexName);
         }

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/CollectionTest.java
@@ -41,7 +41,7 @@ public class CollectionTest {
     private static String namespace;
 
     @BeforeAll
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
         indexName = indexManager.getOrCreatePodIndex();
         collectionName = indexManager.getOrCreateCollection();
         collection = indexManager.getOrCreateCollectionModel();
@@ -49,7 +49,7 @@ public class CollectionTest {
     }
 
     @AfterAll
-    public static void cleanUp() throws InterruptedException {
+    public static void cleanUp() throws Exception {
         // Clean up indexes
         for (String index : indexesToCleanUp) {
             pineconeClient.deleteIndex(index);
@@ -57,7 +57,7 @@ public class CollectionTest {
     }
 
     @Test
-    public void testIndexFromCollectionHappyPath() throws InterruptedException {
+    public void testIndexFromCollectionHappyPath() throws Exception {
         // Verify collection is listed
         List<CollectionModel> collectionList = pineconeClient.listCollections().getCollections();
         boolean collectionFound = false;
@@ -115,7 +115,7 @@ public class CollectionTest {
     }
 
     @Test
-    public void testCreateIndexFromCollectionWithDiffMetric() throws InterruptedException {
+    public void testCreateIndexFromCollectionWithDiffMetric() throws Exception {
         // Use a different metric than the source index
         String[] metrics = {
                 "cosine",
@@ -232,7 +232,7 @@ public class CollectionTest {
     }
 
     @Test
-    public void testCreateCollectionFromNotReadyIndex() throws InterruptedException {
+    public void testCreateCollectionFromNotReadyIndex() throws Exception {
         String notReadyIndexName = RandomStringBuilder.build("from-coll", 8);
         String newCollectionName = RandomStringBuilder.build("coll-", 8);
         try {

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -34,11 +34,11 @@ public class ConfigureIndexTest {
     private static String indexName;
 
     @BeforeAll
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
         indexName = indexManager.getOrCreatePodIndex();
     }
 
-    private static void waitUntilIndexStateIsReady(String indexName) throws InterruptedException {
+    private static void waitUntilIndexStateIsReady(String indexName) throws Exception {
         int timeToWaitMs = 100000;
         int timeWaited = 0;
         IndexModel index = controlPlaneClient.describeIndex(indexName);
@@ -55,7 +55,7 @@ public class ConfigureIndexTest {
     }
 
     @AfterEach
-    public void afterEach() throws InterruptedException {
+    public void afterEach() throws Exception {
         waitUntilIndexStateIsReady(indexName);
     }
 
@@ -81,7 +81,7 @@ public class ConfigureIndexTest {
     }
 
     @Test
-    public void scaleUpAndDown() throws InterruptedException {
+    public void scaleUpAndDown() throws Exception {
         IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
         assertNotNull(indexModel.getSpec().getIndexModelPodBased().getPod());
         assertEquals(1, indexModel.getSpec().getIndexModelPodBased().getPod().getReplicas());
@@ -106,7 +106,7 @@ public class ConfigureIndexTest {
     }
 
     @Test
-    public void changingBasePodType() throws InterruptedException {
+    public void changingBasePodType() throws Exception {
         try {
             // Verify the starting state
             IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
@@ -123,7 +123,7 @@ public class ConfigureIndexTest {
     }
 
     @Test
-    public void sizeIncrease() throws InterruptedException {
+    public void sizeIncrease() throws Exception {
         // Verify the starting state
         IndexModel indexModel = controlPlaneClient.describeIndex(indexName);
         assertNotNull(indexModel.getSpec().getIndexModelPodBased().getPod());

--- a/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/pod/ConfigureIndexTest.java
@@ -9,6 +9,7 @@ import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.openapitools.db_control.client.model.IndexModel;
 import org.openapitools.db_control.client.model.PodSpec;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Isolated
 public class ConfigureIndexTest {
     private static final Logger logger = LoggerFactory.getLogger(ConfigureIndexTest.class);
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
@@ -43,7 +45,7 @@ public class ConfigureIndexTest {
         int timeWaited = 0;
         IndexModel index = controlPlaneClient.describeIndex(indexName);
 
-        while (index.getStatus().getState() != "ready" && timeWaited <= timeToWaitMs) {
+        while (!"ready".equalsIgnoreCase(index.getStatus().getState()) && timeWaited <= timeToWaitMs) {
             Thread.sleep(2000);
             timeWaited += 2000;
             logger.info("waited 2000ms for index to upgrade, time waited: " + timeWaited);

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/ReadCapacityAndSchemaTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/ReadCapacityAndSchemaTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.*;
 import org.openapitools.db_control.client.ApiException;
 import org.openapitools.db_control.client.model.*;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -27,43 +29,48 @@ public class ReadCapacityAndSchemaTest {
                     .build())
             .build();
 
+    private static final List<String> createdIndexNames = new ArrayList<>();
+
+    @AfterAll
+    static void cleanUp() {
+        for (String name : createdIndexNames) {
+            try {
+                controlPlaneClient.deleteIndex(name);
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
     @Test
     @Order(1)
-    public void createServerlessIndexWithOnDemandReadCapacity() throws InterruptedException {
-        String indexNameOnDemand = RandomStringBuilder.build("ondemand-index", 8);
+    public void createServerlessIndexWithOnDemandReadCapacity() {
+        String indexName = RandomStringBuilder.build("ondemand-index", 8);
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
         tags.put("read-capacity", "ondemand");
 
-        // Create index with OnDemand read capacity
         ReadCapacity readCapacity = new ReadCapacity(new ReadCapacityOnDemandSpec().mode("OnDemand"));
         IndexModel indexModel = controlPlaneClient.createServerlessIndex(
-                indexNameOnDemand, "cosine", 1536, "aws", "us-west-2", 
+                indexName, "cosine", 1536, "aws", "us-west-2",
                 "disabled", tags, readCapacity, null);
+        createdIndexNames.add(indexName);
 
         assertNotNull(indexModel);
-        assertEquals(indexNameOnDemand, indexModel.getName());
+        assertEquals(indexName, indexModel.getName());
         assertEquals("cosine", indexModel.getMetric());
         assertEquals(1536, indexModel.getDimension());
         assertEquals("disabled", indexModel.getDeletionProtection());
         assertEquals(tags, indexModel.getTags());
-
-        // Wait for index to be ready and verify read capacity
-        waitUntilIndexIsReady(controlPlaneClient, indexNameOnDemand);
-        IndexModel describedIndex = controlPlaneClient.describeIndex(indexNameOnDemand);
-        assertNotNull(describedIndex.getSpec().getIndexModelServerless());
-        // Note: Read capacity response may not be immediately available in describe
     }
 
     @Test
     @Order(2)
-    public void createServerlessIndexWithDedicatedReadCapacity() throws InterruptedException {
-        String indexNameDedicated = RandomStringBuilder.build("dedicated-index", 8);
+    public void createServerlessIndexWithDedicatedReadCapacity() {
+        String indexName = RandomStringBuilder.build("dedicated-index", 8);
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
         tags.put("read-capacity", "dedicated");
 
-        // Create index with Dedicated read capacity
         ScalingConfigManual manual = new ScalingConfigManual().shards(2).replicas(2);
         ReadCapacityDedicatedConfig dedicated = new ReadCapacityDedicatedConfig()
                 .nodeType("t1")
@@ -73,29 +80,26 @@ public class ReadCapacityAndSchemaTest {
                 new ReadCapacityDedicatedSpec().mode("Dedicated").dedicated(dedicated));
 
         IndexModel indexModel = controlPlaneClient.createServerlessIndex(
-                indexNameDedicated, "cosine", 1536, "aws", "us-west-2", 
+                indexName, "cosine", 1536, "aws", "us-west-2",
                 "disabled", tags, readCapacity, null);
+        createdIndexNames.add(indexName);
 
         assertNotNull(indexModel);
-        assertEquals(indexNameDedicated, indexModel.getName());
+        assertEquals(indexName, indexModel.getName());
         assertEquals("cosine", indexModel.getMetric());
         assertEquals(1536, indexModel.getDimension());
         assertEquals("disabled", indexModel.getDeletionProtection());
         assertEquals(tags, indexModel.getTags());
-
-        // Wait for index to be ready
-        waitUntilIndexIsReady(controlPlaneClient, indexNameDedicated);
     }
 
     @Test
     @Order(3)
-    public void createServerlessIndexWithMetadataSchema() throws InterruptedException {
-        String indexNameWithSchema = RandomStringBuilder.build("schema-index", 8);
+    public void createServerlessIndexWithMetadataSchema() {
+        String indexName = RandomStringBuilder.build("schema-index", 8);
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
         tags.put("schema", "configured");
 
-        // Create index with metadata schema
         Map<String, BackupModelSchemaFieldsValue> fields = new HashMap<>();
         fields.put("genre", new BackupModelSchemaFieldsValue().filterable(true));
         fields.put("year", new BackupModelSchemaFieldsValue().filterable(true));
@@ -103,28 +107,25 @@ public class ReadCapacityAndSchemaTest {
         BackupModelSchema schema = new BackupModelSchema().fields(fields);
 
         IndexModel indexModel = controlPlaneClient.createServerlessIndex(
-                indexNameWithSchema, "cosine", 1536, "aws", "us-west-2", 
+                indexName, "cosine", 1536, "aws", "us-west-2",
                 "disabled", tags, null, schema);
+        createdIndexNames.add(indexName);
 
         assertNotNull(indexModel);
-        assertEquals(indexNameWithSchema, indexModel.getName());
+        assertEquals(indexName, indexModel.getName());
         assertEquals("cosine", indexModel.getMetric());
         assertEquals(1536, indexModel.getDimension());
         assertEquals("disabled", indexModel.getDeletionProtection());
         assertEquals(tags, indexModel.getTags());
-
-        // Wait for index to be ready
-        waitUntilIndexIsReady(controlPlaneClient, indexNameWithSchema);
     }
 
     @Test
     @Order(4)
-    public void createServerlessIndexWithBothReadCapacityAndSchema() throws InterruptedException {
+    public void createServerlessIndexWithBothReadCapacityAndSchema() {
         String indexName = RandomStringBuilder.build("both-config-index", 8);
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
 
-        // Create index with both Dedicated read capacity and metadata schema
         ScalingConfigManual manual = new ScalingConfigManual().shards(1).replicas(1);
         ReadCapacityDedicatedConfig dedicated = new ReadCapacityDedicatedConfig()
                 .nodeType("t1")
@@ -139,29 +140,23 @@ public class ReadCapacityAndSchemaTest {
         BackupModelSchema schema = new BackupModelSchema().fields(fields);
 
         IndexModel indexModel = controlPlaneClient.createServerlessIndex(
-                indexName, "cosine", 1536, "aws", "us-west-2", 
+                indexName, "cosine", 1536, "aws", "us-west-2",
                 "disabled", tags, readCapacity, schema);
+        createdIndexNames.add(indexName);
 
         assertNotNull(indexModel);
         assertEquals(indexName, indexModel.getName());
         assertEquals("cosine", indexModel.getMetric());
         assertEquals(1536, indexModel.getDimension());
-
-        // Wait for index to be ready
-        waitUntilIndexIsReady(controlPlaneClient, indexName);
-
-        // Clean up
-        controlPlaneClient.deleteIndex(indexName);
     }
 
     @Test
     @Order(5)
-    public void createIndexForModelWithReadCapacityAndSchema() throws InterruptedException, ApiException {
-        String indexNameForModel = RandomStringBuilder.build("model-index", 8);
+    public void createIndexForModelWithReadCapacityAndSchema() throws ApiException {
+        String indexName = RandomStringBuilder.build("model-index", 8);
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
 
-        // Create index for model with Dedicated read capacity and metadata schema
         ScalingConfigManual manual = new ScalingConfigManual().shards(1).replicas(1);
         ReadCapacityDedicatedConfig dedicated = new ReadCapacityDedicatedConfig()
                 .nodeType("t1")
@@ -181,52 +176,46 @@ public class ReadCapacityAndSchemaTest {
         embed.fieldMap(fieldMap);
 
         IndexModel indexModel = controlPlaneClient.createIndexForModel(
-                indexNameForModel, "aws", "us-east-1", embed, 
+                indexName, "aws", "us-east-1", embed,
                 "disabled", tags, readCapacity, schema);
+        createdIndexNames.add(indexName);
 
         assertNotNull(indexModel);
-        assertEquals(indexNameForModel, indexModel.getName());
+        assertEquals(indexName, indexModel.getName());
         assertEquals("disabled", indexModel.getDeletionProtection());
         assertEquals(tags, indexModel.getTags());
-
-        // Wait for index to be ready
-        waitUntilIndexIsReady(controlPlaneClient, indexNameForModel);
     }
 
     @Test
     @Order(6)
     public void configureReadCapacityOnExistingIndex() throws InterruptedException {
-        String indexNameToConfigure = RandomStringBuilder.build("configure-index", 8);
+        String indexName = RandomStringBuilder.build("configure-index", 8);
         Map<String, String> tags = new HashMap<>();
         tags.put("env", "test");
 
-        // First, create an index without read capacity configuration (defaults to OnDemand)
         IndexModel indexModel = controlPlaneClient.createServerlessIndex(
-                indexNameToConfigure, "cosine", 1536, "aws", "us-west-2", 
+                indexName, "cosine", 1536, "aws", "us-west-2",
                 "disabled", tags, null, null);
+        createdIndexNames.add(indexName);
 
         assertNotNull(indexModel);
-        assertEquals(indexNameToConfigure, indexModel.getName());
+        assertEquals(indexName, indexModel.getName());
 
-        // Wait for index to be ready
-        waitUntilIndexIsReady(controlPlaneClient, indexNameToConfigure);
-        // Wait for read capacity to be ready before configuring
-        waitUntilReadCapacityIsReady(controlPlaneClient, indexNameToConfigure);
+        // Must be ready before configuring read capacity
+        waitUntilIndexIsReady(controlPlaneClient, indexName);
+        waitUntilReadCapacityIsReady(controlPlaneClient, indexName);
 
-        // Configure to Dedicated read capacity
         IndexModel configuredIndex = controlPlaneClient.configureServerlessIndex(
-                indexNameToConfigure, "disabled", tags, null, "Dedicated", "t1", 2, 2);
+                indexName, "disabled", tags, null, "Dedicated", "t1", 2, 2);
 
         assertNotNull(configuredIndex);
-        assertEquals(indexNameToConfigure, configuredIndex.getName());
+        assertEquals(indexName, configuredIndex.getName());
 
-        // Wait a bit for configuration to apply
         Thread.sleep(10000);
 
-        // Verify the configuration by describing the index
-        IndexModel describedIndex = controlPlaneClient.describeIndex(indexNameToConfigure);
+        IndexModel describedIndex = controlPlaneClient.describeIndex(indexName);
         assertNotNull(describedIndex);
-        assertEquals(indexNameToConfigure, describedIndex.getName());
+        assertEquals(indexName, describedIndex.getName());
     }
 
     // Note: Tests for switching read capacity modes and scaling are omitted due to API rate limits.
@@ -236,4 +225,3 @@ public class ReadCapacityAndSchemaTest {
     // - Scaling dedicated read capacity (changing shards/replicas)
     // These operations are still supported by the API, but cannot be tested in CI/CD due to rate limits.
 }
-

--- a/src/integration/java/io/pinecone/integration/controlPlane/serverless/ReadCapacityAndSchemaTest.java
+++ b/src/integration/java/io/pinecone/integration/controlPlane/serverless/ReadCapacityAndSchemaTest.java
@@ -4,6 +4,8 @@ import io.pinecone.clients.Pinecone;
 import io.pinecone.helpers.RandomStringBuilder;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.openapitools.db_control.client.ApiException;
 import org.openapitools.db_control.client.model.*;
 
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ReadCapacityAndSchemaTest {
+    private static final Logger logger = LoggerFactory.getLogger(ReadCapacityAndSchemaTest.class);
     private static final Pinecone controlPlaneClient = new Pinecone
             .Builder(System.getenv("PINECONE_API_KEY"))
             .withSourceTag("pinecone_test")
@@ -36,7 +39,8 @@ public class ReadCapacityAndSchemaTest {
         for (String name : createdIndexNames) {
             try {
                 controlPlaneClient.deleteIndex(name);
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                logger.warn("Failed to delete index '{}' during cleanup: {}", name, e.getMessage());
             }
         }
     }

--- a/src/integration/java/io/pinecone/integration/dataPlane/FetchAndUpdateByMetadataTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/FetchAndUpdateByMetadataTest.java
@@ -9,7 +9,6 @@ import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.FetchByMetadataResponse;
 import io.pinecone.proto.UpdateResponse;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -56,12 +55,6 @@ public class FetchAndUpdateByMetadataTest {
         
         // Wait for vectors to be indexed
         Thread.sleep(5000);
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        index.close();
-        asyncIndex.close();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/FetchAndUpdateByMetadataTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/FetchAndUpdateByMetadataTest.java
@@ -30,7 +30,7 @@ public class FetchAndUpdateByMetadataTest {
     private static final String namespace = RandomStringBuilder.build("ns", 8);
 
     @BeforeAll
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
         int dimension = indexManager.getDimension();
         index = indexManager.getOrCreateServerlessIndexConnection();
         asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
@@ -65,7 +65,7 @@ public class FetchAndUpdateByMetadataTest {
     }
 
     @Test
-    public void fetchByMetadataSyncTest() throws InterruptedException {
+    public void fetchByMetadataSyncTest() throws Exception {
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
         String filterValue = metadataMap.get(metadataFields[0]).get(0);
         
@@ -86,7 +86,7 @@ public class FetchAndUpdateByMetadataTest {
     }
 
     @Test
-    public void updateByMetadataSyncTest() throws InterruptedException {
+    public void updateByMetadataSyncTest() throws Exception {
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
         String filterValue = metadataMap.get(metadataFields[0]).get(0);
         
@@ -111,7 +111,7 @@ public class FetchAndUpdateByMetadataTest {
     }
 
     @Test
-    public void fetchByMetadataAsyncTest() throws InterruptedException, ExecutionException {
+    public void fetchByMetadataAsyncTest() throws Exception {
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
         String filterValue = metadataMap.get(metadataFields[1]).get(0);
         
@@ -132,7 +132,7 @@ public class FetchAndUpdateByMetadataTest {
     }
 
     @Test
-    public void updateByMetadataAsyncTest() throws InterruptedException, ExecutionException {
+    public void updateByMetadataAsyncTest() throws Exception {
         HashMap<String, List<String>> metadataMap = createAndGetMetadataMap();
         String filterValue = metadataMap.get(metadataFields[1]).get(0);
         

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -18,8 +18,14 @@ public class ListEndpointTest {
     private static AsyncIndex asyncIndexConnection;
     private static String customNamespace;
 
+    // ID prefixes used when seeding the shared index in TestResourcesManager.
+    // Filtering by these prefixes makes assertions immune to concurrent test writes.
+    private static final String DEFAULT_NS_PREFIX = "def-";
+    private static final String CUSTOM_NS_PREFIX = "cus-";
+    private static final String CUSTOM_NS_SUBPREFIX = "cus-prefix-";
+
     @BeforeAll
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
         indexManager.getOrCreateServerlessIndex();
         indexConnection = indexManager.getOrCreateServerlessIndexConnection();
         asyncIndexConnection = indexManager.getOrCreateServerlessAsyncIndexConnection();
@@ -33,86 +39,76 @@ public class ListEndpointTest {
     }
 
     @Test
-    public void testSyncListEndpoint() throws InterruptedException {
-        // Confirm default vector IDs are returned when no namespace is specified
-        ListResponse listResponseNoArgs = indexConnection.list();
-        assertEquals(listResponseNoArgs.getVectorsList().size(), 4);
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-id1"));
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-id2"));
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-prefix-id3"));
-        assertTrue(listResponseNoArgs.getVectorsList().toString().contains("def-prefix-id4"));
+    public void testSyncListEndpoint() throws Exception {
+        // Use prefix filtering so concurrent writes to these namespaces don't affect counts
+        ListResponse listDefaultNs = indexConnection.list("", DEFAULT_NS_PREFIX);
+        assertEquals(4, listDefaultNs.getVectorsList().size());
+        assertTrue(listDefaultNs.getVectorsList().toString().contains("def-id1"));
+        assertTrue(listDefaultNs.getVectorsList().toString().contains("def-id2"));
+        assertTrue(listDefaultNs.getVectorsList().toString().contains("def-prefix-id3"));
+        assertTrue(listDefaultNs.getVectorsList().toString().contains("def-prefix-id4"));
 
-        // Confirm all vector IDs from custom namespace are returned when pass customNamespace
-        ListResponse listResponseCustomNamespace = indexConnection.list(customNamespace);
-        assertEquals(listResponseCustomNamespace.getVectorsList().size(), 4);
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-id1"));
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-id2"));
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id3"));
-        assertTrue(listResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id4"));
+        ListResponse listCustomNs = indexConnection.list(customNamespace, CUSTOM_NS_PREFIX);
+        assertEquals(4, listCustomNs.getVectorsList().size());
+        assertTrue(listCustomNs.getVectorsList().toString().contains("cus-id1"));
+        assertTrue(listCustomNs.getVectorsList().toString().contains("cus-id2"));
+        assertTrue(listCustomNs.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(listCustomNs.getVectorsList().toString().contains("cus-prefix-id4"));
 
-        // Confirm all vector IDs from custom namespace are returned, filtered by given prefix
-        ListResponse listResponseCustomNamespaceWithPrefix = indexConnection.list(customNamespace, "cus-prefix-");
-        assertEquals(listResponseCustomNamespaceWithPrefix.getVectorsList().size(), 2);
-        assertTrue(listResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id3"));
-        assertTrue(listResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id4"));
+        // Sub-prefix filter
+        ListResponse listCustomNsSubPrefix = indexConnection.list(customNamespace, CUSTOM_NS_SUBPREFIX);
+        assertEquals(2, listCustomNsSubPrefix.getVectorsList().size());
+        assertTrue(listCustomNsSubPrefix.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(listCustomNsSubPrefix.getVectorsList().toString().contains("cus-prefix-id4"));
 
-        // Confirm all vector IDs from custom namespace are returned when limit is specified
-        ListResponse listResponseWithLimit = indexConnection.list(customNamespace, 1);
-        assertEquals(1, listResponseWithLimit.getVectorsList().size());
+        // Limit
+        ListResponse listWithLimit = indexConnection.list(customNamespace, CUSTOM_NS_PREFIX, 1);
+        assertEquals(1, listWithLimit.getVectorsList().size());
 
-        // Confirm all vector IDs from custom namespace are returned using pagination
-        ListResponse listResponseWithPaginationNoPrefix1 = indexConnection.list(customNamespace, 2);
-        assertEquals(listResponseWithPaginationNoPrefix1.getVectorsList().size(), 2);
-        ListResponse listResponseWithPaginationNoPrefix2 = indexConnection.list(
-                customNamespace,
-                2,
-                listResponseWithPaginationNoPrefix1.getPagination().getNext()
-        );
-        assertEquals(listResponseWithPaginationNoPrefix2.getVectorsList().size(), 2);
+        // Pagination over exactly the 4 pre-seeded cus-* vectors
+        ListResponse page1 = indexConnection.list(customNamespace, CUSTOM_NS_PREFIX, 2);
+        assertEquals(2, page1.getVectorsList().size());
+        ListResponse page2 = indexConnection.list(
+                customNamespace, CUSTOM_NS_PREFIX, page1.getPagination().getNext(), 2);
+        assertEquals(2, page2.getVectorsList().size());
     }
 
     @Test
-    public void testAsyncListEndpoint() throws InterruptedException {
-        // Confirm default vector IDs are returned when no namespace is specified
-        ListenableFuture<ListResponse> futureResponseNoArgs = asyncIndexConnection.list();
-        ListResponse asyncListResponseNoArgs = Futures.getUnchecked(futureResponseNoArgs);
-        assertEquals(asyncListResponseNoArgs.getVectorsList().size(), 4);
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-id1"));
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-id2"));
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-prefix-id3"));
-        assertTrue(asyncListResponseNoArgs.getVectorsList().toString().contains("def-prefix-id4"));
+    public void testAsyncListEndpoint() throws Exception {
+        ListResponse asyncListDefaultNs = Futures.getUnchecked(
+                asyncIndexConnection.list("", DEFAULT_NS_PREFIX));
+        assertEquals(4, asyncListDefaultNs.getVectorsList().size());
+        assertTrue(asyncListDefaultNs.getVectorsList().toString().contains("def-id1"));
+        assertTrue(asyncListDefaultNs.getVectorsList().toString().contains("def-id2"));
+        assertTrue(asyncListDefaultNs.getVectorsList().toString().contains("def-prefix-id3"));
+        assertTrue(asyncListDefaultNs.getVectorsList().toString().contains("def-prefix-id4"));
 
-        // Confirm all vector IDs from custom namespace are returned when pass customNamespace
-        ListenableFuture<ListResponse> futureResponseCustomNamespace = asyncIndexConnection.list(customNamespace);
-        ListResponse asyncListResponseCustomNamespace = Futures.getUnchecked(futureResponseCustomNamespace);
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-id1"));
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-id2"));
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id3"));
-        assertTrue(asyncListResponseCustomNamespace.getVectorsList().toString().contains("cus-prefix-id4"));
+        ListResponse asyncListCustomNs = Futures.getUnchecked(
+                asyncIndexConnection.list(customNamespace, CUSTOM_NS_PREFIX));
+        assertEquals(4, asyncListCustomNs.getVectorsList().size());
+        assertTrue(asyncListCustomNs.getVectorsList().toString().contains("cus-id1"));
+        assertTrue(asyncListCustomNs.getVectorsList().toString().contains("cus-id2"));
+        assertTrue(asyncListCustomNs.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(asyncListCustomNs.getVectorsList().toString().contains("cus-prefix-id4"));
 
-        // Confirm all vector IDs from custom namespace are returned, filtered by given prefix
-        ListenableFuture<ListResponse> futureResponseCustomNamespaceWithPrefix =
-                asyncIndexConnection.list(customNamespace, "cus-prefix-");
-        ListResponse asyncListResponseCustomNamespaceWithPrefix = Futures.getUnchecked(futureResponseCustomNamespaceWithPrefix);
-        assertEquals(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().size(), 2);
-        assertTrue(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id3"));
-        assertTrue(asyncListResponseCustomNamespaceWithPrefix.getVectorsList().toString().contains("cus-prefix-id4"));
+        // Sub-prefix filter
+        ListResponse asyncListSubPrefix = Futures.getUnchecked(
+                asyncIndexConnection.list(customNamespace, CUSTOM_NS_SUBPREFIX));
+        assertEquals(2, asyncListSubPrefix.getVectorsList().size());
+        assertTrue(asyncListSubPrefix.getVectorsList().toString().contains("cus-prefix-id3"));
+        assertTrue(asyncListSubPrefix.getVectorsList().toString().contains("cus-prefix-id4"));
 
-        // Confirm all vector IDs from custom namespace are returned when limit is specified
-        ListenableFuture<ListResponse> futureResponseWithLimit = asyncIndexConnection.list(customNamespace, 1);
-        ListResponse asyncListResponseWithLimit = Futures.getUnchecked(futureResponseWithLimit);
-        assertEquals(1, asyncListResponseWithLimit.getVectorsList().size());
+        // Limit
+        ListResponse asyncListWithLimit = Futures.getUnchecked(
+                asyncIndexConnection.list(customNamespace, CUSTOM_NS_PREFIX, 1));
+        assertEquals(1, asyncListWithLimit.getVectorsList().size());
 
-        // Confirm all vector IDs from custom namespace are returned using pagination
-        ListenableFuture<ListResponse> futureResponseWithPaginationNoPrefix1 = asyncIndexConnection.list(customNamespace, 2);
-        ListResponse asyncListResponseWithPaginationNoPrefix1 = Futures.getUnchecked(futureResponseWithPaginationNoPrefix1);
-        assertEquals(asyncListResponseWithPaginationNoPrefix1.getVectorsList().size(), 2);
-        ListenableFuture<ListResponse> futureResponseWithPaginationNoPrefix2 = asyncIndexConnection.list(
-                customNamespace,
-                2,
-                asyncListResponseWithPaginationNoPrefix1.getPagination().getNext()
-        );
-        ListResponse asyncListResponseWithPaginationNoPrefix2 = Futures.getUnchecked(futureResponseWithPaginationNoPrefix2);
-        assertEquals(asyncListResponseWithPaginationNoPrefix2.getVectorsList().size(), 2);
+        // Pagination over exactly the 4 pre-seeded cus-* vectors
+        ListResponse asyncPage1 = Futures.getUnchecked(
+                asyncIndexConnection.list(customNamespace, CUSTOM_NS_PREFIX, 2));
+        assertEquals(2, asyncPage1.getVectorsList().size());
+        ListResponse asyncPage2 = Futures.getUnchecked(asyncIndexConnection.list(
+                customNamespace, CUSTOM_NS_PREFIX, asyncPage1.getPagination().getNext(), 2));
+        assertEquals(2, asyncPage2.getVectorsList().size());
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ListEndpointTest.java
@@ -6,7 +6,6 @@ import io.pinecone.clients.AsyncIndex;
 import io.pinecone.clients.Index;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.ListResponse;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -30,12 +29,6 @@ public class ListEndpointTest {
         indexConnection = indexManager.getOrCreateServerlessIndexConnection();
         asyncIndexConnection = indexManager.getOrCreateServerlessAsyncIndexConnection();
         customNamespace = indexManager.getCustomNamespace();
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        indexConnection.close();
-        asyncIndexConnection.close();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/NamespacesTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/NamespacesTest.java
@@ -11,10 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
+import static io.pinecone.helpers.AssertRetry.assertWithRetry;
 import static io.pinecone.helpers.BuildUpsertRequest.generateVectorValuesByDimension;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NamespacesTest {
     private static final TestResourcesManager indexManager = TestResourcesManager.getInstance();
@@ -24,110 +23,113 @@ public class NamespacesTest {
 
     @AfterAll
     public static void cleanUp() {
-        index.close();
-        asyncIndex.close();
+        if (index != null) index.close();
+        if (asyncIndex != null) asyncIndex.close();
     }
 
     @Test
-    public void namespacesSyncTest() throws InterruptedException {
+    public void namespacesSyncTest() throws Exception {
+        // Use a unique prefix so this test's namespaces can be counted independently
+        String prefix = "sync-ns-" + RandomStringBuilder.build("", 4) + "-";
         String[] namespaces = new String[4];
         index = indexManager.getOrCreateServerlessIndexConnection();
-        ListNamespacesResponse listNamespacesResponse = index.listNamespaces();
-        int namespaceCount = listNamespacesResponse.getNamespacesCount();
 
-        // Create namespace explicitly using createNamespace
-        namespaces[0] = RandomStringBuilder.build("namespace-", 3);
+        // Create namespace explicitly
+        namespaces[0] = prefix + "explicit";
         NamespaceDescription createdNamespace = index.createNamespace(namespaces[0]);
         assertNotNull(createdNamespace);
         assertEquals(namespaces[0], createdNamespace.getName());
 
         // Create namespaces implicitly by upserting vectors
-        for (int i=1; i<4; i++) {
-            namespaces[i] = RandomStringBuilder.build("namespace-", 3);
-            index.upsert("v"+i, generateVectorValuesByDimension(dimension), namespaces[i]);
+        for (int i = 1; i < 4; i++) {
+            namespaces[i] = prefix + i;
+            index.upsert("v" + i, generateVectorValuesByDimension(dimension), namespaces[i]);
         }
 
-        // wait for vectors to be upserted
-        Thread.sleep(5000);
-        listNamespacesResponse = index.listNamespaces();
-        assertEquals(listNamespacesResponse.getNamespacesCount(), namespaceCount + 4);
+        // Wait for all 4 namespaces to appear under this test's unique prefix
+        assertWithRetry(() -> {
+            ListNamespacesResponse resp = index.listNamespaces(prefix, null, 100);
+            assertEquals(4, resp.getNamespacesCount(),
+                    "Expected 4 namespaces with prefix '" + prefix + "'");
+        }, 3);
 
         index.describeNamespace(namespaces[0]);
         index.deleteNamespace(namespaces[0]);
 
-        // wait for namespace to be deleted
-        Thread.sleep(3000);
-        listNamespacesResponse = index.listNamespaces();
-        assertEquals(listNamespacesResponse.getNamespacesCount(), namespaceCount + 3);
+        // Wait for the deleted namespace to disappear
+        assertWithRetry(() -> {
+            ListNamespacesResponse resp = index.listNamespaces(prefix, null, 100);
+            assertEquals(3, resp.getNamespacesCount(),
+                    "Expected 3 namespaces with prefix '" + prefix + "' after deletion");
+        }, 3);
 
-        // Test prefix filtering and total count
-        String prefix = "namespace-";
+        // Verify all remaining namespaces start with the prefix
         ListNamespacesResponse prefixResponse = index.listNamespaces(prefix, null, 100);
         assertNotNull(prefixResponse);
         assertTrue(prefixResponse.getTotalCount() >= 3, "totalCount should be at least 3");
         assertTrue(prefixResponse.getNamespacesCount() >= 3, "Should return at least 3 namespaces with prefix");
-        
-        // Verify all returned namespaces start with the prefix
         for (int i = 0; i < prefixResponse.getNamespacesCount(); i++) {
             String namespaceName = prefixResponse.getNamespaces(i).getName();
-            assertTrue(namespaceName.startsWith(prefix), 
-                "Namespace " + namespaceName + " should start with prefix " + prefix);
+            assertTrue(namespaceName.startsWith(prefix),
+                    "Namespace " + namespaceName + " should start with prefix " + prefix);
         }
-        
-        // Verify totalCount is at least the number of namespaces returned
         assertTrue(prefixResponse.getTotalCount() >= prefixResponse.getNamespacesCount(),
-            "totalCount should be at least equal to the number of namespaces returned");
+                "totalCount should be at least equal to the number of namespaces returned");
     }
 
     @Test
-    public void namespacesAsyncTest() throws InterruptedException, ExecutionException {
+    public void namespacesAsyncTest() throws Exception {
+        // Use a unique prefix so this test's namespaces can be counted independently
+        String prefix = "async-ns-" + RandomStringBuilder.build("", 4) + "-";
         String[] namespaces = new String[4];
         asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
 
-        ListNamespacesResponse listNamespacesResponse = asyncIndex.listNamespaces().get();
-        int namespaceCount = listNamespacesResponse.getNamespacesCount();
-
-        // Create namespace explicitly using createNamespace
-        namespaces[0] = RandomStringBuilder.build("namespace-", 3);
+        // Create namespace explicitly
+        namespaces[0] = prefix + "explicit";
         NamespaceDescription createdNamespace = asyncIndex.createNamespace(namespaces[0]).get();
         assertNotNull(createdNamespace);
         assertEquals(namespaces[0], createdNamespace.getName());
 
-        // Create namespaces implicitly by upserting vectors
-        for (int i=1; i<4; i++) {
-            namespaces[i] = RandomStringBuilder.build("namespace-", 3);
-            asyncIndex.upsert("v"+i, generateVectorValuesByDimension(dimension), namespaces[i]);
+        // Create namespaces implicitly by upserting vectors; await each to ensure they're registered
+        for (int i = 1; i < 4; i++) {
+            namespaces[i] = prefix + i;
+            asyncIndex.upsert("v" + i, generateVectorValuesByDimension(dimension), namespaces[i]).get();
         }
 
-        // wait for vectors to be upserted
-        Thread.sleep(5000);
-        listNamespacesResponse = asyncIndex.listNamespaces().get();
-        assertEquals(listNamespacesResponse.getNamespacesCount(), namespaceCount + 4);
+        // Wait for all 4 namespaces to appear under this test's unique prefix
+        assertWithRetry(() -> {
+            ListNamespacesResponse resp = asyncIndex.listNamespaces().get();
+            long count = 0;
+            for (int i = 0; i < resp.getNamespacesCount(); i++) {
+                if (resp.getNamespaces(i).getName().startsWith(prefix)) count++;
+            }
+            assertEquals(4, count, "Expected 4 namespaces with prefix '" + prefix + "'");
+        }, 3);
 
         asyncIndex.describeNamespace(namespaces[0]);
         asyncIndex.deleteNamespace(namespaces[0]);
 
-        // wait for namespace to be deleted
-        Thread.sleep(3000);
-        listNamespacesResponse = asyncIndex.listNamespaces().get();
-        assertEquals(listNamespacesResponse.getNamespacesCount(), namespaceCount + 3);
+        // Wait for the deleted namespace to disappear
+        assertWithRetry(() -> {
+            ListNamespacesResponse resp = asyncIndex.listNamespaces().get();
+            long count = 0;
+            for (int i = 0; i < resp.getNamespacesCount(); i++) {
+                if (resp.getNamespaces(i).getName().startsWith(prefix)) count++;
+            }
+            assertEquals(3, count, "Expected 3 namespaces with prefix '" + prefix + "' after deletion");
+        }, 3);
 
         // Test prefix filtering and total count
-        String prefix = "namespace-";
         ListNamespacesResponse prefixResponse = asyncIndex.listNamespaces(prefix, null, 100).get();
         assertNotNull(prefixResponse);
         assertTrue(prefixResponse.getTotalCount() >= 3, "totalCount should be at least 3");
         assertTrue(prefixResponse.getNamespacesCount() >= 3, "Should return at least 3 namespaces with prefix");
-        
-        // Verify all returned namespaces start with the prefix
         for (int i = 0; i < prefixResponse.getNamespacesCount(); i++) {
             String namespaceName = prefixResponse.getNamespaces(i).getName();
             assertTrue(namespaceName.startsWith(prefix),
-                "Namespace " + namespaceName + " should start with prefix " + prefix);
+                    "Namespace " + namespaceName + " should start with prefix " + prefix);
         }
-        
-        // Verify totalCount is at least the number of namespaces returned
         assertTrue(prefixResponse.getTotalCount() >= prefixResponse.getNamespacesCount(),
-            "totalCount should be at least equal to the number of namespaces returned");
+                "totalCount should be at least equal to the number of namespaces returned");
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/NamespacesTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/NamespacesTest.java
@@ -6,7 +6,6 @@ import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.ListNamespacesResponse;
 import io.pinecone.proto.NamespaceDescription;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -20,12 +19,6 @@ public class NamespacesTest {
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static final int dimension = indexManager.getDimension();
-
-    @AfterAll
-    public static void cleanUp() {
-        if (index != null) index.close();
-        if (asyncIndex != null) asyncIndex.close();
-    }
 
     @Test
     public void namespacesSyncTest() throws Exception {

--- a/src/integration/java/io/pinecone/integration/dataPlane/NamespacesTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/NamespacesTest.java
@@ -98,12 +98,9 @@ public class NamespacesTest {
 
         // Wait for all 4 namespaces to appear under this test's unique prefix
         assertWithRetry(() -> {
-            ListNamespacesResponse resp = asyncIndex.listNamespaces().get();
-            long count = 0;
-            for (int i = 0; i < resp.getNamespacesCount(); i++) {
-                if (resp.getNamespaces(i).getName().startsWith(prefix)) count++;
-            }
-            assertEquals(4, count, "Expected 4 namespaces with prefix '" + prefix + "'");
+            ListNamespacesResponse resp = asyncIndex.listNamespaces(prefix, null, 100).get();
+            assertEquals(4, resp.getNamespacesCount(),
+                    "Expected 4 namespaces with prefix '" + prefix + "'");
         }, 3);
 
         asyncIndex.describeNamespace(namespaces[0]);
@@ -111,12 +108,9 @@ public class NamespacesTest {
 
         // Wait for the deleted namespace to disappear
         assertWithRetry(() -> {
-            ListNamespacesResponse resp = asyncIndex.listNamespaces().get();
-            long count = 0;
-            for (int i = 0; i < resp.getNamespacesCount(); i++) {
-                if (resp.getNamespaces(i).getName().startsWith(prefix)) count++;
-            }
-            assertEquals(3, count, "Expected 3 namespaces with prefix '" + prefix + "' after deletion");
+            ListNamespacesResponse resp = asyncIndex.listNamespaces(prefix, null, 100).get();
+            assertEquals(3, resp.getNamespacesCount(),
+                    "Expected 3 namespaces with prefix '" + prefix + "' after deletion");
         }, 3);
 
         // Test prefix filtering and total count

--- a/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataAsyncListenerIntegrationTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataAsyncListenerIntegrationTest.java
@@ -7,7 +7,6 @@ import io.pinecone.configs.ResponseMetadata;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -53,13 +52,6 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
                 .build();
 
         asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        if (asyncIndex != null) {
-            asyncIndex.close();
-        }
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataAsyncListenerIntegrationTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataAsyncListenerIntegrationTest.java
@@ -2,11 +2,13 @@ package io.pinecone.integration.dataPlane;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.pinecone.clients.AsyncIndex;
-import io.pinecone.clients.Pinecone;
+import io.pinecone.configs.PineconeConfig;
+import io.pinecone.configs.PineconeConnection;
 import io.pinecone.configs.ResponseMetadata;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -36,22 +38,32 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
 
     private static String indexName;
     private static AsyncIndex asyncIndex;
+    private static PineconeConnection connection;
     private static int dimension;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
         dimension = resourceManager.getDimension();
         indexName = resourceManager.getOrCreateServerlessIndex();
+        String host = resourceManager.getOrCreateServerlessIndexHost();
 
-        Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY"))
-                .withSourceTag("pinecone_test")
-                .withResponseMetadataListener(metadata -> {
-                    logger.debug("Captured async metadata: {}", metadata);
-                    capturedMetadata.add(metadata);
-                })
-                .build();
+        // Build a fresh PineconeConnection directly, bypassing the shared static connectionsMap,
+        // so this listener-configured connection is guaranteed to be independent of the shared one.
+        PineconeConfig config = new PineconeConfig(System.getenv("PINECONE_API_KEY"), "pinecone_test");
+        config.setHost(host);
+        config.setResponseMetadataListener(metadata -> {
+            logger.debug("Captured async metadata: {}", metadata);
+            capturedMetadata.add(metadata);
+        });
+        connection = new PineconeConnection(config, indexName);
+        asyncIndex = new AsyncIndex(config, connection, indexName);
+    }
 
-        asyncIndex = pineconeClient.getAsyncIndexConnection(indexName);
+    @AfterAll
+    public static void cleanUp() {
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataAsyncListenerIntegrationTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataAsyncListenerIntegrationTest.java
@@ -72,7 +72,6 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
                 vectorId, values, null, null, null);
 
         asyncIndex.upsert(Collections.singletonList(vector), namespace).get(30, TimeUnit.SECONDS);
-        Thread.sleep(100);
 
         ResponseMetadata metadata = findMetadataForOperation("upsert");
         assertNotNull(metadata, "Should have captured metadata for async upsert operation");
@@ -95,12 +94,9 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         asyncIndex.upsert(Collections.singletonList(vector), namespace).get(30, TimeUnit.SECONDS);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         asyncIndex.query(5, values, null, null, null, namespace, null, false, false).get(30, TimeUnit.SECONDS);
-        Thread.sleep(100);
 
         ResponseMetadata metadata = findMetadataForOperation("query");
         assertNotNull(metadata, "Should have captured metadata for async query operation");
@@ -121,12 +117,9 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         asyncIndex.upsert(Collections.singletonList(vector), namespace).get(30, TimeUnit.SECONDS);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         asyncIndex.fetch(Collections.singletonList(vectorId), namespace).get(30, TimeUnit.SECONDS);
-        Thread.sleep(100);
 
         ResponseMetadata metadata = findMetadataForOperation("fetch");
         assertNotNull(metadata, "Should have captured metadata for async fetch operation");
@@ -147,13 +140,10 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         asyncIndex.upsert(Collections.singletonList(vector), namespace).get(30, TimeUnit.SECONDS);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         List<Float> updatedValues = generateVectorValuesByDimension(dimension);
         asyncIndex.update(vectorId, updatedValues, namespace).get(30, TimeUnit.SECONDS);
-        Thread.sleep(100);
 
         ResponseMetadata metadata = findMetadataForOperation("update");
         assertNotNull(metadata, "Should have captured metadata for async update operation");
@@ -174,12 +164,9 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         asyncIndex.upsert(Collections.singletonList(vector), namespace).get(30, TimeUnit.SECONDS);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         asyncIndex.deleteByIds(Collections.singletonList(vectorId), namespace).get(30, TimeUnit.SECONDS);
-        Thread.sleep(100);
 
         ResponseMetadata metadata = findMetadataForOperation("delete");
         assertNotNull(metadata, "Should have captured metadata for async delete operation");
@@ -213,7 +200,6 @@ public class ResponseMetadataAsyncListenerIntegrationTest {
         future1.get(30, TimeUnit.SECONDS);
         future2.get(30, TimeUnit.SECONDS);
         future3.get(30, TimeUnit.SECONDS);
-        Thread.sleep(100);
 
         int upsertCount = 0;
         for (ResponseMetadata m : capturedMetadata) {

--- a/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataListenerIntegrationTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataListenerIntegrationTest.java
@@ -1,11 +1,13 @@
 package io.pinecone.integration.dataPlane;
 
 import io.pinecone.clients.Index;
-import io.pinecone.clients.Pinecone;
+import io.pinecone.configs.PineconeConfig;
+import io.pinecone.configs.PineconeConnection;
 import io.pinecone.configs.ResponseMetadata;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -32,22 +34,32 @@ public class ResponseMetadataListenerIntegrationTest {
 
     private static String indexName;
     private static Index index;
+    private static PineconeConnection connection;
     private static int dimension;
 
     @BeforeAll
     public static void setUp() throws InterruptedException {
         dimension = resourceManager.getDimension();
         indexName = resourceManager.getOrCreateServerlessIndex();
+        String host = resourceManager.getOrCreateServerlessIndexHost();
 
-        Pinecone pineconeClient = new Pinecone.Builder(System.getenv("PINECONE_API_KEY"))
-                .withSourceTag("pinecone_test")
-                .withResponseMetadataListener(metadata -> {
-                    logger.debug("Captured metadata: {}", metadata);
-                    capturedMetadata.add(metadata);
-                })
-                .build();
+        // Build a fresh PineconeConnection directly, bypassing the shared static connectionsMap,
+        // so this listener-configured connection is guaranteed to be independent of the shared one.
+        PineconeConfig config = new PineconeConfig(System.getenv("PINECONE_API_KEY"), "pinecone_test");
+        config.setHost(host);
+        config.setResponseMetadataListener(metadata -> {
+            logger.debug("Captured metadata: {}", metadata);
+            capturedMetadata.add(metadata);
+        });
+        connection = new PineconeConnection(config, indexName);
+        index = new Index(config, connection, indexName);
+    }
 
-        index = pineconeClient.getIndexConnection(indexName);
+    @AfterAll
+    public static void cleanUp() {
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataListenerIntegrationTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataListenerIntegrationTest.java
@@ -96,8 +96,6 @@ public class ResponseMetadataListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 ids.get(0), values, null, null, null);
         index.upsert(Collections.singletonList(vector), namespace);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         index.query(5, values, null, null, null, namespace, null, false, false);
@@ -123,8 +121,6 @@ public class ResponseMetadataListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         index.upsert(Collections.singletonList(vector), namespace);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         index.fetch(Collections.singletonList(vectorId), namespace);
@@ -150,8 +146,6 @@ public class ResponseMetadataListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         index.upsert(Collections.singletonList(vector), namespace);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         List<Float> updatedValues = generateVectorValuesByDimension(dimension);
@@ -178,8 +172,6 @@ public class ResponseMetadataListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         index.upsert(Collections.singletonList(vector), namespace);
-
-        Thread.sleep(1000);
         capturedMetadata.clear();
 
         index.deleteByIds(Collections.singletonList(vectorId), namespace);
@@ -206,8 +198,6 @@ public class ResponseMetadataListenerIntegrationTest {
         VectorWithUnsignedIndices vector = buildUpsertVectorWithUnsignedIndices(
                 vectorId, values, null, null, null);
         index.upsert(Collections.singletonList(vector), namespace);
-
-        Thread.sleep(500);
 
         index.query(5, values, null, null, null, namespace, null, false, false);
         index.fetch(Collections.singletonList(vectorId), namespace);

--- a/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataListenerIntegrationTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/ResponseMetadataListenerIntegrationTest.java
@@ -6,7 +6,6 @@ import io.pinecone.configs.ResponseMetadata;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -49,13 +48,6 @@ public class ResponseMetadataListenerIntegrationTest {
                 .build();
 
         index = pineconeClient.getIndexConnection(indexName);
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        if (index != null) {
-            index.close();
-        }
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -13,7 +13,6 @@ import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.SparseValuesWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -67,12 +66,6 @@ public class  UpdateFetchAndQueryPodTest {
         }
 
         index.upsert(vectorsToUpsert, namespace);
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        index.close();
-        asyncIndex.close();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryPodTest.java
@@ -76,7 +76,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void updateAllParamsFetchAndQuerySyncTest() throws InterruptedException {
+    public void updateAllParamsFetchAndQuerySyncTest() throws Exception {
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = index.fetch(upsertIds, namespace);
@@ -139,7 +139,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void addIncorrectDimensionalValuesSyncTest() throws InterruptedException {
+    public void addIncorrectDimensionalValuesSyncTest() throws Exception {
         // Update required fields only but with incorrect values dimension
         String idToUpdate = upsertIds.get(0);
         List<Float> updatedValues = Arrays.asList(101F);
@@ -172,7 +172,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void queryWithFiltersSyncTest() throws InterruptedException {
+    public void queryWithFiltersSyncTest() throws Exception {
         String fieldToQuery = metadataFields[0];
         String valueToQuery = createAndGetMetadataMap().get(fieldToQuery).get(0);
 
@@ -199,7 +199,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void updateAllParamsFetchAndQueryFutureTest() throws InterruptedException, ExecutionException {
+    public void updateAllParamsFetchAndQueryFutureTest() throws Exception {
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
@@ -263,7 +263,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void addIncorrectDimensionalValuesFutureTest() throws InterruptedException {
+    public void addIncorrectDimensionalValuesFutureTest() throws Exception {
         // Update required fields only but with incorrect values dimension
         String idToUpdate = upsertIds.get(0);
         List<Float> updatedValues = Arrays.asList(101F);
@@ -278,7 +278,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void queryWithFiltersFutureTest() throws ExecutionException, InterruptedException {
+    public void queryWithFiltersFutureTest() throws Exception {
         String fieldToQuery = metadataFields[0];
         String valueToQuery = createAndGetMetadataMap().get(fieldToQuery).get(0);
 
@@ -315,7 +315,7 @@ public class  UpdateFetchAndQueryPodTest {
     }
 
     @Test
-    public void updateNullSparseIndicesNotNullSparseValuesFutureTest() throws InterruptedException, ExecutionException {
+    public void updateNullSparseIndicesNotNullSparseValuesFutureTest() throws Exception {
         String id = RandomStringBuilder.build(3);
 
         try {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -13,7 +13,6 @@ import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.SparseValuesWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -70,12 +69,6 @@ public class UpdateFetchAndQueryServerlessTest {
         }
 
         index.upsert(vectorsToUpsert, namespace);
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        index.close();
-        asyncIndex.close();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpdateFetchAndQueryServerlessTest.java
@@ -79,7 +79,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void updateAllParamsFetchAndQuerySyncTest() throws InterruptedException {
+    public void updateAllParamsFetchAndQuerySyncTest() throws Exception {
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = index.fetch(upsertIds, namespace);
@@ -146,7 +146,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void addIncorrectDimensionalValuesSyncTest() throws InterruptedException {
+    public void addIncorrectDimensionalValuesSyncTest() throws Exception {
         // Update required fields only but with incorrect values dimension
         String idToUpdate = upsertIds.get(0);
         List<Float> updatedValues = Arrays.asList(101F); // should be of size 4
@@ -180,7 +180,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void queryWithFiltersSyncTest() throws InterruptedException {
+    public void queryWithFiltersSyncTest() throws Exception {
         String fieldToQuery = metadataFields[0];
         String valueToQuery = createAndGetMetadataMap().get(fieldToQuery).get(0);
 
@@ -208,7 +208,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void updateAllParamsFetchAndQueryFutureTest() throws InterruptedException, ExecutionException {
+    public void updateAllParamsFetchAndQueryFutureTest() throws Exception {
         // Verify the upserted vector count with fetch
         assertWithRetry(() -> {
             FetchResponse fetchResponse = asyncIndex.fetch(upsertIds, namespace).get();
@@ -275,7 +275,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void addIncorrectDimensionalValuesFutureTest() throws InterruptedException {
+    public void addIncorrectDimensionalValuesFutureTest() throws Exception {
         // Update required fields only but with incorrect values dimension
         String idToUpdate = upsertIds.get(0);
         List<Float> updatedValues = Arrays.asList(101F); // should be of size 4
@@ -291,7 +291,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void queryWithFiltersFutureTest() throws InterruptedException {
+    public void queryWithFiltersFutureTest() throws Exception {
         String fieldToQuery = metadataFields[0];
         String valueToQuery = createAndGetMetadataMap().get(fieldToQuery).get(0);
 
@@ -319,7 +319,7 @@ public class UpdateFetchAndQueryServerlessTest {
     }
 
     @Test
-    public void updateNullSparseIndicesNotNullSparseValuesFutureTest() throws InterruptedException, ExecutionException {
+    public void updateNullSparseIndicesNotNullSparseValuesFutureTest() throws Exception {
         String id = RandomStringBuilder.build(3);
 
         try {

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryPodTest.java
@@ -38,7 +38,7 @@ public class UpsertAndQueryPodTest {
     }
 
     @Test
-    public void upsertOptionalVectorsAndQueryIndexSyncTest() throws InterruptedException {
+    public void upsertOptionalVectorsAndQueryIndexSyncTest() throws Exception {
         int numOfVectors = 5;
         int topK = 5;
 
@@ -121,7 +121,7 @@ public class UpsertAndQueryPodTest {
     }
 
     @Test
-    public void upsertOptionalVectorsAndQueryIndexFutureTest() throws InterruptedException, ExecutionException {
+    public void upsertOptionalVectorsAndQueryIndexFutureTest() throws Exception {
         int numOfVectors = 5;
         int topK = 5;
 

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -10,7 +10,6 @@ import io.pinecone.proto.DescribeIndexStatsResponse;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -36,12 +35,6 @@ public class UpsertAndQueryServerlessTest {
         dimension = indexManager.getDimension();
         index = indexManager.getOrCreateServerlessIndexConnection();
         asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        index.close();
-        asyncIndex.close();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndQueryServerlessTest.java
@@ -32,7 +32,7 @@ public class UpsertAndQueryServerlessTest {
     private static final String namespace = RandomStringBuilder.build("ns", 8);
 
     @BeforeAll
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
         dimension = indexManager.getDimension();
         index = indexManager.getOrCreateServerlessIndexConnection();
         asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
@@ -136,7 +136,7 @@ public class UpsertAndQueryServerlessTest {
     }
 
     @Test
-    public void upsertOptionalVectorsAndQueryIndexFutureTest() throws InterruptedException, ExecutionException {
+    public void upsertOptionalVectorsAndQueryIndexFutureTest() throws Exception {
         int numOfVectors = 5;
         int topK = 5;
 

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndSearchRecordsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndSearchRecordsTest.java
@@ -13,9 +13,12 @@ import org.openapitools.db_data.client.model.SearchRecordsResponse;
 
 import java.util.*;
 
+import static io.pinecone.helpers.AssertRetry.assertWithRetry;
+import static io.pinecone.helpers.TestUtilities.waitUntilIndexIsReady;
+
 public class UpsertAndSearchRecordsTest {
     @Test
-    public void upsertAndSearchRecordsTest() throws ApiException, org.openapitools.db_control.client.ApiException, InterruptedException {
+    public void upsertAndSearchRecordsTest() throws Exception {
         Pinecone pinecone = new Pinecone.Builder(System.getenv("PINECONE_API_KEY")).build();
         String indexName = RandomStringBuilder.build("inf", 8);
         HashMap<String, String> fieldMap = new HashMap<>();
@@ -25,65 +28,62 @@ public class UpsertAndSearchRecordsTest {
                 .fieldMap(fieldMap);
         pinecone.createIndexForModel(indexName, "aws", "us-west-2", embed, "disabled", new HashMap<>());
 
-        // Wait for index to be created
-        Thread.sleep(10000);
+        try {
+            waitUntilIndexIsReady(pinecone, indexName);
+            // Additional buffer after ready signal to avoid "no healthy upstream" errors
+            Thread.sleep(30000);
 
-        Index index = pinecone.getIndexConnection(indexName);
-        ArrayList<Map<String, String>> upsertRecords = new ArrayList<>();
+            Index index = pinecone.getIndexConnection(indexName);
+            ArrayList<Map<String, String>> upsertRecords = new ArrayList<>();
 
-        HashMap<String, String> record1 = new HashMap<>();
-        record1.put("_id", "rec1");
-        record1.put("category", "digestive system");
-        record1.put("chunk_text", "Apples are a great source of dietary fiber, which supports digestion and helps maintain a healthy gut.");
+            HashMap<String, String> record1 = new HashMap<>();
+            record1.put("_id", "rec1");
+            record1.put("category", "digestive system");
+            record1.put("chunk_text", "Apples are a great source of dietary fiber, which supports digestion and helps maintain a healthy gut.");
 
-        HashMap<String, String> record2 = new HashMap<>();
-        record2.put("_id", "rec2");
-        record2.put("category", "cultivation");
-        record2.put("chunk_text", "Apples originated in Central Asia and have been cultivated for thousands of years, with over 7,500 varieties available today.");
+            HashMap<String, String> record2 = new HashMap<>();
+            record2.put("_id", "rec2");
+            record2.put("category", "cultivation");
+            record2.put("chunk_text", "Apples originated in Central Asia and have been cultivated for thousands of years, with over 7,500 varieties available today.");
 
-        HashMap<String, String> record3 = new HashMap<>();
-        record3.put("_id", "rec3");
-        record3.put("category", "immune system");
-        record3.put("chunk_text", "Rich in vitamin C and other antioxidants, apples contribute to immune health and may reduce the risk of chronic diseases.");
+            HashMap<String, String> record3 = new HashMap<>();
+            record3.put("_id", "rec3");
+            record3.put("category", "immune system");
+            record3.put("chunk_text", "Rich in vitamin C and other antioxidants, apples contribute to immune health and may reduce the risk of chronic diseases.");
 
-        HashMap<String, String> record4 = new HashMap<>();
-        record4.put("_id", "rec4");
-        record4.put("category", "endocrine system");
-        record4.put("chunk_text", "The high fiber content in apples can also help regulate blood sugar levels, making them a favorable snack for people with diabetes.");
+            HashMap<String, String> record4 = new HashMap<>();
+            record4.put("_id", "rec4");
+            record4.put("category", "endocrine system");
+            record4.put("chunk_text", "The high fiber content in apples can also help regulate blood sugar levels, making them a favorable snack for people with diabetes.");
 
-        upsertRecords.add(record1);
-        upsertRecords.add(record2);
-        upsertRecords.add(record3);
-        upsertRecords.add(record4);
+            upsertRecords.add(record1);
+            upsertRecords.add(record2);
+            upsertRecords.add(record3);
+            upsertRecords.add(record4);
 
-        index.upsertRecords("example-namespace", upsertRecords);
+            String namespace = "example-namespace";
+            index.upsertRecords(namespace, upsertRecords);
 
-        String namespace = "example-namespace";
-        HashMap<String, String> inputsMap = new HashMap<>();
-        inputsMap.put("text", "Disease prevention");
-        SearchRecordsRequestQuery query = new SearchRecordsRequestQuery()
-                .topK(4)
-                .inputs(inputsMap);
+            List<String> fields = new ArrayList<>();
+            fields.add("category");
+            fields.add("chunk_text");
 
-        List<String> fields = new ArrayList<>();
-        fields.add("category");
-        fields.add("chunk_text");
+            // Poll until the upserted record is searchable
+            assertWithRetry(() -> {
+                SearchRecordsResponse resp = index.searchRecordsById(record1.get("_id"), namespace, fields, 1, null, null);
+                Assertions.assertEquals(1, resp.getResult().getHits().size());
+                Assertions.assertEquals(record1.get("_id"), resp.getResult().getHits().get(0).getId());
+            }, 3);
 
-        // Wait for vectors to be upserted
-        Thread.sleep(5000);
+            SearchRecordsRequestRerank rerank = new SearchRecordsRequestRerank()
+                    .model("bge-reranker-v2-m3")
+                    .topN(2)
+                    .rankFields(Arrays.asList("chunk_text"));
 
-        SearchRecordsResponse recordsResponse = index.searchRecordsById(record1.get("_id"), namespace, fields, 1, null, null);
-        Assertions.assertEquals(1, recordsResponse.getResult().getHits().size());
-        Assertions.assertEquals(record1.get("_id"), recordsResponse.getResult().getHits().get(0).getId());
-
-        SearchRecordsRequestRerank rerank = new SearchRecordsRequestRerank()
-                .model("bge-reranker-v2-m3")
-                .topN(2)
-                .rankFields(Arrays.asList("chunk_text"));
-
-        recordsResponse = index.searchRecordsByText("Disease prevention", namespace, fields, 4, null, rerank);
-        Assertions.assertEquals(record3.get("_id"), recordsResponse.getResult().getHits().get(0).getId());
-
-        pinecone.deleteIndex(indexName);
+            SearchRecordsResponse recordsResponse = index.searchRecordsByText("Disease prevention", namespace, fields, 4, null, rerank);
+            Assertions.assertEquals(record3.get("_id"), recordsResponse.getResult().getHits().get(0).getId());
+        } finally {
+            pinecone.deleteIndex(indexName);
+        }
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndSearchRecordsTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertAndSearchRecordsTest.java
@@ -26,9 +26,10 @@ public class UpsertAndSearchRecordsTest {
         CreateIndexForModelRequestEmbed embed = new CreateIndexForModelRequestEmbed()
                 .model("multilingual-e5-large")
                 .fieldMap(fieldMap);
-        pinecone.createIndexForModel(indexName, "aws", "us-west-2", embed, "disabled", new HashMap<>());
-
+        boolean indexCreated = false;
         try {
+            pinecone.createIndexForModel(indexName, "aws", "us-west-2", embed, "disabled", new HashMap<>());
+            indexCreated = true;
             waitUntilIndexIsReady(pinecone, indexName);
             // Additional buffer after ready signal to avoid "no healthy upstream" errors
             Thread.sleep(30000);
@@ -83,7 +84,9 @@ public class UpsertAndSearchRecordsTest {
             SearchRecordsResponse recordsResponse = index.searchRecordsByText("Disease prevention", namespace, fields, 4, null, rerank);
             Assertions.assertEquals(record3.get("_id"), recordsResponse.getResult().getHits().get(0).getId());
         } finally {
-            pinecone.deleteIndex(indexName);
+            if (indexCreated) {
+                pinecone.deleteIndex(indexName);
+            }
         }
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeletePodTest.java
@@ -27,8 +27,6 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
     private static AsyncIndex asyncIndex;
     private static int dimension;
     private static final Struct nullFilterStruct = null;
-    private static final String namespace = RandomStringBuilder.build("ns", 8);
-    private static int namespaceVectorCount = 0;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
@@ -38,69 +36,58 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
     }
 
     @Test
-    public void upsertVectorsAndDeleteByIdSyncTest() throws InterruptedException {
-        // Upsert vectors with required parameters
+    public void upsertVectorsAndDeleteByIdSyncTest() throws Exception {
+        String namespace = RandomStringBuilder.build("ns", 8);
         int numOfVectors = 3;
         List<String> upsertIds = getIdsList(numOfVectors);
         List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
         for (String id : upsertIds) {
-            VectorWithUnsignedIndices vector =
-            new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension));
-            vectorsToUpsert.add(vector);
+            vectorsToUpsert.add(new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension)));
         }
 
         index.upsert(vectorsToUpsert, namespace);
-        namespaceVectorCount += numOfVectors;
 
         assertWithRetry(() -> {
-            // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
-            
-            // verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = index.describeIndexStats();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(numOfVectors, ns == null ? 0 : ns.getVectorCount());
         }, 3);
 
-        // Delete vectors
         index.delete(upsertIds, false, namespace, nullFilterStruct);
-        namespaceVectorCount -= numOfVectors;
 
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(nullFilterStruct);
-            // Verify the vectors have been deleted
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = index.describeIndexStats(nullFilterStruct);
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(0, ns == null ? 0 : ns.getVectorCount());
         }, 3);
     }
 
     @Test
-    public void upsertVectorsAndDeleteByFilterSyncTest() throws InterruptedException {
+    public void upsertVectorsAndDeleteByFilterSyncTest() throws Exception {
+        String namespace = RandomStringBuilder.build("ns", 8);
         int numOfVectors = 3;
         List<String> upsertIds = getIdsList(numOfVectors);
         List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
-        // Upsert vectors with required + optional and custom metadata parameters
-        for (int i=0; i<upsertIds.size(); i++) {
-            VectorWithUnsignedIndices vector =
-            new VectorWithUnsignedIndices(upsertIds.get(i),
+        for (int i = 0; i < upsertIds.size(); i++) {
+            vectorsToUpsert.add(new VectorWithUnsignedIndices(
+                    upsertIds.get(i),
                     generateVectorValuesByDimension(dimension),
                     generateMetadataStruct(i, i),
-                    new SparseValuesWithUnsignedIndices(generateSparseIndicesByDimension(dimension),
+                    new SparseValuesWithUnsignedIndices(
+                            generateSparseIndicesByDimension(dimension),
                             generateVectorValuesByDimension(dimension)
                     )
-            );
-            vectorsToUpsert.add(vector);
+            ));
         }
 
         index.upsert(vectorsToUpsert, namespace);
-        namespaceVectorCount += numOfVectors;
 
-        // Verify the vectors are upserted
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(nullFilterStruct);
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = index.describeIndexStats(nullFilterStruct);
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(numOfVectors, ns == null ? 0 : ns.getVectorCount());
         }, 3);
 
         String fieldToDelete = metadataFields[0];
@@ -114,80 +101,69 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
                         .build())
                 .build();
 
-        // Delete by filtering
         index.delete(null, false, namespace, filterStruct);
-        namespaceVectorCount = namespaceVectorCount - 1;
+        int expectedAfterDelete = numOfVectors - 1;
 
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats(nullFilterStruct);
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = index.describeIndexStats(nullFilterStruct);
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(expectedAfterDelete, ns == null ? 0 : ns.getVectorCount());
         }, 3);
     }
 
     @Test
-    public void upsertVectorsAndDeleteByIdFutureTest() throws InterruptedException, ExecutionException {
-        // Upsert vectors with required parameters
+    public void upsertVectorsAndDeleteByIdFutureTest() throws Exception {
+        String namespace = RandomStringBuilder.build("ns", 8);
         int numOfVectors = 3;
         List<String> upsertIds = getIdsList(numOfVectors);
         List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
         for (String id : upsertIds) {
-            VectorWithUnsignedIndices vector =
-            new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension));
-            vectorsToUpsert.add(vector);
+            vectorsToUpsert.add(new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension)));
         }
+
         asyncIndex.upsert(vectorsToUpsert, namespace).get();
-        namespaceVectorCount += numOfVectors;
 
         assertWithRetry(() -> {
-            // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
-            // verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = asyncIndex.describeIndexStats().get();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(numOfVectors, ns == null ? 0 : ns.getVectorCount());
         }, 3);
 
-        // Delete vectors
         asyncIndex.delete(upsertIds, false, namespace, null).get();
-        namespaceVectorCount -= numOfVectors;
 
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = asyncIndex.describeIndexStats().get();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(0, ns == null ? 0 : ns.getVectorCount());
         }, 3);
     }
 
     @Test
-    public void upsertVectorsAndDeleteByFilterFutureTest() throws InterruptedException, ExecutionException {
+    public void upsertVectorsAndDeleteByFilterFutureTest() throws Exception {
+        String namespace = RandomStringBuilder.build("ns", 8);
         int numOfVectors = 3;
         List<String> upsertIds = getIdsList(numOfVectors);
         List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
-        // Upsert vectors with required + optional and custom metadata parameters
-        for (int i=0; i<upsertIds.size(); i++) {
-            VectorWithUnsignedIndices vector =
-            new VectorWithUnsignedIndices(upsertIds.get(i),
+        for (int i = 0; i < upsertIds.size(); i++) {
+            vectorsToUpsert.add(new VectorWithUnsignedIndices(
+                    upsertIds.get(i),
                     generateVectorValuesByDimension(dimension),
                     generateMetadataStruct(i, i),
-                    new SparseValuesWithUnsignedIndices(generateSparseIndicesByDimension(dimension),
+                    new SparseValuesWithUnsignedIndices(
+                            generateSparseIndicesByDimension(dimension),
                             generateVectorValuesByDimension(dimension)
                     )
-            );
-            vectorsToUpsert.add(vector);
+            ));
         }
+
         asyncIndex.upsert(vectorsToUpsert, namespace).get();
-        namespaceVectorCount += numOfVectors;
 
-
-        // Verify the vectors are upserts
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(nullFilterStruct).get();
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = asyncIndex.describeIndexStats(nullFilterStruct).get();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(numOfVectors, ns == null ? 0 : ns.getVectorCount());
         }, 3);
 
         String fieldToDelete = metadataFields[0];
@@ -201,15 +177,13 @@ public class UpsertDescribeIndexStatsAndDeletePodTest {
                         .build())
                 .build();
 
-        // Delete by filtering
         asyncIndex.delete(new ArrayList<>(), false, namespace, filterStruct).get();
-        namespaceVectorCount -= 1;
+        int expectedAfterDelete = numOfVectors - 1;
 
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats(nullFilterStruct).get();
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = asyncIndex.describeIndexStats(nullFilterStruct).get();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(expectedAfterDelete, ns == null ? 0 : ns.getVectorCount());
         }, 3);
     }
 }

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -8,7 +8,6 @@ import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
 import io.pinecone.proto.NamespaceSummary;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -32,12 +31,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
         dimension = indexManager.getDimension();
         index = indexManager.getOrCreateServerlessIndexConnection();
         asyncIndex = indexManager.getOrCreateServerlessAsyncIndexConnection();
-    }
-
-    @AfterAll
-    public static void cleanUp() {
-        index.close();
-        asyncIndex.close();
     }
 
     @Test

--- a/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
+++ b/src/integration/java/io/pinecone/integration/dataPlane/UpsertDescribeIndexStatsAndDeleteServerlessTest.java
@@ -6,6 +6,7 @@ import io.pinecone.clients.Index;
 import io.pinecone.helpers.RandomStringBuilder;
 import io.pinecone.helpers.TestResourcesManager;
 import io.pinecone.proto.DescribeIndexStatsResponse;
+import io.pinecone.proto.NamespaceSummary;
 import io.pinecone.unsigned_indices_model.VectorWithUnsignedIndices;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,8 +26,6 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     private static Index index;
     private static AsyncIndex asyncIndex;
     private static int dimension;
-    private static final String namespace = RandomStringBuilder.build("ns", 8);
-    private static int namespaceVectorCount = 0;
 
     @BeforeAll
     public static void setUp() throws IOException, InterruptedException {
@@ -42,76 +41,58 @@ public class UpsertDescribeIndexStatsAndDeleteServerlessTest {
     }
 
     @Test
-    public void upsertVectorsAndDeleteByIdSyncTest() throws InterruptedException {
-        // Upsert vectors with required parameters
+    public void upsertVectorsAndDeleteByIdSyncTest() throws Exception {
+        String namespace = RandomStringBuilder.build("ns", 8);
         int numOfVectors = 3;
-
         List<String> upsertIds = getIdsList(numOfVectors);
         List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
         for (String id : upsertIds) {
-            VectorWithUnsignedIndices vector =
-            new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension));
-            vectorsToUpsert.add(vector);
+            vectorsToUpsert.add(new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension)));
         }
 
         index.upsert(vectorsToUpsert, namespace);
-        namespaceVectorCount += numOfVectors;
 
         assertWithRetry(() -> {
-            // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
-
-            // verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = index.describeIndexStats();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(numOfVectors, ns == null ? 0 : ns.getVectorCount());
         }, 3);
 
-        // Delete vectors
         index.deleteByIds(upsertIds, namespace);
-        namespaceVectorCount -= numOfVectors;
 
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = index.describeIndexStats();
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = index.describeIndexStats();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(0, ns == null ? 0 : ns.getVectorCount());
         }, 3);
     }
 
     @Test
-    public void upsertVectorsAndDeleteByIdFutureTest() throws InterruptedException, ExecutionException {
-        // Upsert vectors with required parameters
-        Struct emptyFilterStruct = null;
+    public void upsertVectorsAndDeleteByIdFutureTest() throws Exception {
+        String namespace = RandomStringBuilder.build("ns", 8);
         int numOfVectors = 3;
         List<String> upsertIds = getIdsList(numOfVectors);
         List<VectorWithUnsignedIndices> vectorsToUpsert = new ArrayList<>(numOfVectors);
 
         for (String id : upsertIds) {
-            VectorWithUnsignedIndices vector =
-            new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension));
-            vectorsToUpsert.add(vector);
+            vectorsToUpsert.add(new VectorWithUnsignedIndices(id, generateVectorValuesByDimension(dimension)));
         }
 
         asyncIndex.upsert(vectorsToUpsert, namespace).get();
-        namespaceVectorCount += numOfVectors;
 
         assertWithRetry(() -> {
-            // call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
-
-            // verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = asyncIndex.describeIndexStats().get();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(numOfVectors, ns == null ? 0 : ns.getVectorCount());
         }, 3);
 
-        // Delete vectors
         asyncIndex.deleteByIds(upsertIds, namespace);
-        namespaceVectorCount -= numOfVectors;
 
         assertWithRetry(() -> {
-            // Call describeIndexStats to get updated vector count
-            DescribeIndexStatsResponse describeIndexStatsResponse = asyncIndex.describeIndexStats().get();
-            // Verify the updated vector count
-            assertEquals(describeIndexStatsResponse.getNamespacesMap().get(namespace).getVectorCount(), namespaceVectorCount);
+            DescribeIndexStatsResponse response = asyncIndex.describeIndexStats().get();
+            NamespaceSummary ns = response.getNamespacesMap().get(namespace);
+            assertEquals(0, ns == null ? 0 : ns.getVectorCount());
         }, 3);
     }
 }

--- a/src/integration/resources/junit-platform.properties
+++ b/src/integration/resources/junit-platform.properties
@@ -1,0 +1,9 @@
+# Run test classes in parallel, but keep test methods within a class sequential.
+# This allows shared indexes (via TestResourcesManager singleton) to be reused
+# across classes without per-class re-creation, while still running independent
+# test classes concurrently.
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism=4

--- a/src/main/java/io/pinecone/commons/Constants.java
+++ b/src/main/java/io/pinecone/commons/Constants.java
@@ -1,5 +1,5 @@
 package io.pinecone.commons;
 
 public class Constants {
-    public static final String pineconeClientVersion = "v6.1.0";
+    public static final String pineconeClientVersion = "v6.2.0";
 }


### PR DESCRIPTION
## Problem
We need to bump version packaging and constants for releasing v6.2.0. There's also a significant amount of integration test flakiness to address, and the suite was taking ~20 minutes to run.

## Solution

**Version bump**

Bump version to 6.2.0 in `gradle.properties` and `CHANGELOG.md`.

**NOTE: All of the following changes are within the integration testing harness, so none of the client code is actually touched. I spent a bit of time working with claude to tighten up the testing harness itself. Test execution went from 20-24mins per run to 7-8mins, it looks like. Primarily, this was achieved through parallelizing the test classes since a lot of them are reusing the TestResourcesManagerSingle already. The singleton class also needed a lot of work to make it a bit more robust when being accessed by parallel testing threads. I summarized most of this with claude since it was done across numerous commits.**

**Parallel test execution**

Added `junit-platform.properties` enabling concurrent class-level execution at parallelism 4, with methods within each class remaining sequential. This alone brought the suite runtime from ~20 minutes to ~8 minutes.

**AssertRetry — exception handling gap**

The retry helper only caught `AssertionError`, `ExecutionException`, and `IOException`. Any other exception (most commonly `NullPointerException` when a namespace key is absent from the stats map during eventual consistency) escaped the retry loop immediately. Widened the catch and the `AssertionRunnable` interface to `Exception`. Also added
explicit `InterruptedException` re-throw before the broad catch so that cancellation signals propagate correctly rather than being silently retried.

**TestResourcesManager — thread safety**

Enabling parallel class execution exposed multiple races in the shared singleton:
- `getInstance()` was unsynchronized; two classes could both see `null` and construct duplicate instances. Fixed with `volatile` + `synchronized`.
- `getOrCreatePodIndex()`, `getOrCreateServerlessIndex()`, and `getOrCreateCollection()` had check-then-act races where two threads could both pass the null guard and create duplicate indexes. All marked `synchronized`.
- `getOrCreate*Connection()` methods now cache their results and are `synchronized`, ensuring parallel classes that both call `getOrCreateServerlessIndexConnection()` share the same `Index` object rather than creating duplicate channels.
- `cleanupResources()` now closes all cached connections before deleting indexes.
- Fixed a string identity comparison bug (`!= "ready"`) in the collection-readiness loop that caused it to always run to the full 120-second timeout. Fixed to `!"ready".equals(...)`.

**Parallel tests closing shared connections early**

`Index.close()` shuts down the underlying `PineconeConnection`, which is shared via a `static final ConcurrentHashMap` keyed by index name across all `Pinecone` instances. With parallel class execution, one class calling `close()` in `@AfterAll` could terminate the channel while another class was mid-request. Removed `close()` calls from
`@AfterAll` in all test classes that obtained connections from `TestResourcesManager`. Connections are now closed exclusively in `TestResourcesManager.cleanupResources()` at the end of the run.

**ResponseMetadata tests — static connection map race**

The `ResponseMetadata*` tests create their own `Pinecone` client with a listener interceptor, but `getIndexConnection()` uses `computeIfAbsent` on the shared static map — whichever class first creates a connection for the shared index name wins. If another class won the race, the `ResponseMetadata*` tests got a listener-less connection and
captured nothing. Fixed by constructing `PineconeConnection` directly (bypassing `computeIfAbsent`) using a host exposed via `TestResourcesManager.getOrCreateServerlessIndexHost()`. Each `ResponseMetadata*` test now owns its connection and closes it in its own `@AfterAll`.

**UpsertDescribeIndexStatsAndDeletePodTest / ...ServerlessTest — shared mutable counter**

A `static namespaceVectorCount` field was shared and mutated across all test methods. Each test now creates its own isolated namespace and tracks its own local count, with null-safe assertions for the case where a deleted namespace is removed from the stats map.

**NamespacesTest — cross-test namespace count interference**

Both sync and async tests asserted on exact total namespace counts against the same shared index. Each test now uses a unique random prefix and counts only its own namespaces via prefix-filtered `listNamespaces`, making assertions fully isolated. `Thread.sleep` replaced with `assertWithRetry`. Async upserts now properly await with `.get()`.

**ListEndpointTest — concurrent write interference**

Count assertions against the shared serverless index were vulnerable to concurrent writes from parallel classes inflating the results. All assertions now use prefix-filtered `list()` calls that only count vectors seeded by `TestResourcesManager` under known prefixes.

**ReadCapacityAndSchemaTest — unnecessary waits + missing cleanup**

Removed `waitUntilIndexIsReady` from tests 1–5 (assertions are on the create response, not index state). Added `@AfterAll` that deletes all indexes created by the class, with logged warnings on deletion failure rather than silent swallowing.

**ConfigureIndexTest — parallel isolation**

Added `@Isolated` since this test mutates a shared pod index's replica count and pod type, which cannot safely run concurrently with any other class. Also fixed a string identity comparison (`!= "ready"`) in the local readiness poll.

**ConnectionsMapTest — size assertions replaced**

`assertEquals(size, 1)` / `assertEquals(size, 2)` assumed the static map contained only this test's entries, which breaks under parallel execution when other classes have their own connections in the map. Replaced with key-presence checks (`assertFalse(containsKey(...))`) and object-identity checks (`assertSame`) to verify connection reuse without
counting map entries. Also replaced bare `assert` keywords (silently skipped without `-ea`) with `assertFalse`/`assertSame`. Fixed a pre-existing typo where `config1.setHost(host2)` was overwriting the wrong config.

**UpsertAndSearchRecordsTest — cleanup masking failures**

`createIndexForModel` was called before the `try` block, so if it failed the `finally` clause would call `deleteIndex` on a non-existent index, replacing the original exception with a not-found error. Moved creation inside `try` with an `indexCreated` flag so `deleteIndex` only runs when there is actually an index to clean up. Also replaced
hardcoded sleeps with `waitUntilIndexIsReady` and `assertWithRetry`.