### PR TITLE
fix(build): pin Shadow plugin's vulnerable build-time deps (CVE-2024-47554, CVE-2025-67030)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,18 @@
+buildscript {
+    // Build-time only: the Shadow 8.1.1 Gradle plugin pulls vulnerable transitive deps onto
+    // the plugin (buildscript) classpath. These run only in the Gradle build JVM and are NOT
+    // part of the published artifact, but we still pin them to patched versions to clear the
+    // Dependabot alerts:
+    //   - commons-io 2.11.0  -> CVE-2024-47554  (fixed in 2.14.0)
+    //   - plexus-utils 3.5.1 -> CVE-2025-67030  (fixed in 3.6.1)
+    configurations.classpath {
+        resolutionStrategy {
+            force 'commons-io:commons-io:2.18.0'
+            force 'org.codehaus.plexus:plexus-utils:3.6.1'
+        }
+    }
+}
+
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'java-library'


### PR DESCRIPTION
## Summary
Clears the two remaining HIGH Dependabot alerts on `build.gradle`, both from **build-time-only** transitives of the Shadow 8.1.1 Gradle plugin:

| Dependency (via Shadow plugin classpath) | CVE | Fixed in | Pinned to |
|---|---|---|---|
| `commons-io` 2.11.0 | CVE-2024-47554 (HIGH) | 2.14.0 | **2.18.0** |
| `org.codehaus.plexus:plexus-utils` 3.5.1 | CVE-2025-67030 (HIGH) | 3.6.1 | **3.6.1** |

## Context — these are not in the shipped artifact
`./gradlew buildEnvironment` shows both come from `com.github.johnrengelman:shadow:8.1.1` on the **buildscript (plugin) classpath**. They execute only in the Gradle build JVM during `shadowJar` and are **not** dependencies of the published `pinecone-client` (they don't appear on `runtimeClasspath` or in the published POM). So real-world exposure is limited to the build environment — but Dependabot still flags them, so this pins them to patched versions.

## Approach
Force patched versions on the buildscript classpath via a `buildscript { configurations.classpath { resolutionStrategy { force ... } } }` block. This intentionally **keeps Shadow at 8.1.1** — upgrading the Shadow plugin would be the alternative, but the Java 8 CI matrix limits us to `com.gradleup.shadow` ≤ 8.3.1 and carries coordinate/DSL changes, so a targeted force is lower-risk for a build-tooling fix.

## Verification
- `./gradlew buildEnvironment` → `commons-io 2.11.0 -> 2.18.0`, `plexus-utils 3.5.1 -> 3.6.1`.
- `./gradlew clean build` → `shadowJar` runs, **BUILD SUCCESSFUL**, 90/90 unit tests pass (JDK 17, Gradle 8.5).

## Related
Third of three CVE-remediation PRs: #221 (jackson, runtime), #222 (netty, runtime), and this one (build-time tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Gradle classpath overrides with no change to runtime dependencies or published library contents; Shadow plugin version is unchanged.
> 
> **Overview**
> Adds a **`buildscript`** block that forces patched versions of Shadow 8.1.1’s transitive **buildscript classpath** dependencies: **`commons-io` → 2.18.0** (CVE-2024-47554) and **`plexus-utils` → 3.6.1** (CVE-2025-67030). Inline comments document that these run only in the Gradle build JVM during tasks like **`shadowJar`**, not in the published **`pinecone-client`** artifact.
> 
> Shadow remains at **8.1.1**; the change is classpath resolution only, intended to clear Dependabot alerts without upgrading the Shadow plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c64b3b612637b92a45ab84935510250ecf9122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->