### PR TITLE
fix(deps): pin Netty to 4.1.135.Final to fix CVE-2025-24970 (high-severity DoS)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,23 @@ sourceSets {
 }
 
 def grpcVersion = '1.60.2'
+// Netty is pulled in transitively by grpc-netty (1.60.2 -> 4.1.100.Final, which is vulnerable
+// to CVE-2025-24970). grpc-netty does not pin a patched Netty even in recent releases, so we
+// pin Netty directly here. Bump alongside grpc when grpc itself ships a patched Netty.
+def nettyVersion = '4.1.135.Final'
 
 dependencies {
     api "io.grpc:grpc-protobuf:${grpcVersion}"
     api "io.grpc:grpc-stub:${grpcVersion}"
     api "io.grpc:grpc-netty:${grpcVersion}"
-    runtimeOnly 'io.netty:netty-tcnative-boringssl-static:2.0.61.Final'
+    // Pin every Netty module that grpc-netty declares directly so the patched version wins
+    // transitive resolution for consumers too (Maven nearest-wins / Gradle highest-wins).
+    // Fixes CVE-2025-24970 (netty-handler/netty-common, HIGH) and pulls in the patched
+    // netty-codec-http (CVE-2024-29025) and netty-common (CVE-2025-25193).
+    api "io.netty:netty-codec-http2:${nettyVersion}"
+    api "io.netty:netty-handler-proxy:${nettyVersion}"
+    api "io.netty:netty-transport-native-unix-common:${nettyVersion}"
+    runtimeOnly 'io.netty:netty-tcnative-boringssl-static:2.0.77.Final'
     implementation 'org.slf4j:slf4j-api:2.0.5'
     implementation 'com.google.api.grpc:proto-google-common-protos:2.14.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'


### PR DESCRIPTION
## Summary
Fixes **CVE-2025-24970** (HIGH, CVSS 7.5) in Netty. `grpc-netty:1.60.2` pulls **Netty 4.1.100.Final** transitively, where a specially crafted packet can crash the native `SslHandler`, causing a **denial of service**. The fix is Netty ≥ 4.1.118.Final.

grpc-netty does not pin a patched Netty even in recent releases (see [grpc/grpc-java#11911](https://github.com/grpc/grpc-java/issues/11911) — 1.70.0 still scans HIGH), so this pins Netty directly without a large grpc upgrade.

## Changes
- Pin the three Netty modules that `grpc-netty` declares directly — `netty-codec-http2`, `netty-handler-proxy`, `netty-transport-native-unix-common` — to **4.1.135.Final**.
- Bump `netty-tcnative-boringssl-static` **2.0.61.Final → 2.0.77.Final** (the version paired with Netty 4.1.135).

### Why pin those three modules
The published artifact is the thin jar with a flat dependency POM (no `<dependencyManagement>`), so consumers resolve Netty transitively from `grpc-netty`. A BOM/constraint would **not** override the transitive version for Maven consumers. Declaring the same three modules `grpc-netty` declares — as **direct** deps at the patched version — makes the patched version win for everyone (Maven nearest-wins, Gradle highest-wins), pulling the whole Netty graph (incl. the vulnerable `netty-handler` / `netty-common`) up to 4.1.135.

### Bonus
Also brings in patched `netty-codec-http` (CVE-2024-29025) and `netty-common` (CVE-2025-25193).

## Verification
- `./gradlew clean build jar compileIntegrationTestJava` → **BUILD SUCCESSFUL**, unit tests pass (JDK 17, Gradle 8.5).
- `gradle dependencies --configuration runtimeClasspath` → **every** `io.netty:*` module resolves to **4.1.135.Final** (the three `4.1.100 -> 4.1.135` overrides are visible), tcnative at 2.0.77.
- Generated POM lists the three Netty modules at 4.1.135.Final + tcnative 2.0.77 as direct deps, so the override propagates to consumers.

## Notes
- Netty 4.1.x is binary-backward-compatible, so pinning ahead of grpc-netty's tested 4.1.100 is safe; this is the remediation grpc recommends for these CVEs. CI's `integration-test` job exercises the live gRPC/Netty transport.
- Related but heavier alternative: draft #198 (grpc → 1.75.0). This PR is the focused CVE fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gRPC transport stack (Netty/tcnative) for all library consumers; low code churn but affects security-sensitive networking dependencies.
> 
> **Overview**
> Pins **Netty 4.1.135.Final** on the three modules `grpc-netty` pulls in directly (`netty-codec-http2`, `netty-handler-proxy`, `netty-transport-native-unix-common`) so Gradle/Maven consumers get patched artifacts instead of **4.1.100.Final** from `grpc-netty:1.60.2`, addressing **CVE-2025-24970** and related Netty CVEs without upgrading gRPC.
> 
> Bumps **`netty-tcnative-boringssl-static`** from **2.0.61.Final** to **2.0.77.Final** to match the pinned Netty line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dbacce5dd667a71995846ab45758f413a076a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->